### PR TITLE
Update Example projects to use API version 2.2.0

### DIFF
--- a/Examples/ClientConsole/ClientConsole.csproj
+++ b/Examples/ClientConsole/ClientConsole.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Binance.Net, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Binance.Net.2.1.1\lib\net46\Binance.Net.dll</HintPath>
+    <Reference Include="Binance.Net">
+      <HintPath>..\packages\Binance.Net.2.2.0\lib\netstandard2.0\Binance.Net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Examples/ClientConsole/Program.cs
+++ b/Examples/ClientConsole/Program.cs
@@ -22,16 +22,16 @@ namespace BinanceApi.TestConsole
                 var orderBook = client.GetOrderBook("BNBBTC", 10);
                 var aggTrades = client.GetAggregatedTrades("BNBBTC", startTime: DateTime.UtcNow.AddMinutes(-2), endTime: DateTime.UtcNow, limit: 10);
                 var klines = client.GetKlines("BNBBTC", KlineInterval.OneHour, startTime: DateTime.UtcNow.AddHours(-10), endTime: DateTime.UtcNow, limit: 10);
-                var prices24h = client.Get24HPrices("BNBBTC");
+                var prices24h = client.Get24HPrice("BNBBTC");
                 var allPrices = client.GetAllPrices();
                 var allBookPrices = client.GetAllBookPrices();
 
                 // Private
                 var openOrders = client.GetOpenOrders("BNBBTC");
                 var allOrders = client.GetAllOrders("BNBBTC");
-                var testOrderResult = client.PlaceTestOrder("BNBBTC", OrderSide.Buy, OrderType.Limit, TimeInForce.GoodTillCancel, 1, 1);
+                var testOrderResult = client.PlaceTestOrder("BNBBTC", OrderSide.Buy, OrderType.Limit, 1, price: 1, timeInForce: TimeInForce.GoodTillCancel);
                 var queryOrder = client.QueryOrder("BNBBTC", allOrders.Data[0].OrderId);
-                var orderResult = client.PlaceOrder("BNBBTC", OrderSide.Sell, OrderType.Limit, TimeInForce.GoodTillCancel, 10, 0.0002);
+                var orderResult = client.PlaceOrder("BNBBTC", OrderSide.Sell, OrderType.Limit, 10, price: 0.0002m, timeInForce: TimeInForce.GoodTillCancel);
                 var cancelResult = client.CancelOrder("BNBBTC", orderResult.Data.OrderId);
                 var accountInfo = client.GetAccountInfo();
                 var myTrades = client.GetMyTrades("BNBBTC");

--- a/Examples/ClientConsole/packages.config
+++ b/Examples/ClientConsole/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Binance.Net" version="2.1.1" targetFramework="net461" />
+  <package id="Binance.Net" version="2.2.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="WebSocketSharp-NonPreRelease" version="1.0.0" targetFramework="net461" />
 </packages>

--- a/Examples/ClientWPF/ClientWPF.csproj
+++ b/Examples/ClientWPF/ClientWPF.csproj
@@ -36,8 +36,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Binance.Net, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Binance.Net.2.1.1\lib\net46\Binance.Net.dll</HintPath>
+    <Reference Include="Binance.Net, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Binance.Net.2.2.0\lib\netstandard2.0\Binance.Net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -145,7 +145,9 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/Examples/ClientWPF/ViewModels/AssetViewModel.cs
+++ b/Examples/ClientWPF/ViewModels/AssetViewModel.cs
@@ -15,8 +15,8 @@ namespace Binance.Net.ClientWPF.ViewModels
             }
         }
 
-        private double free;
-        public double Free
+        private decimal free;
+        public decimal Free
         {
             get { return free; }
             set
@@ -26,8 +26,8 @@ namespace Binance.Net.ClientWPF.ViewModels
             }
         }
 
