### PR TITLE
Lowered AutoTimestamp Threshold

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,3 @@ deploy:
   skip_cleanup: true
   provider: script
   script: dotnet nuget push src/Binance.Net/Binance.Net/bin/Release/Binance.Net.AutoTimestamp.*.nupkg --api-key $NUGET_API_KEY
-  on:
-    tags: true
-    condition: $TRAVIS_TAG =~ ^(\d+\.)?(\d+\.)?(\*|\d+)$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
 language: csharp
 mono: none
+os: linux
 solution: Binance.Net.sln
 dotnet: 2.0.0
 dist: trusty
 script:
- - dotnet build Binance.Net/Binance.Net.csproj --framework "netstandard2.0"
+ - dotnet build Binance.Net/Binance.Net.csproj -c Release --framework "netstandard2.0"
  - dotnet test Binance.Net.UnitTests/Binance.Net.UnitTests.csproj
+ - dotnet pack Binance.Net/Binance.Net.csproj -c Release
+ deploy:
+  skip_cleanup: true
+  provider: script
+  script: dotnet nuget push src/Binance.Net/Binance.Net/bin/Release/SampleNetLib.*.nupkg --api-key $NUGET_API_KEY
+  on:
+    tags: true
+    condition: $TRAVIS_TAG =~ ^(\d+\.)?(\d+\.)?(\*|\d+)$

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
 deploy:
   skip_cleanup: true
   provider: script
-  script: dotnet nuget push src/Binance.Net/Binance.Net/bin/Release/SampleNetLib.*.nupkg --api-key $NUGET_API_KEY
+  script: dotnet nuget push src/Binance.Net/Binance.Net/bin/Release/Binance.Net.AutoTimestamp.*.nupkg --api-key $NUGET_API_KEY
   on:
     tags: true
     condition: $TRAVIS_TAG =~ ^(\d+\.)?(\d+\.)?(\*|\d+)$

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
  - dotnet build Binance.Net/Binance.Net.csproj -c Release --framework "netstandard2.0"
  - dotnet test Binance.Net.UnitTests/Binance.Net.UnitTests.csproj
  - dotnet pack Binance.Net/Binance.Net.csproj -c Release
- deploy:
+deploy:
   skip_cleanup: true
   provider: script
   script: dotnet nuget push src/Binance.Net/Binance.Net/bin/Release/SampleNetLib.*.nupkg --api-key $NUGET_API_KEY

--- a/Binance.Net/Binance.Net.csproj
+++ b/Binance.Net/Binance.Net.csproj
@@ -5,18 +5,18 @@
   </PropertyGroup>
     
   <PropertyGroup>
-    <PackageId>Binance.Net</PackageId>
+    <PackageId>Binance.Net.AutoTimestamp</PackageId>
 	<Authors>JKorf</Authors>
-    <PackageVersion>4.0.7</PackageVersion>
+    <PackageVersion>1.0.0</PackageVersion>
 	<Description>Binance.Net is a .Net wrapper for the Binance API. It includes all features the API provides, REST API and Websocket, using clear and readable objects including but not limited to Reading market info, Placing and managing orders and Reading balances and funds</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>Binance Binance.Net C# .Net CryptoCurrency Exchange API wrapper</PackageTags>
-    <PackageProjectUrl>https://github.com/JKorf/Binance.Net</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/lucaswalter/Binance.Net/blob/master/Binance.Net/Binance.Net.csproj</PackageProjectUrl>
 	<PackageIconUrl>https://raw.githubusercontent.com/JKorf/Binance.Net/master/Resources/binance-coin.png</PackageIconUrl>
 	<PackageLicenseUrl>https://github.com/JKorf/Binance.Net/blob/master/LICENSE</PackageLicenseUrl>
 	<NeutralLanguage>en</NeutralLanguage>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	<PackageReleaseNotes>4.0.7 - Added Exception event to socket subscriptions, some general fixes</PackageReleaseNotes>
