### PR TITLE
Update Binance24hPrice FirstId JsonProperty name

### DIFF
--- a/Binance.Net/Objects/Binance24hPrice.cs
+++ b/Binance.Net/Objects/Binance24hPrice.cs
@@ -68,7 +68,6 @@ namespace Binance.Net.Objects
         /// <summary>
         /// The first trade ID in the last 24 hours
         /// </summary>
-        [JsonProperty("fristId")] // ?
         public long FirstId { get; set; }
         /// <summary>
         /// The last trade ID in the last 24 hours


### PR DESCRIPTION
`firstId` no longer contains spelling error on api (`fristId`).
With the existing overriding of FirstId property, the property is set to default `0`.

Verified here: https://www.binance.com/api/v1/ticker/24hr?symbol=XRPBTC