-        private double locked;
-        public double Locked
+        private decimal locked;
+        public decimal Locked
         {
             get { return locked; }
             set

--- a/Examples/ClientWPF/ViewModels/BinanceSymbolViewModel.cs
+++ b/Examples/ClientWPF/ViewModels/BinanceSymbolViewModel.cs
@@ -4,7 +4,7 @@ using Binance.Net.ClientWPF.MVVM;
 
 namespace Binance.Net.ClientWPF.ViewModels
 {
-    public class BinanceSymbolViewModel: ObservableObject
+    public class BinanceSymbolViewModel : ObservableObject
     {
         private string symbol;
         public string Symbol
@@ -17,8 +17,8 @@ namespace Binance.Net.ClientWPF.ViewModels
             }
         }
 
-        private double price;
-        public double Price
+        private decimal price;
+        public decimal Price
         {
             get { return price; }
             set
@@ -28,8 +28,8 @@ namespace Binance.Net.ClientWPF.ViewModels
             }
         }
 
-        private double priceChangePercent;
-        public double PriceChangePercent
+        private decimal priceChangePercent;
+        public decimal PriceChangePercent
         {
             get { return priceChangePercent; }
             set
@@ -39,8 +39,8 @@ namespace Binance.Net.ClientWPF.ViewModels
             }
         }
 
-        private double highPrice;
-        public double HighPrice
+        private decimal highPrice;
+        public decimal HighPrice
         {
             get { return highPrice; }
             set
@@ -50,8 +50,8 @@ namespace Binance.Net.ClientWPF.ViewModels
             }
         }
 
-        private double lowPrice;
-        public double LowPrice
+        private decimal lowPrice;
+        public decimal LowPrice
         {
             get { return lowPrice; }
             set
@@ -61,8 +61,8 @@ namespace Binance.Net.ClientWPF.ViewModels
             }
         }
 
-        private double volume;
-        public double Volume
+        private decimal volume;
+        public decimal Volume
         {
             get { return volume; }
             set
@@ -72,8 +72,8 @@ namespace Binance.Net.ClientWPF.ViewModels
             }
         }
 
-        private double tradeAmount;
-        public double TradeAmount
+        private decimal tradeAmount;
+        public decimal TradeAmount
         {
             get { return tradeAmount; }
             set
@@ -83,8 +83,8 @@ namespace Binance.Net.ClientWPF.ViewModels
             }
         }
 
-        private double tradePrice;
-        public double TradePrice
+        private decimal tradePrice;
+        public decimal TradePrice
         {
             get { return tradePrice; }
             set
@@ -93,7 +93,7 @@ namespace Binance.Net.ClientWPF.ViewModels
                 RaisePropertyChangedEvent("TradePrice");
             }
         }
-        
+
         private ObservableCollection<OrderViewModel> orders;
         public ObservableCollection<OrderViewModel> Orders
         {
@@ -105,7 +105,7 @@ namespace Binance.Net.ClientWPF.ViewModels
             }
         }
 
-        public BinanceSymbolViewModel(string symbol, double price)
+        public BinanceSymbolViewModel(string symbol, decimal price)
         {
             this.symbol = symbol;
             this.price = price;

--- a/Examples/ClientWPF/ViewModels/MainViewModel.cs
+++ b/Examples/ClientWPF/ViewModels/MainViewModel.cs
@@ -12,7 +12,7 @@ using Binance.Net.ClientWPF.MessageBox;
 
 namespace Binance.Net.ClientWPF
 {
-    public class MainViewModel: ObservableObject
+    public class MainViewModel : ObservableObject
     {
         private ObservableCollection<BinanceSymbolViewModel> allPrices;
         public ObservableCollection<BinanceSymbolViewModel> AllPrices
@@ -74,7 +74,7 @@ namespace Binance.Net.ClientWPF
                 RaisePropertyChangedEvent("ApiKey");
 
                 if (value != null && apiSecret != null)
-                    BinanceDefaults.SetDefaultApiCredentials(value, apiSecret);         
+                    BinanceDefaults.SetDefaultApiCredentials(value, apiSecret);
             }
         }
 
@@ -116,7 +116,7 @@ namespace Binance.Net.ClientWPF
             SettingsCommand = new DelegateCommand(Settings);
             CloseSettingsCommand = new DelegateCommand(CloseSettings);
 
-            Task.Run(() => GetAllSymbols());            
+            Task.Run(() => GetAllSymbols());
         }
 
         public void Cancel(object o)