+	<PackageReleaseNotes>1.0.0 - Adjusted AutoTimestamp Threshold</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Binance.Net/Binance.Net.csproj
+++ b/Binance.Net/Binance.Net.csproj
@@ -13,7 +13,6 @@
     <PackageTags>Binance Binance.Net C# .Net CryptoCurrency Exchange API wrapper</PackageTags>
     <PackageProjectUrl>https://github.com/lucaswalter/Binance.Net/blob/master/Binance.Net/Binance.Net.csproj</PackageProjectUrl>
 	<PackageIconUrl>https://raw.githubusercontent.com/lucaswalter/Binance.Net/master/Resources/binance-coin.png</PackageIconUrl>
-	<PackageLicenseUrl>https://github.com/lucaswalter/Binance.Net/blob/master/LICENSE</PackageLicenseUrl>
 	<NeutralLanguage>en</NeutralLanguage>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<PackageReleaseNotes>1.0.0 - Adjusted AutoTimestamp Threshold</PackageReleaseNotes>

--- a/Binance.Net/Binance.Net.csproj
+++ b/Binance.Net/Binance.Net.csproj
@@ -12,8 +12,8 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>Binance Binance.Net C# .Net CryptoCurrency Exchange API wrapper</PackageTags>
     <PackageProjectUrl>https://github.com/lucaswalter/Binance.Net/blob/master/Binance.Net/Binance.Net.csproj</PackageProjectUrl>
-	<PackageIconUrl>https://raw.githubusercontent.com/JKorf/Binance.Net/master/Resources/binance-coin.png</PackageIconUrl>
-	<PackageLicenseUrl>https://github.com/JKorf/Binance.Net/blob/master/LICENSE</PackageLicenseUrl>
+	<PackageIconUrl>https://raw.githubusercontent.com/lucaswalter/Binance.Net/master/Resources/binance-coin.png</PackageIconUrl>
+	<PackageLicenseUrl>https://github.com/lucaswalter/Binance.Net/blob/master/LICENSE</PackageLicenseUrl>
 	<NeutralLanguage>en</NeutralLanguage>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<PackageReleaseNotes>1.0.0 - Adjusted AutoTimestamp Threshold</PackageReleaseNotes>

--- a/Binance.Net/BinanceClient.cs
+++ b/Binance.Net/BinanceClient.cs
@@ -194,13 +194,13 @@ namespace Binance.Net
 
                 // Calculate time offset between local and server
                 var offset = Math.Abs((result.Data.ServerTime - localTime).TotalMilliseconds);
-                if (offset < 1000)
+                if (offset < 500)
                 {
                     // Small offset, probably mainly due to ping. Don't adjust time
                     timeOffset = 0;
                     timeSynced = true;
                     lastTimeSync = DateTime.UtcNow;
-                    log.Write(LogVerbosity.Info, $"Time offset within 1 seconds ({offset}ms), no adjustment needed");
+                    log.Write(LogVerbosity.Info, $"Time offset within 0.5 seconds ({offset}ms), no adjustment needed");
                     return new CallResult<DateTime>(result.Data.ServerTime, result.Error);
                 }
 

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="defaultPushSource" value="https://api.nuget.org/v3/index.json" />
+  </config>
+  <packageSources>
+    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Opening this PR due to some issues we have been having with the "-1021, Timestamp for this request was 1000ms ahead of the server's time."

Our application is currently trying to iterate through each Binance trading pair and retrieve the authenticated user's trades for that pair.  We are currently initializing our BinanceClient with the following options and are unable to make it through each trading pair without running into the 1021 error. (Happens when running locally and in our staging enviroment)

![image](https://user-images.githubusercontent.com/5252764/53377731-9bfc7780-3928-11e9-8b59-f2bc4a9e10a1.png)

This threshold change is an attempted fix for this use case.