### PR TITLE
Update BinanceSymbol.cs

### DIFF
--- a/Binance.Net/Objects/BinanceSymbol.cs
+++ b/Binance.Net/Objects/BinanceSymbol.cs
@@ -31,6 +31,7 @@ namespace Binance.Net.Objects
         /// <summary>
         /// The precision of the quote asset
         /// </summary>
+        [JsonProperty("quotePrecision")]
         public string QuoteAssetPrecision { get; set; }
         /// <summary>
         /// Allowed order types


### PR DESCRIPTION
QuoteAssetPrecision is not found in BinanceSymbol data returned from Server, the current json key is quotePrecision.