@@ -141,7 +141,7 @@ namespace Binance.Net.ClientWPF
             {
                 using (var client = new BinanceClient())
                 {
-                    var result = client.PlaceOrder(SelectedSymbol.Symbol, OrderSide.Buy, OrderType.Limit, TimeInForce.GoodTillCancel, SelectedSymbol.TradeAmount, SelectedSymbol.TradePrice);
+                    var result = client.PlaceOrder(SelectedSymbol.Symbol, OrderSide.Buy, OrderType.Limit, SelectedSymbol.TradeAmount, price: SelectedSymbol.TradePrice, timeInForce: TimeInForce.GoodTillCancel);
                     if (result.Success)
                         messageBoxService.ShowMessage("Order placed!", "Sucess", System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Information);
                     else
@@ -156,7 +156,7 @@ namespace Binance.Net.ClientWPF
             {
                 using (var client = new BinanceClient())
                 {
-                    var result = client.PlaceOrder(SelectedSymbol.Symbol, OrderSide.Sell, OrderType.Limit, TimeInForce.GoodTillCancel, SelectedSymbol.TradeAmount, SelectedSymbol.TradePrice);
+                    var result = client.PlaceOrder(SelectedSymbol.Symbol, OrderSide.Sell, OrderType.Limit, SelectedSymbol.TradeAmount, price: SelectedSymbol.TradePrice, timeInForce: TimeInForce.GoodTillCancel);
                     if (result.Success)
                         messageBoxService.ShowMessage("Order placed!", "Sucess", System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Information);
                     else
@@ -208,7 +208,7 @@ namespace Binance.Net.ClientWPF
         {
             using (var client = new BinanceClient())
             {
-                var result = client.Get24HPrices(SelectedSymbol.Symbol);
+                var result = client.Get24HPrice(SelectedSymbol.Symbol);
                 if (result.Success)
                 {
                     SelectedSymbol.HighPrice = result.Data.HighPrice;
@@ -256,7 +256,7 @@ namespace Binance.Net.ClientWPF
                 using (var client = new BinanceClient())
                 {
                     var startOkay = client.StartUserStream();
-                    if(!startOkay.Success)
+                    if (!startOkay.Success)
                         messageBoxService.ShowMessage($"Error requesting data: {startOkay.Error.Message}", "error", MessageBoxButton.OK, MessageBoxImage.Error);
 
                     socketClient.SubscribeToAccountUpdateStream(startOkay.Data.ListenKey, OnAccountUpdate);

--- a/Examples/ClientWPF/ViewModels/OrderViewModel.cs
+++ b/Examples/ClientWPF/ViewModels/OrderViewModel.cs
@@ -28,8 +28,8 @@ namespace Binance.Net.ClientWPF.ViewModels
             }
         }
 
-        private double price;
-        public double Price
+        private decimal price;
+        public decimal Price
         {
             get { return price; }
             set
@@ -39,8 +39,8 @@ namespace Binance.Net.ClientWPF.ViewModels
             }
         }
 
-        private double originalQuantity;
-        public double OriginalQuantity
+        private decimal originalQuantity;
+        public decimal OriginalQuantity
         {
             get { return originalQuantity; }
             set
@@ -50,8 +50,8 @@ namespace Binance.Net.ClientWPF.ViewModels
             }
         }
 
-        private double executedQuantity;
-        public double ExecutedQuantity
+        private decimal executedQuantity;
+        public decimal ExecutedQuantity
         {
             get { return executedQuantity; }
             set

--- a/Examples/ClientWPF/packages.config
+++ b/Examples/ClientWPF/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Binance.Net" version="2.1.1" targetFramework="net461" />
+  <package id="Binance.Net" version="2.2.0" targetFramework="net461" />
   <package id="Extended.Wpf.Toolkit" version="3.2.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="WebSocketSharp-NonPreRelease" version="1.0.0" targetFramework="net461" />


### PR DESCRIPTION
Updated Console and WPF projects to use API version `2.2.0` from `2.1.1`
 - Updated stored values from double to decimal.
 - Updated order signature to adapt to changed parameter order and optional parameters.
