### PR TITLE
Added combined stream on one socket connection

### DIFF
--- a/Binance.Net/BinanceClientOptions.cs
+++ b/Binance.Net/BinanceClientOptions.cs
@@ -4,7 +4,7 @@ using CryptoExchange.Net;
 
 namespace Binance.Net
 {
-    public class BinanceClientOptions: ExchangeOptions
+    public class BinanceClientOptions : ExchangeOptions
     {
         /// <summary>
         /// The base address used to connect to the API
@@ -30,6 +30,11 @@ namespace Binance.Net
         /// The base adress for the socket connections
         /// </summary>
         public string BaseSocketAddress { get; set; } = "wss://stream.binance.com:9443/ws/";
+
+        /// <summary>
+        /// The base address for combined data in socket connections
+        /// </summary>
+        public string BaseSocketCombinedAddress { get; set; } = "wss://stream.binance.com:9443/";
 
         /// <summary>
         /// What should be done when the connection is interupted

--- a/Binance.Net/Objects/BinanceCombinedStream.cs
+++ b/Binance.Net/Objects/BinanceCombinedStream.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+
+namespace Binance.Net.Objects
+{
+    /// <summary>
+    /// Represents the binance result for combined data on a single socket connection
+    /// See on https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md
+    /// Combined streams
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class BinanceCombinedStream<T>
+    {
+        /// <summary>
+        /// The stream combined
+        /// </summary>
+        [JsonProperty("stream")]
+        public string Stream { get; set; }
+
+        /// <summary>
+        /// The data of stream
+        /// </summary>
+        [JsonProperty("data")]
+        public T Data { get; set; }
+    }
+}


### PR DESCRIPTION
Today when we need to listen to several markets at the same time, a socket connection is open for each market, this does not work very well in Binance, it does not let many socket connections be made in a small timeout, but it recommends that when you need listen to many different markets at the same time you pass the markets you need via query string in the websocket connection link.

My implementation supports this. I added support to be able to listen from several markets at the same time in the following methods: `SubscribeToCombinedDepthStream`, `SubscribeToCombinedTradesStream `and `SubscribeToCombinedPartialBookDepthStream` in the `BinanceSocketClient` object, you receive from this methods the object `BinanceCombinedStream` its the Stream name received, and Data received from listen, the data is converted to object represent you stream data listening.

See more about combined streams in documentation: https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md