### PR TITLE
Add Futures Client and Socket

### DIFF
--- a/Binance.Net/Binance.Net.csproj
+++ b/Binance.Net/Binance.Net.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Binance.Net</PackageId>
-    <Authors>JKorf</Authors>
+    <Authors>JKorf, CaptHolley</Authors>
     <PackageVersion>5.0.7</PackageVersion>
     <Description>Binance.Net is a .Net wrapper for the Binance API. It includes all features the API provides, REST API and Websocket, using clear and readable objects including but not limited to Reading market info, Placing and managing orders and Reading balances and funds</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -16,7 +16,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageReleaseNotes>5.0.7 - Fixed incorrect Invalid symbol error</PackageReleaseNotes>
+    <PackageReleaseNotes>5.1.0 - Added Binance Futures Client and Socket</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <DocumentationFile>Binance.Net.xml</DocumentationFile>

--- a/Binance.Net/Binance.Net.xml
+++ b/Binance.Net/Binance.Net.xml
@@ -1452,6 +1452,851 @@
         <member name="M:Binance.Net.BinanceClient.ParseErrorResponse(Newtonsoft.Json.Linq.JToken)">
             <inheritdoc />
         </member>
+        <member name="T:Binance.Net.BinanceFuturesClient">
+            <summary>
+            Client providing access to the Binance REST Api
+            </summary>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.#ctor">
+            <summary>
+            Create a new instance of BinanceFuturesClient using the default options
+            </summary>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.#ctor(Binance.Net.Objects.BinanceFuturesClientOptions)">
+            <summary>
+            Create a new instance of BinanceFuturesClient using provided options
+            </summary>
+            <param name="options">The options to use for this client</param>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.SetDefaultOptions(Binance.Net.Objects.BinanceFuturesClientOptions)">
+            <summary>
+            Set the default options to be used when creating new clients
+            </summary>
+            <param name="options"></param>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.SetApiCredentials(System.String,System.String)">
+            <summary>
+            Set the API key and secret
+            </summary>
+            <param name="apiKey">The api key</param>
+            <param name="apiSecret">The api secret</param>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.Ping(System.Threading.CancellationToken)">
+            <summary>
+            Pings the Binance Futures API
+            </summary>
+            <returns>True if successful ping, false if no response</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.PingAsync(System.Threading.CancellationToken)">
+            <summary>
+            Pings the Binance Futures API
+            </summary>
+            <returns>True if successful ping, false if no response</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetServerTime(System.Boolean,System.Threading.CancellationToken)">
+            <summary>
+            Requests the server for the local time. This function also determines the offset between server and local time and uses this for subsequent API calls
+            </summary>
+            <param name="resetAutoTimestamp">Whether the response should be used for a new auto timestamp calculation</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Server time</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetServerTimeAsync(System.Boolean,System.Threading.CancellationToken)">
+            <summary>
+            Requests the server for the local time. This function also determines the offset between server and local time and uses this for subsequent API calls
+            </summary>
+            <param name="resetAutoTimestamp">Whether the response should be used for a new auto timestamp calculation</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Server time</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetExchangeInfo(System.Threading.CancellationToken)">
+            <summary>
+            Get's information about the exchange including rate limits and symbol list
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>Exchange info</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetExchangeInfoAsync(System.Threading.CancellationToken)">
+            <summary>
+            Get's information about the exchange including rate limits and symbol list
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>Exchange info</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetOrderBook(System.String,System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets the order book for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get the order book for</param>
+            <param name="limit">Max number of results</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The order book for the symbol</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetOrderBookAsync(System.String,System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets the order book for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get the order book for</param>
+            <param name="limit">Max number of results</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The order book for the symbol</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetSymbolTrades(System.String,System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets the recent trades for a symbol
+            </summary>
+            <param name="symbol">The symbol to get recent trades for</param>
+            <param name="limit">Result limit</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of recent trades</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetSymbolTradesAsync(System.String,System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets the recent trades for a symbol
+            </summary>
+            <param name="symbol">The symbol to get recent trades for</param>
+            <param name="limit">Result limit</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of recent trades</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetHistoricalSymbolTrades(System.String,System.Nullable{System.Int32},System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets the historical  trades for a symbol
+            </summary>
+            <param name="symbol">The symbol to get recent trades for</param>
+            <param name="limit">Result limit</param>
+            <param name="fromId">From which trade id on results should be retrieved</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of recent trades</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetHistoricalSymbolTradesAsync(System.String,System.Nullable{System.Int32},System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets the historical  trades for a symbol
+            </summary>
+            <param name="symbol">The symbol to get recent trades for</param>
+            <param name="limit">Result limit</param>
+            <param name="fromId">From which trade id on results should be retrieved</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of recent trades</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetAggregatedTrades(System.String,System.Nullable{System.Int64},System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets compressed, aggregate trades. Trades that fill at the time, from the same order, with the same price will have the quantity aggregated.
+            </summary>
+            <param name="symbol">The symbol to get the trades for</param>
+            <param name="fromId">ID to get aggregate trades from INCLUSIVE.</param>
+            <param name="startTime">Time to start getting trades from</param>
+            <param name="endTime">Time to stop getting trades from</param>
+            <param name="limit">Max number of results</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The aggregated trades list for the symbol</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetAggregatedTradesAsync(System.String,System.Nullable{System.Int64},System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets compressed, aggregate trades. Trades that fill at the time, from the same order, with the same price will have the quantity aggregated.
+            </summary>
+            <param name="symbol">The symbol to get the trades for</param>
+            <param name="fromId">ID to get aggregate trades from INCLUSIVE.</param>
+            <param name="startTime">Time to start getting trades from</param>
+            <param name="endTime">Time to stop getting trades from</param>
+            <param name="limit">Max number of results</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The aggregated trades list for the symbol</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetKlines(System.String,Binance.Net.Objects.KlineInterval,System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Get candlestick data for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get the data for</param>
+            <param name="interval">The candlestick timespan</param>
+            <param name="startTime">Start time to get candlestick data</param>
+            <param name="endTime">End time to get candlestick data</param>
+            <param name="limit">Max number of results</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The candlestick data for the provided symbol</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetKlinesAsync(System.String,Binance.Net.Objects.KlineInterval,System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Get candlestick data for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get the data for</param>
+            <param name="interval">The candlestick timespan</param>
+            <param name="startTime">Start time to get candlestick data</param>
+            <param name="endTime">End time to get candlestick data</param>
+            <param name="limit">Max number of results</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The candlestick data for the provided symbol</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetMarkPrice(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Get Mark Price and Funding Rate for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get the data for</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Data over the last 24 hours</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetMarkPriceAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Get Mark Price and Funding Rate for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get the data for</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Data over the last 24 hours</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetMarkPricesList(System.Threading.CancellationToken)">
+            <summary>
+            Get Mark Price and Funding Rate for all symbols
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>List of data over the last 24 hours</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetMarkPricesListAsync(System.Threading.CancellationToken)">
+            <summary>
+            Get Mark Price and Funding Rate for all symbols
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>List of data over the last 24 hours</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetFundingRates(System.String,System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Get funding rate history for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get the data for</param>
+            <param name="startTime">Start time to get funding rate history</param>
+            <param name="endTime">End time to get funding rate history</param>
+            <param name="limit">Max number of results</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The funding rate history for the provided symbol</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetFundingRatesAsync(System.String,System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Get funding rate history for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get the data for</param>
+            <param name="startTime">Start time to get funding rate history</param>
+            <param name="endTime">End time to get funding rate history</param>
+            <param name="limit">Max number of results</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The funding rate history for the provided symbol</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.Get24HPrice(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Get data regarding the last 24 hours for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get the data for</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Data over the last 24 hours</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.Get24HPriceAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Get data regarding the last 24 hours for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get the data for</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Data over the last 24 hours</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.Get24HPricesList(System.Threading.CancellationToken)">
+            <summary>
+            Get data regarding the last 24 hours for all symbols
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>List of data over the last 24 hours</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.Get24HPricesListAsync(System.Threading.CancellationToken)">
+            <summary>
+            Get data regarding the last 24 hours for all symbols
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>List of data over the last 24 hours</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetPrice(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Gets the price of a symbol
+            </summary>
+            <param name="symbol">The symbol to get the price for</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Price of symbol</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetPriceAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Gets the price of a symbol
+            </summary>
+            <param name="symbol">The symbol to get the price for</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Price of symbol</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetAllPrices(System.Threading.CancellationToken)">
+            <summary>
+            Get a list of the prices of all symbols
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>List of prices</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetAllPricesAsync(System.Threading.CancellationToken)">
+            <summary>
+            Get a list of the prices of all symbols
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>List of prices</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetBookPrice(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Gets the best price/quantity on the order book for a symbol.
+            </summary>
+            <param name="symbol">Symbol to get book price for</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of book prices</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetBookPriceAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Gets the best price/quantity on the order book for a symbol.
+            </summary>
+            <param name="symbol">Symbol to get book price for</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of book prices</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetAllBookPrices(System.Threading.CancellationToken)">
+            <summary>
+            Gets the best price/quantity on the order book for all symbols.
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>List of book prices</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetAllBookPricesAsync(System.Threading.CancellationToken)">
+            <summary>
+            Gets the best price/quantity on the order book for all symbols.
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>List of book prices</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.PlaceOrder(System.String,Binance.Net.Objects.OrderSide,Binance.Net.Objects.OrderType,System.Nullable{System.Decimal},System.Nullable{Binance.Net.Objects.TimeInForce},System.Nullable{System.Boolean},System.Nullable{System.Decimal},System.String,System.Nullable{System.Decimal},System.Nullable{Binance.Net.Objects.OrderResponseType},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Places a new order
+            </summary>
+            <param name="symbol">The symbol the order is for</param>
+            <param name="side">The order side (buy/sell)</param>
+            <param name="type">The order type</param>
+            <param name="timeInForce">Lifetime of the order (GoodTillCancel/ImmediateOrCancel/FillOrKill)</param>
+            <param name="quantity">The amount of the base symbol</param>
+            <param name="reduceOnly">Specify as true if the order is intended to only reduce the position</param>
+            <param name="price">The price to use</param>
+            <param name="newClientOrderId">Unique id for order</param>
+            <param name="stopPrice">Used for stop orders</param>
+            <param name="orderResponseType">The type of response to receive</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Id's for the placed order</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.PlaceOrderAsync(System.String,Binance.Net.Objects.OrderSide,Binance.Net.Objects.OrderType,System.Nullable{System.Decimal},System.Nullable{Binance.Net.Objects.TimeInForce},System.Nullable{System.Boolean},System.Nullable{System.Decimal},System.String,System.Nullable{System.Decimal},System.Nullable{Binance.Net.Objects.OrderResponseType},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Places a new order
+            </summary>
+            <param name="symbol">The symbol the order is for</param>
+            <param name="side">The order side (buy/sell)</param>
+            <param name="type">The order type</param>
+            <param name="timeInForce">Lifetime of the order (GoodTillCancel/ImmediateOrCancel/FillOrKill)</param>
+            <param name="quantity">The amount of the base symbol</param>
+            <param name="reduceOnly">Specify as true if the order is intended to only reduce the position</param>
+            <param name="price">The price to use</param>
+            <param name="newClientOrderId">Unique id for order</param>
+            <param name="stopPrice">Used for stop orders</param>
+            <param name="orderResponseType">The type of response to receive</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Id's for the placed order</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetOrder(System.String,System.Nullable{System.Int64},System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Retrieves data for a specific order. Either orderId or origClientOrderId should be provided.
+            </summary>
+            <param name="symbol">The symbol the order is for</param>
+            <param name="orderId">The order id of the order</param>
+            <param name="origClientOrderId">The client order id of the order</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The specific order</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetOrderAsync(System.String,System.Nullable{System.Int64},System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Retrieves data for a specific order. Either orderId or origClientOrderId should be provided.
+            </summary>
+            <param name="symbol">The symbol the order is for</param>
+            <param name="orderId">The order id of the order</param>
+            <param name="origClientOrderId">The client order id of the order</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The specific order</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.CancelOrder(System.String,System.Nullable{System.Int64},System.String,System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Cancels a pending order
+            </summary>
+            <param name="symbol">The symbol the order is for</param>
+            <param name="orderId">The order id of the order</param>
+            <param name="origClientOrderId">The client order id of the order</param>
+            <param name="newClientOrderId">The new client order id of the order</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Id's for canceled order</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.CancelOrderAsync(System.String,System.Nullable{System.Int64},System.String,System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Cancels a pending order
+            </summary>
+            <param name="symbol">The symbol the order is for</param>
+            <param name="orderId">The order id of the order</param>
+            <param name="origClientOrderId">The client order id of the order</param>
+            <param name="newClientOrderId">Unique identifier for this cancel</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Id's for canceled order</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetOpenOrders(System.String,System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets a list of open orders
+            </summary>
+            <param name="symbol">The symbol to get open orders for</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of open orders</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetOpenOrdersAsync(System.String,System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets a list of open orders
+            </summary>
+            <param name="symbol">The symbol to get open orders for</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of open orders</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetAllOrders(System.String,System.Nullable{System.Int64},System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets all orders for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get orders for</param>
+            <param name="orderId">If set, only orders with an order id higher than the provided will be returned</param>
+            <param name="startTime">If set, only orders placed after this time will be returned</param>
+            <param name="endTime">If set, only orders placed before this time will be returned</param>
+            <param name="limit">Max number of results</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of orders</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetAllOrdersAsync(System.String,System.Nullable{System.Int64},System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets all orders for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get orders for</param>
+            <param name="orderId">If set, only orders with an order id higher than the provided will be returned</param>
+            <param name="startTime">If set, only orders placed after this time will be returned</param>
+            <param name="endTime">If set, only orders placed before this time will be returned</param>
+            <param name="limit">Max number of results</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of orders</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetFuturesAccountBalance(System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets account balances
+            </summary>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The account information</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetFuturesAccountBalanceAsync(System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>.
+            Gets account balances
+            </summary>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The account information</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetAccountInfo(System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets account information, including balances
+            </summary>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The account information</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetAccountInfoAsync(System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets account information, including balances
+            </summary>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The account information</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetMyTrades(System.String,System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Nullable{System.Int64},System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets all user trades for provided symbol
+            </summary>
+            <param name="symbol">Symbol to get trades for</param>
+            <param name="limit">The max number of results</param>
+            <param name="startTime">Orders newer than this date will be retrieved</param>
+            <param name="endTime">Orders older than this date will be retrieved</param>
+            <param name="fromId">TradeId to fetch from. Default gets most recent trades</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of trades</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetMyTradesAsync(System.String,System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Nullable{System.Int64},System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets all user trades for provided symbol
+            </summary>
+            <param name="symbol">Symbol to get trades for</param>
+            <param name="limit">The max number of results</param>
+            <param name="fromId">TradeId to fetch from. Default gets most recent trades</param>
+            <param name="startTime">Orders newer than this date will be retrieved</param>
+            <param name="endTime">Orders older than this date will be retrieved</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of trades</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetOpenPositions(System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets all user positions
+            </summary>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of Positions</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.GetOpenPositionsAsync(System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets all user positions
+            </summary>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of Positions</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.StartUserStream(System.Threading.CancellationToken)">
+            <summary>
+            Starts a user stream by requesting a listen key. This listen key can be used in subsequent requests to <see cref="M:Binance.Net.BinanceSocketClient.SubscribeToUserDataUpdates(System.String,System.Action{Binance.Net.Objects.BinanceStreamAccountInfo},System.Action{Binance.Net.Objects.BinanceStreamOrderUpdate},System.Action{Binance.Net.Objects.BinanceStreamOrderList},System.Action{System.Collections.Generic.IEnumerable{Binance.Net.Objects.BinanceStreamBalance}},System.Action{Binance.Net.Objects.Sockets.BinanceStreamBalanceUpdate})"/>. The stream will close after 60 minutes unless a keep alive is send.
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>Listen key</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.StartUserStreamAsync(System.Threading.CancellationToken)">
+            <summary>
+            Starts a user stream by requesting a listen key. This listen key can be used in subsequent requests to <see cref="M:Binance.Net.BinanceSocketClient.SubscribeToUserDataUpdates(System.String,System.Action{Binance.Net.Objects.BinanceStreamAccountInfo},System.Action{Binance.Net.Objects.BinanceStreamOrderUpdate},System.Action{Binance.Net.Objects.BinanceStreamOrderList},System.Action{System.Collections.Generic.IEnumerable{Binance.Net.Objects.BinanceStreamBalance}},System.Action{Binance.Net.Objects.Sockets.BinanceStreamBalanceUpdate})"/>. The stream will close after 60 minutes unless a keep alive is send.
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>Listen key</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.KeepAliveUserStream(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Sends a keep alive for the current user stream listen key to keep the stream from closing. Stream auto closes after 60 minutes if no keep alive is send. 30 minute interval for keep alive is recommended.
+            </summary>
+            <param name="listenKey">The listen key to keep alive</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.KeepAliveUserStreamAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Sends a keep alive for the current user stream listen key to keep the stream from closing. Stream auto closes after 60 minutes if no keep alive is send. 30 minute interval for keep alive is recommended.
+            </summary>
+            <param name="listenKey">The listen key to keep alive</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.StopUserStream(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Stops the current user stream
+            </summary>
+            <param name="listenKey">The listen key to keep alive</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.StopUserStreamAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Stops the current user stream
+            </summary>
+            <param name="listenKey">The listen key to keep alive</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesClient.ParseErrorResponse(Newtonsoft.Json.Linq.JToken)">
+            <inheritdoc />
+        </member>
+        <member name="T:Binance.Net.BinanceFuturesSocketClient">
+            <summary>
+            Client providing access to the Binance websocket Api
+            </summary>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.#ctor">
+            <summary>
+            Create a new instance of BinanceSocketClient with default options
+            </summary>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.#ctor(Binance.Net.Objects.BinanceFuturesSocketClientOptions)">
+            <summary>
+            Create a new instance of BinanceSocketClient using provided options
+            </summary>
+            <param name="options">The options to use for this client</param>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SetDefaultOptions(Binance.Net.Objects.BinanceFuturesSocketClientOptions)">
+            <summary>
+            Set the default options to be used when creating new socket clients
+            </summary>
+            <param name="options"></param>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SetApiCredentials(System.String,System.String)">
+            <summary>
+            Set the API key and secret
+            </summary>
+            <param name="apiKey">The api key</param>
+            <param name="apiSecret">The api secret</param>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToAggregatedTradeUpdates(System.String,System.Action{Binance.Net.Objects.BinanceStreamAggregatedTrade})">
+            <summary>
+            Subscribes to the aggregated trades update stream for the provided symbol
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToAggregatedTradeUpdatesAsync(System.String,System.Action{Binance.Net.Objects.BinanceStreamAggregatedTrade})">
+            <summary>
+            Subscribes to the aggregated trades update stream for the provided symbol
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToAggregatedTradeUpdates(System.Collections.Generic.IEnumerable{System.String},System.Action{Binance.Net.Objects.BinanceStreamAggregatedTrade})">
+            <summary>
+            Subscribes to the aggregated trades update stream for the provided symbols
+            </summary>
+            <param name="symbols">The symbols</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToAggregatedTradeUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},System.Action{Binance.Net.Objects.BinanceStreamAggregatedTrade})">
+            <summary>
+            Subscribes to the aggregated trades update stream for the provided symbols
+            </summary>
+            <param name="symbols">The symbols</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToKlineUpdates(System.String,Binance.Net.Objects.KlineInterval,System.Action{Binance.Net.Objects.BinanceStreamKlineData})">
+            <summary>
+            Subscribes to the candlestick update stream for the provided symbol
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="interval">The interval of the candlesticks</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToKlineUpdatesAsync(System.String,Binance.Net.Objects.KlineInterval,System.Action{Binance.Net.Objects.BinanceStreamKlineData})">
+            <summary>
+            Subscribes to the candlestick update stream for the provided symbol
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="interval">The interval of the candlesticks</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToKlineUpdates(System.Collections.Generic.IEnumerable{System.String},Binance.Net.Objects.KlineInterval,System.Action{Binance.Net.Objects.BinanceStreamKlineData})">
+            <summary>
+            Subscribes to the candlestick update stream for the provided symbols
+            </summary>
+            <param name="symbols">The symbols</param>
+            <param name="interval">The interval of the candlesticks</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToKlineUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},Binance.Net.Objects.KlineInterval,System.Action{Binance.Net.Objects.BinanceStreamKlineData})">
+            <summary>
+            Subscribes to the candlestick update stream for the provided symbols
+            </summary>
+            <param name="symbols">The symbols</param>
+            <param name="interval">The interval of the candlesticks</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToOrderBookUpdates(System.String,System.Nullable{System.Int32},System.Action{Binance.Net.Objects.BinanceOrderBook})">
+            <summary>
+            Subscribes to the order book updates for the provided symbol
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToOrderBookUpdatesAsync(System.String,System.Nullable{System.Int32},System.Action{Binance.Net.Objects.BinanceOrderBook})">
+            <summary>
+            Subscribes to the order book updates for the provided symbol
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToOrderBookUpdates(System.Collections.Generic.IEnumerable{System.String},System.Nullable{System.Int32},System.Action{Binance.Net.Objects.BinanceOrderBook})">
+            <summary>
+            Subscribes to the depth update stream for the provided symbols
+            </summary>
+            <param name="symbols">The symbols</param>
+            <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToOrderBookUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},System.Nullable{System.Int32},System.Action{Binance.Net.Objects.BinanceOrderBook})">
+            <summary>
+            Subscribes to the depth update stream for the provided symbols
+            </summary>
+            <param name="symbols">The symbols</param>
+            <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToBookTickerUpdates(System.String,System.Action{Binance.Net.Objects.BinanceBookTick})">
+            <summary>
+            Subscribes to the book ticker update stream for the provided symbol
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToBookTickerUpdatesAsync(System.String,System.Action{Binance.Net.Objects.BinanceBookTick})">
+            <summary>
+            Subscribes to the book ticker update stream for the provided symbol
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToBookTickerUpdates(System.Collections.Generic.IEnumerable{System.String},System.Action{Binance.Net.Objects.BinanceBookTick})">
+            <summary>
+            Subscribes to the book ticker update stream for the provided symbols
+            </summary>
+            <param name="symbols">The symbols</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToBookTickerUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},System.Action{Binance.Net.Objects.BinanceBookTick})">
+            <summary>
+            Subscribes to the book ticker update stream for the provided symbols
+            </summary>
+            <param name="symbols">The symbols</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToAllBookTickerUpdates(System.Action{Binance.Net.Objects.BinanceBookTick})">
+            <summary>
+            Subscribes to all book ticker update streams
+            </summary>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToAllBookTickerUpdatesAsync(System.Action{Binance.Net.Objects.BinanceBookTick})">
+            <summary>
+            Subscribes to all book ticker update streams
+            </summary>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToSymbolTickerUpdates(System.String,System.Action{Binance.Net.Objects.BinanceStreamTick})">
+            <summary>
+            Subscribes to ticker updates stream for a specific symbol
+            </summary>
+            <param name="symbol">The symbol to subscribe to</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToSymbolTickerUpdatesAsync(System.String,System.Action{Binance.Net.Objects.BinanceStreamTick})">
+            <summary>
+            Subscribes to ticker updates stream for a specific symbol
+            </summary>
+            <param name="symbol">The symbol to subscribe to</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToPartialOrderBookUpdates(System.String,System.Int32,System.Nullable{System.Int32},System.Action{Binance.Net.Objects.BinanceOrderBook})">
+            <summary>
+            Subscribes to the depth updates for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to subscribe on</param>
+            <param name="levels">The amount of entries to be returned in the update</param>
+            <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToPartialOrderBookUpdatesAsync(System.String,System.Int32,System.Nullable{System.Int32},System.Action{Binance.Net.Objects.BinanceOrderBook})">
+            <summary>
+            Subscribes to the depth updates for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to subscribe on</param>
+            <param name="levels">The amount of entries to be returned in the update</param>
+            <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToPartialOrderBookUpdates(System.Collections.Generic.IEnumerable{System.String},System.Int32,System.Nullable{System.Int32},System.Action{Binance.Net.Objects.BinanceOrderBook})">
+            <summary>
+            Subscribes to the depth updates for the provided symbols
+            </summary>
+            <param name="symbols">The symbols to subscribe on</param>
+            <param name="levels">The amount of entries to be returned in the update of each symbol</param>
+            <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToPartialOrderBookUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},System.Int32,System.Nullable{System.Int32},System.Action{Binance.Net.Objects.BinanceOrderBook})">
+            <summary>
+            Subscribes to the depth updates for the provided symbols
+            </summary>
+            <param name="symbols">The symbols to subscribe on</param>
+            <param name="levels">The amount of entries to be returned in the update of each symbol</param>
+            <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToUserDataUpdates(System.String,System.Action{Binance.Net.Objects.BinanceFuturesStreamAccountInfo},System.Action{Binance.Net.Objects.BinanceFuturesStreamOrderUpdate},System.Action{Binance.Net.Objects.BinanceStreamOrderList},System.Action{System.Collections.Generic.IEnumerable{Binance.Net.Objects.BinanceStreamBalance}},System.Action{Binance.Net.Objects.Sockets.BinanceStreamBalanceUpdate},System.Action{Binance.Net.Objects.BinanceStreamEvent})">
+            <summary>
+            Subscribes to the account update stream. Prior to using this, the <see cref="M:Binance.Net.BinanceClient.StartUserStream(System.Threading.CancellationToken)"/> method should be called.
+            </summary>
+            <param name="listenKey">Listen key retrieved by the StartUserStream method</param>
+            <param name="onAccountInfoMessage">The event handler for whenever an account info update is received</param>
+            <param name="onOrderUpdateMessage">The event handler for whenever an order status update is received</param>
+            <param name="onOcoOrderUpdateMessage">The event handler for whenever an oco status update is received</param>
+            <param name="onAccountPositionMessage">The event handler for whenever an account position update is received. Account position updates are a list of changed funds</param>
+            <param name="onAccountBalanceUpdate">The event handler for whenever a deposit or withdrawal has been processed and the account balance has changed</param>
+            <param name="onListenKeyExpired">Responds when the listen key for the stream has expired. Initiate a new instance of the stream here</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.SubscribeToUserDataUpdatesAsync(System.String,System.Action{Binance.Net.Objects.BinanceFuturesStreamAccountInfo},System.Action{Binance.Net.Objects.BinanceFuturesStreamOrderUpdate},System.Action{Binance.Net.Objects.BinanceStreamOrderList},System.Action{System.Collections.Generic.IEnumerable{Binance.Net.Objects.BinanceStreamBalance}},System.Action{Binance.Net.Objects.Sockets.BinanceStreamBalanceUpdate},System.Action{Binance.Net.Objects.BinanceStreamEvent})">
+            <summary>
+            Subscribes to the account update stream. Prior to using this, the <see cref="M:Binance.Net.BinanceClient.StartUserStream(System.Threading.CancellationToken)"/> method should be called.
+            </summary>
+            <param name="listenKey">Listen key retrieved by the StartUserStream method</param>
+            <param name="onAccountInfoMessage">The event handler for whenever an account info update is received</param>
+            <param name="onOrderUpdateMessage">The event handler for whenever an order status update is received</param>
+            <param name="onOcoOrderUpdateMessage">The event handler for whenever an oco order status update is received</param>
+            <param name="onAccountPositionMessage">The event handler for whenever an account position update is received. Account position updates are a list of changed funds</param>
+            <param name="onAccountBalanceUpdate">The event handler for whenever a deposit or withdrawal has been processed and the account balance has changed</param>
+            <param name="onListenKeyExpired">Responds when the listen key for the stream has expired. Initiate a new instance of the stream here</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.HandleQueryResponse``1(CryptoExchange.Net.Sockets.SocketConnection,System.Object,Newtonsoft.Json.Linq.JToken,CryptoExchange.Net.Objects.CallResult{``0}@)">
+            <inheritdoc />
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.HandleSubscriptionResponse(CryptoExchange.Net.Sockets.SocketConnection,CryptoExchange.Net.Sockets.SocketSubscription,System.Object,Newtonsoft.Json.Linq.JToken,CryptoExchange.Net.Objects.CallResult{System.Object}@)">
+            <inheritdoc />
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.MessageMatchesHandler(Newtonsoft.Json.Linq.JToken,System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.MessageMatchesHandler(Newtonsoft.Json.Linq.JToken,System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.AuthenticateSocket(CryptoExchange.Net.Sockets.SocketConnection)">
+            <inheritdoc />
+        </member>
+        <member name="M:Binance.Net.BinanceFuturesSocketClient.Unsubscribe(CryptoExchange.Net.Sockets.SocketConnection,CryptoExchange.Net.Sockets.SocketSubscription)">
+            <inheritdoc />
+        </member>
         <member name="T:Binance.Net.BinanceHelpers">
             <summary>
             Helper methods for the Binance API
@@ -3259,6 +4104,744 @@
             <param name="ct">Cancellation token</param>
             <returns></returns>
         </member>
+        <member name="T:Binance.Net.Interfaces.IBinanceFuturesClient">
+            <summary>
+            Interface for the Binance client
+            </summary>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.SetApiCredentials(System.String,System.String)">
+            <summary>
+            Set the API key and secret
+            </summary>
+            <param name="apiKey">The api key</param>
+            <param name="apiSecret">The api secret</param>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.Ping(System.Threading.CancellationToken)">
+            <summary>
+            Pings the Binance API
+            </summary>
+            <returns>True if successful ping, false if no response</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.PingAsync(System.Threading.CancellationToken)">
+            <summary>
+            Pings the Binance API
+            </summary>
+            <returns>True if successful ping, false if no response</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetServerTime(System.Boolean,System.Threading.CancellationToken)">
+            <summary>
+            Requests the server for the local time. This function also determines the offset between server and local time and uses this for subsequent API calls
+            </summary>
+            <param name="resetAutoTimestamp">Whether the response should be used for a new auto timestamp calculation</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Server time</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetServerTimeAsync(System.Boolean,System.Threading.CancellationToken)">
+            <summary>
+            Requests the server for the local time. This function also determines the offset between server and local time and uses this for subsequent API calls
+            </summary>
+            <param name="resetAutoTimestamp">Whether the response should be used for a new auto timestamp calculation</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Server time</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetExchangeInfo(System.Threading.CancellationToken)">
+            <summary>
+            Get's information about the exchange including rate limits and symbol list
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>Exchange info</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetExchangeInfoAsync(System.Threading.CancellationToken)">
+            <summary>
+            Get's information about the exchange including rate limits and symbol list
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>Exchange info</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetOrderBook(System.String,System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets the order book for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get the order book for</param>
+            <param name="limit">Max number of results</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The order book for the symbol</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetOrderBookAsync(System.String,System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets the order book for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get the order book for</param>
+            <param name="limit">Max number of results</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The order book for the symbol</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetAggregatedTrades(System.String,System.Nullable{System.Int64},System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets compressed, aggregate trades. Trades that fill at the time, from the same order, with the same price will have the quantity aggregated.
+            </summary>
+            <param name="symbol">The symbol to get the trades for</param>
+            <param name="fromId">ID to get aggregate trades from INCLUSIVE.</param>
+            <param name="startTime">Time to start getting trades from</param>
+            <param name="endTime">Time to stop getting trades from</param>
+            <param name="limit">Max number of results</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The aggregated trades list for the symbol</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetAggregatedTradesAsync(System.String,System.Nullable{System.Int64},System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets compressed, aggregate trades. Trades that fill at the time, from the same order, with the same price will have the quantity aggregated.
+            </summary>
+            <param name="symbol">The symbol to get the trades for</param>
+            <param name="fromId">ID to get aggregate trades from INCLUSIVE.</param>
+            <param name="startTime">Time to start getting trades from</param>
+            <param name="endTime">Time to stop getting trades from</param>
+            <param name="limit">Max number of results</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The aggregated trades list for the symbol</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetSymbolTrades(System.String,System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets the recent trades for a symbol
+            </summary>
+            <param name="symbol">The symbol to get recent trades for</param>
+            <param name="limit">Result limit</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of recent trades</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetSymbolTradesAsync(System.String,System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets the recent trades for a symbol
+            </summary>
+            <param name="symbol">The symbol to get recent trades for</param>
+            <param name="limit">Result limit</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of recent trades</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetHistoricalSymbolTrades(System.String,System.Nullable{System.Int32},System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets the historical  trades for a symbol
+            </summary>
+            <param name="symbol">The symbol to get recent trades for</param>
+            <param name="limit">Result limit</param>
+            <param name="fromId">From which trade id on results should be retrieved</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of recent trades</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetHistoricalSymbolTradesAsync(System.String,System.Nullable{System.Int32},System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets the historical  trades for a symbol
+            </summary>
+            <param name="symbol">The symbol to get recent trades for</param>
+            <param name="limit">Result limit</param>
+            <param name="fromId">From which trade id on results should be retrieved</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of recent trades</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetKlines(System.String,Binance.Net.Objects.KlineInterval,System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Get candlestick data for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get the data for</param>
+            <param name="interval">The candlestick timespan</param>
+            <param name="startTime">Start time to get candlestick data</param>
+            <param name="endTime">End time to get candlestick data</param>
+            <param name="limit">Max number of results</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The candlestick data for the provided symbol</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetKlinesAsync(System.String,Binance.Net.Objects.KlineInterval,System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Get candlestick data for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get the data for</param>
+            <param name="interval">The candlestick timespan</param>
+            <param name="startTime">Start time to get candlestick data</param>
+            <param name="endTime">End time to get candlestick data</param>
+            <param name="limit">Max number of results</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The candlestick data for the provided symbol</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.Get24HPrice(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Get data regarding the last 24 hours for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get the data for</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Data over the last 24 hours</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.Get24HPriceAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Get data regarding the last 24 hours for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get the data for</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Data over the last 24 hours</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.Get24HPricesList(System.Threading.CancellationToken)">
+            <summary>
+            Get data regarding the last 24 hours for all symbols
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>List of data over the last 24 hours</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.Get24HPricesListAsync(System.Threading.CancellationToken)">
+            <summary>
+            Get data regarding the last 24 hours for all symbols
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>List of data over the last 24 hours</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetPrice(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Gets the price of a symbol
+            </summary>
+            <param name="symbol">The symbol to get the price for</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Price of symbol</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetPriceAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Gets the price of a symbol
+            </summary>
+            <param name="symbol">The symbol to get the price for</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Price of symbol</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetAllPrices(System.Threading.CancellationToken)">
+            <summary>
+            Get a list of the prices of all symbols
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>List of prices</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetAllPricesAsync(System.Threading.CancellationToken)">
+            <summary>
+            Get a list of the prices of all symbols
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>List of prices</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetBookPrice(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Gets the best price/quantity on the order book for a symbol.
+            </summary>
+            <param name="symbol">Symbol to get book price for</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of book prices</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetBookPriceAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Gets the best price/quantity on the order book for a symbol.
+            </summary>
+            <param name="symbol">Symbol to get book price for</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of book prices</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetAllBookPrices(System.Threading.CancellationToken)">
+            <summary>
+            Gets the best price/quantity on the order book for all symbols.
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>List of book prices</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetAllBookPricesAsync(System.Threading.CancellationToken)">
+            <summary>
+            Gets the best price/quantity on the order book for all symbols.
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>List of book prices</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetOpenOrders(System.String,System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets a list of open orders
+            </summary>
+            <param name="symbol">The symbol to get open orders for</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of open orders</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetOpenOrdersAsync(System.String,System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets a list of open orders
+            </summary>
+            <param name="symbol">The symbol to get open orders for</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of open orders</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetAllOrders(System.String,System.Nullable{System.Int64},System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets all orders for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get orders for</param>
+            <param name="orderId">If set, only orders with an order id higher than the provided will be returned</param>
+            <param name="startTime">If set, only orders placed after this time will be returned</param>
+            <param name="endTime">If set, only orders placed before this time will be returned</param>
+            <param name="limit">Max number of results</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of orders</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetAllOrdersAsync(System.String,System.Nullable{System.Int64},System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Gets all orders for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to get orders for</param>
+            <param name="orderId">If set, only orders with an order id higher than the provided will be returned</param>
+            <param name="startTime">If set, only orders placed after this time will be returned</param>
+            <param name="endTime">If set, only orders placed before this time will be returned</param>
+            <param name="limit">Max number of results</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of orders</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.PlaceOrder(System.String,Binance.Net.Objects.OrderSide,Binance.Net.Objects.OrderType,System.Nullable{System.Decimal},System.Nullable{Binance.Net.Objects.TimeInForce},System.Nullable{System.Boolean},System.Nullable{System.Decimal},System.String,System.Nullable{System.Decimal},System.Nullable{Binance.Net.Objects.OrderResponseType},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Places a new order
+            </summary>
+            <param name="symbol">The symbol the order is for</param>
+            <param name="side">The order side (buy/sell)</param>
+            <param name="type">The order type</param>
+            <param name="timeInForce">Lifetime of the order (GoodTillCancel/ImmediateOrCancel/FillOrKill)</param>
+            <param name="quantity">The amount of the base symbol</param>
+            <param name="reduceOnly">Specify as true if the order is intended to only reduce the position</param>
+            <param name="price">The price to use</param>
+            <param name="newClientOrderId">Unique id for order</param>
+            <param name="stopPrice">Used for stop orders</param>
+            <param name="orderResponseType">The type of response to receive</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Id's for the placed order</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.PlaceOrderAsync(System.String,Binance.Net.Objects.OrderSide,Binance.Net.Objects.OrderType,System.Nullable{System.Decimal},System.Nullable{Binance.Net.Objects.TimeInForce},System.Nullable{System.Boolean},System.Nullable{System.Decimal},System.String,System.Nullable{System.Decimal},System.Nullable{Binance.Net.Objects.OrderResponseType},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Places a new order
+            </summary>
+            <param name="symbol">The symbol the order is for</param>
+            <param name="side">The order side (buy/sell)</param>
+            <param name="type">The order type</param>
+            <param name="timeInForce">Lifetime of the order (GoodTillCancel/ImmediateOrCancel/FillOrKill)</param>
+            <param name="quantity">The amount of the base symbol</param>
+            <param name="reduceOnly">Specify as true if the order is intended to only reduce the position</param>
+            <param name="price">The price to use</param>
+            <param name="newClientOrderId">Unique id for order</param>
+            <param name="stopPrice">Used for stop orders</param>
+            <param name="orderResponseType">The type of response to receive</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Id's for the placed order</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetOrder(System.String,System.Nullable{System.Int64},System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Retrieves data for a specific order. Either orderId or origClientOrderId should be provided.
+            </summary>
+            <param name="symbol">The symbol the order is for</param>
+            <param name="orderId">The order id of the order</param>
+            <param name="origClientOrderId">The client order id of the order</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The specific order</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetOrderAsync(System.String,System.Nullable{System.Int64},System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Retrieves data for a specific order. Either orderId or origClientOrderId should be provided.
+            </summary>
+            <param name="symbol">The symbol the order is for</param>
+            <param name="orderId">The order id of the order</param>
+            <param name="origClientOrderId">The client order id of the order</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The specific order</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.CancelOrder(System.String,System.Nullable{System.Int64},System.String,System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Cancels a pending order
+            </summary>
+            <param name="symbol">The symbol the order is for</param>
+            <param name="orderId">The order id of the order</param>
+            <param name="origClientOrderId">The client order id of the order</param>
+            <param name="newClientOrderId">The new client order id of the order</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Id's for canceled order</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.CancelOrderAsync(System.String,System.Nullable{System.Int64},System.String,System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Cancels a pending order
+            </summary>
+            <param name="symbol">The symbol the order is for</param>
+            <param name="orderId">The order id of the order</param>
+            <param name="origClientOrderId">The client order id of the order</param>
+            <param name="newClientOrderId">Unique identifier for this cancel</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Id's for canceled order</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetAccountInfo(System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets account information, including balances
+            </summary>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The account information</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetAccountInfoAsync(System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets account information, including balances
+            </summary>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>The account information</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetMyTrades(System.String,System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Nullable{System.Int64},System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets all user trades for provided symbol
+            </summary>
+            <param name="symbol">Symbol to get trades for</param>
+            <param name="limit">The max number of results</param>
+            <param name="startTime">Orders newer than this date will be retrieved</param>
+            <param name="endTime">Orders older than this date will be retrieved</param>
+            <param name="fromId">TradeId to fetch from. Default gets most recent trades</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of trades</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetMyTradesAsync(System.String,System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Nullable{System.Int64},System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets all user trades for provided symbol
+            </summary>
+            <param name="symbol">Symbol to get trades for</param>
+            <param name="limit">The max number of results</param>
+            <param name="fromId">TradeId to fetch from. Default gets most recent trades</param>
+            <param name="startTime">Orders newer than this date will be retrieved</param>
+            <param name="endTime">Orders older than this date will be retrieved</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of trades</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetFuturesAccountBalance(System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets Futures Account Balance
+            </summary>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of Positions</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetFuturesAccountBalanceAsync(System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets Futures Account Balance
+            </summary>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of Positions</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetOpenPositions(System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets all user positions
+            </summary>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of Positions</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.GetOpenPositionsAsync(System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Gets all user positions
+            </summary>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns>List of Positions</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.StartUserStream(System.Threading.CancellationToken)">
+            <summary>
+            Starts a user stream by requesting a listen key. This listen key can be used in subsequent requests to <see cref="M:Binance.Net.BinanceSocketClient.SubscribeToUserDataUpdates(System.String,System.Action{Binance.Net.Objects.BinanceStreamAccountInfo},System.Action{Binance.Net.Objects.BinanceStreamOrderUpdate},System.Action{Binance.Net.Objects.BinanceStreamOrderList},System.Action{System.Collections.Generic.IEnumerable{Binance.Net.Objects.BinanceStreamBalance}},System.Action{Binance.Net.Objects.Sockets.BinanceStreamBalanceUpdate})"/>. The stream will close after 60 minutes unless a keep alive is send.
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>Listen key</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.StartUserStreamAsync(System.Threading.CancellationToken)">
+            <summary>
+            Starts a user stream by requesting a listen key. This listen key can be used in subsequent requests to <see cref="M:Binance.Net.BinanceSocketClient.SubscribeToUserDataUpdates(System.String,System.Action{Binance.Net.Objects.BinanceStreamAccountInfo},System.Action{Binance.Net.Objects.BinanceStreamOrderUpdate},System.Action{Binance.Net.Objects.BinanceStreamOrderList},System.Action{System.Collections.Generic.IEnumerable{Binance.Net.Objects.BinanceStreamBalance}},System.Action{Binance.Net.Objects.Sockets.BinanceStreamBalanceUpdate})"/>. The stream will close after 60 minutes unless a keep alive is send.
+            </summary>
+            <param name="ct">Cancellation token</param>
+            <returns>Listen key</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.KeepAliveUserStream(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Sends a keep alive for the current user stream listen key to keep the stream from closing. Stream auto closes after 60 minutes if no keep alive is send. 30 minute interval for keep alive is recommended.
+            </summary>
+            <param name="listenKey">The listen key to keep alive</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.KeepAliveUserStreamAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Sends a keep alive for the current user stream listen key to keep the stream from closing. Stream auto closes after 60 minutes if no keep alive is send. 30 minute interval for keep alive is recommended.
+            </summary>
+            <param name="listenKey">The listen key to keep alive</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.StopUserStream(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Stops the current user stream
+            </summary>
+            <param name="listenKey">The listen key to keep alive</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesClient.StopUserStreamAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            Stops the current user stream
+            </summary>
+            <param name="listenKey">The listen key to keep alive</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="T:Binance.Net.Interfaces.IBinanceFuturesSocketClient">
+            <summary>
+            Interface for the Binance socket client
+            </summary>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SetApiCredentials(System.String,System.String)">
+            <summary>
+            Set the API key and secret
+            </summary>
+            <param name="apiKey">The api key</param>
+            <param name="apiSecret">The api secret</param>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToKlineUpdates(System.String,Binance.Net.Objects.KlineInterval,System.Action{Binance.Net.Objects.BinanceStreamKlineData})">
+            <summary>
+            Subscribes to the candlestick update stream for the provided symbol
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="interval">The interval of the candlesticks</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToKlineUpdatesAsync(System.String,Binance.Net.Objects.KlineInterval,System.Action{Binance.Net.Objects.BinanceStreamKlineData})">
+            <summary>
+            Subscribes to the candlestick update stream for the provided symbol
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="interval">The interval of the candlesticks</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToKlineUpdates(System.Collections.Generic.IEnumerable{System.String},Binance.Net.Objects.KlineInterval,System.Action{Binance.Net.Objects.BinanceStreamKlineData})">
+            <summary>
+            Subscribes to the candlestick update stream for the provided symbols
+            </summary>
+            <param name="symbols">The symbols</param>
+            <param name="interval">The interval of the candlesticks</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToKlineUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},Binance.Net.Objects.KlineInterval,System.Action{Binance.Net.Objects.BinanceStreamKlineData})">
+            <summary>
+            Subscribes to the candlestick update stream for the provided symbols
+            </summary>
+            <param name="symbols">The symbols</param>
+            <param name="interval">The interval of the candlesticks</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToOrderBookUpdates(System.String,System.Nullable{System.Int32},System.Action{Binance.Net.Objects.BinanceOrderBook})">
+            <summary>
+            Subscribes to the order book updates for the provided symbol
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToOrderBookUpdatesAsync(System.String,System.Nullable{System.Int32},System.Action{Binance.Net.Objects.BinanceOrderBook})">
+            <summary>
+            Subscribes to the order book updates for the provided symbol
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToOrderBookUpdates(System.Collections.Generic.IEnumerable{System.String},System.Nullable{System.Int32},System.Action{Binance.Net.Objects.BinanceOrderBook})">
+            <summary>
+            Subscribes to the depth update stream for the provided symbols
+            </summary>
+            <param name="symbols">The symbols</param>
+            <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToOrderBookUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},System.Nullable{System.Int32},System.Action{Binance.Net.Objects.BinanceOrderBook})">
+            <summary>
+            Subscribes to the depth update stream for the provided symbols
+            </summary>
+            <param name="symbols">The symbols</param>
+            <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToBookTickerUpdates(System.String,System.Action{Binance.Net.Objects.BinanceBookTick})">
+            <summary>
+            Subscribes to the book ticker update stream for the provided symbol
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToBookTickerUpdatesAsync(System.String,System.Action{Binance.Net.Objects.BinanceBookTick})">
+            <summary>
+            Subscribes to the book ticker update stream for the provided symbol
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToBookTickerUpdates(System.Collections.Generic.IEnumerable{System.String},System.Action{Binance.Net.Objects.BinanceBookTick})">
+            <summary>
+            Subscribes to the book ticker update stream for the provided symbols
+            </summary>
+            <param name="symbols">The symbols</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToBookTickerUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},System.Action{Binance.Net.Objects.BinanceBookTick})">
+            <summary>
+            Subscribes to the book ticker update stream for the provided symbols
+            </summary>
+            <param name="symbols">The symbols</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToAllBookTickerUpdates(System.Action{Binance.Net.Objects.BinanceBookTick})">
+            <summary>
+            Subscribes to all book ticker update streams
+            </summary>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToAllBookTickerUpdatesAsync(System.Action{Binance.Net.Objects.BinanceBookTick})">
+            <summary>
+            Subscribes to all book ticker update streams
+            </summary>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToAggregatedTradeUpdates(System.String,System.Action{Binance.Net.Objects.BinanceStreamAggregatedTrade})">
+            <summary>
+            Subscribes to the aggregated trades update stream for the provided symbol
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToAggregatedTradeUpdatesAsync(System.String,System.Action{Binance.Net.Objects.BinanceStreamAggregatedTrade})">
+            <summary>
+            Subscribes to the aggregated trades update stream for the provided symbol
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToAggregatedTradeUpdates(System.Collections.Generic.IEnumerable{System.String},System.Action{Binance.Net.Objects.BinanceStreamAggregatedTrade})">
+            <summary>
+            Subscribes to the aggregated trades update stream for the provided symbols
+            </summary>
+            <param name="symbols">The symbols</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToAggregatedTradeUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},System.Action{Binance.Net.Objects.BinanceStreamAggregatedTrade})">
+            <summary>
+            Subscribes to the aggregated trades update stream for the provided symbols
+            </summary>
+            <param name="symbols">The symbols</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToSymbolTickerUpdates(System.String,System.Action{Binance.Net.Objects.BinanceStreamTick})">
+            <summary>
+            Subscribes to ticker updates stream for a specific symbol
+            </summary>
+            <param name="symbol">The symbol to subscribe to</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToSymbolTickerUpdatesAsync(System.String,System.Action{Binance.Net.Objects.BinanceStreamTick})">
+            <summary>
+            Subscribes to ticker updates stream for a specific symbol
+            </summary>
+            <param name="symbol">The symbol to subscribe to</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToPartialOrderBookUpdates(System.String,System.Int32,System.Nullable{System.Int32},System.Action{Binance.Net.Objects.BinanceOrderBook})">
+            <summary>
+            Subscribes to the depth updates for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to subscribe on</param>
+            <param name="levels">The amount of entries to be returned in the update</param>
+            <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToPartialOrderBookUpdatesAsync(System.String,System.Int32,System.Nullable{System.Int32},System.Action{Binance.Net.Objects.BinanceOrderBook})">
+            <summary>
+            Subscribes to the depth updates for the provided symbol
+            </summary>
+            <param name="symbol">The symbol to subscribe on</param>
+            <param name="levels">The amount of entries to be returned in the update</param>
+            <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToPartialOrderBookUpdates(System.Collections.Generic.IEnumerable{System.String},System.Int32,System.Nullable{System.Int32},System.Action{Binance.Net.Objects.BinanceOrderBook})">
+            <summary>
+            Subscribes to the depth updates for the provided symbols
+            </summary>
+            <param name="symbols">The symbols to subscribe on</param>
+            <param name="levels">The amount of entries to be returned in the update of each symbol</param>
+            <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToPartialOrderBookUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},System.Int32,System.Nullable{System.Int32},System.Action{Binance.Net.Objects.BinanceOrderBook})">
+            <summary>
+            Subscribes to the depth updates for the provided symbols
+            </summary>
+            <param name="symbols">The symbols to subscribe on</param>
+            <param name="levels">The amount of entries to be returned in the update of each symbol</param>
+            <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToUserDataUpdates(System.String,System.Action{Binance.Net.Objects.BinanceFuturesStreamAccountInfo},System.Action{Binance.Net.Objects.BinanceFuturesStreamOrderUpdate},System.Action{Binance.Net.Objects.BinanceStreamOrderList},System.Action{System.Collections.Generic.IEnumerable{Binance.Net.Objects.BinanceStreamBalance}},System.Action{Binance.Net.Objects.Sockets.BinanceStreamBalanceUpdate},System.Action{Binance.Net.Objects.BinanceStreamEvent})">
+            <summary>
+            Subscribes to the account update stream. Prior to using this, the <see cref="M:Binance.Net.BinanceClient.StartUserStream(System.Threading.CancellationToken)"/> method should be called.
+            </summary>
+            <param name="listenKey">Listen key retrieved by the StartUserStream method</param>
+            <param name="onAccountInfoMessage">The event handler for whenever an account info update is received</param>
+            <param name="onOrderUpdateMessage">The event handler for whenever an order status update is received</param>
+            <param name="onOcoOrderUpdateMessage">The event handler for whenever an oco status update is received</param>
+            <param name="onAccountPositionMessage">The event handler for whenever an account position update is received. Account position updates are a list of changed funds</param>
+            <param name="onAccountBalanceUpdate">The event handler for whenever a deposit or withdrawal has been processed and the account balance has changed</param>
+            <param name="onListenKeyExpired">Responds when the listen key for the stream has expired. Initiate a new instance of the stream here</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.IBinanceFuturesSocketClient.SubscribeToUserDataUpdatesAsync(System.String,System.Action{Binance.Net.Objects.BinanceFuturesStreamAccountInfo},System.Action{Binance.Net.Objects.BinanceFuturesStreamOrderUpdate},System.Action{Binance.Net.Objects.BinanceStreamOrderList},System.Action{System.Collections.Generic.IEnumerable{Binance.Net.Objects.BinanceStreamBalance}},System.Action{Binance.Net.Objects.Sockets.BinanceStreamBalanceUpdate},System.Action{Binance.Net.Objects.BinanceStreamEvent})">
+            <summary>
+            Subscribes to the account update stream. Prior to using this, the <see cref="M:Binance.Net.BinanceClient.StartUserStream(System.Threading.CancellationToken)"/> method should be called.
+            </summary>
+            <param name="listenKey">Listen key retrieved by the StartUserStream method</param>
+            <param name="onAccountInfoMessage">The event handler for whenever an account info update is received</param>
+            <param name="onOrderUpdateMessage">The event handler for whenever an order status update is received</param>
+            <param name="onOcoOrderUpdateMessage">The event handler for whenever an oco order status update is received</param>
+            <param name="onAccountPositionMessage">The event handler for whenever an account position update is received. Account position updates are a list of changed funds</param>
+            <param name="onAccountBalanceUpdate">The event handler for whenever a deposit or withdrawal has been processed and the account balance has changed</param>
+            <param name="onListenKeyExpired">Responds when the listen key for the stream has expired. Initiate a new instance of the stream here</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
         <member name="T:Binance.Net.Interfaces.IBinanceSocketClient">
             <summary>
             Interface for the Binance socket client
@@ -4382,6 +5965,495 @@
         <member name="P:Binance.Net.Objects.BinanceForcedLiquidation.UpdateTime">
             <summary>
             Last update time
+            </summary>
+        </member>
+        <member name="T:Binance.Net.Objects.BinanceFuturesAccountBalance">
+            <summary>
+            Information about an account
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesAccountBalance.Asset">
+            <summary>
+            The asset this balance is for
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesAccountBalance.Balance">
+            <summary>
+            The total balance of this asset
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesAccountBalance.WithdrawAvailable">
+            <summary>
+            The total balance available for withdraw for this asset
+            </summary>
+        </member>
+        <member name="T:Binance.Net.Objects.BinanceFuturesClientOptions">
+            <summary>
+            Options for the binance client
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesClientOptions.AutoTimestamp">
+            <summary>
+            Whether or not to automatically sync the local time with the server time
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesClientOptions.AutoTimestampRecalculationInterval">
+            <summary>
+            Interval for refreshing the auto timestamp calculation
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesClientOptions.TimestampOffset">
+            <summary>
+            A manual offset for the timestamp. Should only be used if AutoTimestamp and regular time synchronization on the OS is not reliable enough
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesClientOptions.TradeRulesBehaviour">
+            <summary>
+            Whether to check the trade rules when placing new orders and what to do if the trade isn't valid
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesClientOptions.TradeRulesUpdateInterval">
+            <summary>
+            How often the trade rules should be updated. Only used when TradeRulesBehaviour is not None
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesClientOptions.ReceiveWindow">
+            <summary>
+            The default receive window for requests
+            </summary>
+        </member>
+        <member name="M:Binance.Net.Objects.BinanceFuturesClientOptions.#ctor">
+            <summary>
+            ctor
+            </summary>
+        </member>
+        <member name="M:Binance.Net.Objects.BinanceFuturesClientOptions.Copy">
+            <summary>
+            Return a copy of these options
+            </summary>
+            <returns></returns>
+        </member>
+        <member name="T:Binance.Net.Objects.BinanceFuturesSocketClientOptions">
+            <summary>
+            Binance socket client options
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSocketClientOptions.BaseSocketCombinedAddress">
+            <summary>
+            The base address for combined data in socket connections
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSocketClientOptions.SocketSubscriptionsCombineTarget">
+            <summary>
+            The amount of subscriptions that should be made on a single socket connection. Not all exchanges support multiple subscriptions on a single socket.
+            Setting this to a higher number increases subscription speed, but having more subscriptions on a single connection will also increase the amount of traffic on that single connection.
+            Not available on Binance.
+            </summary>
+        </member>
+        <member name="M:Binance.Net.Objects.BinanceFuturesSocketClientOptions.#ctor">
+            <summary>
+            ctor
+            </summary>
+        </member>
+        <member name="M:Binance.Net.Objects.BinanceFuturesSocketClientOptions.Copy">
+            <summary>
+            Return a copy of these options
+            </summary>
+            <returns></returns>
+        </member>
+        <member name="T:Binance.Net.Objects.BinanceFuturesExchangeInfo">
+            <summary>
+            Exchange info
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesExchangeInfo.TimeZone">
+            <summary>
+            The timezone the server uses
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesExchangeInfo.ServerTime">
+            <summary>
+            The current server time
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesExchangeInfo.RateLimits">
+            <summary>
+            The rate limits used
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesExchangeInfo.Symbols">
+            <summary>
+            All symbols supported
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesExchangeInfo.ExchangeFilters">
+            <summary>
+            Filters
+            </summary>
+        </member>
+        <member name="T:Binance.Net.Objects.BinanceFuturesFundingRate">
+            <summary>
+            
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesFundingRate.Symbol">
+            <summary>
+            The symbol the information is about
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesFundingRate.BidPrice">
+            <summary>
+            The highest bid price for the symbol
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesFundingRate.BidQuantity">
+            <summary>
+            The quantity of the highest bid price currently in the order book
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesFundingRate.AskPrice">
+            <summary>
+            The lowest ask price for the symbol
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesFundingRate.AskQuantity">
+            <summary>
+            The quantity of the lowest ask price currently in the order book
+            </summary>
+        </member>
+        <member name="T:Binance.Net.Objects.BinanceFuturesMarkPrice">
+            <summary>
+            
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesMarkPrice.Symbol">
+            <summary>
+            The symbol the information is about
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesMarkPrice.BidPrice">
+            <summary>
+            The highest bid price for the symbol
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesMarkPrice.BidQuantity">
+            <summary>
+            The quantity of the highest bid price currently in the order book
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesMarkPrice.AskPrice">
+            <summary>
+            The lowest ask price for the symbol
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesMarkPrice.AskQuantity">
+            <summary>
+            The quantity of the lowest ask price currently in the order book
+            </summary>
+        </member>
+        <member name="T:Binance.Net.Objects.BinanceFuturesPosition">
+            <summary>
+            Information about an account
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesPosition.EntryPrice">
+            <summary>
+            The entry price of the position
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesPosition.Leverage">
+            <summary>
+            The current initial leverage of the position
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesPosition.MaxNotionalValue">
+            <summary>
+            The notional value limit of current initial leverage
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesPosition.LiquidationPrice">
+            <summary>
+            The Liquidation price of the position
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesPosition.MarkPrice">
+            <summary>
+            The Market price of the position
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesPosition.Quantity">
+            <summary>
+            The quantity of the position
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesPosition.Symbol">
+            <summary>
+            The symbol the position is for
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesPosition.unRealizedProfit">
+            <summary>
+            The price of the unrealized PnL
+            </summary>
+        </member>
+        <member name="T:Binance.Net.Objects.BinanceFuturesStreamAccountInfo">
+            <summary>
+            Information about an account
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamAccountInfo.Balances">
+            <summary>
+            List of assets with their current balances
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamAccountInfo.Positions">
+            <summary>
+            List of assets with their current positions
+            </summary>
+        </member>
+        <member name="T:Binance.Net.Objects.BinanceFuturesStreamBalance">
+            <summary>
+            Information about an asset balance
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamBalance.Asset">
+            <summary>
+            The asset this balance is for
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamBalance.WalletBalance">
+            <summary>
+            The amount that isn't locked in a trade
+            </summary>
+        </member>
+        <member name="T:Binance.Net.Objects.BinanceFuturesStreamPosition">
+            <summary>
+            Information about an asset position
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamPosition.Symbol">
+            <summary>
+            The symbol this balance is for
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamPosition.PositionAmount">
+            <summary>
+            The amount of the position
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamPosition.EntryPrice">
+            <summary>
+            The entry price
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamPosition.RealizedPnL">
+            <summary>
+            The accumulated realized PnL
+            </summary>
+        </member>
+        <member name="T:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate">
+            <summary>
+            Update data about an order
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.Symbol">
+            <summary>
+            The symbol the order is for
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.ClientOrderId">
+            <summary>
+            The new client order id
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.Side">
+            <summary>
+            The side of the order
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.Type">
+            <summary>
+            The type of the order
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.TimeInForce">
+            <summary>
+            The timespan the order is active
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.Quantity">
+            <summary>
+            The quantity of the order
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.Price">
+            <summary>
+            The price of the order
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.AveragePrice">
+            <summary>
+            The average price of the order
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.StopPrice">
+            <summary>
+            The stop price of the order
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.ExecutionType">
+            <summary>
+            The execution type
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.Status">
+            <summary>
+            The status of the order
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.OrderId">
+            <summary>
+            The id of the order as assigned by Binance
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.QuantityOfLastFilledTrade">
+            <summary>
+            The quantity of the last filled trade of this order
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.AccumulatedQuantityOfFilledTrades">
+            <summary>
+            The quantity of all trades that were filled for this order
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.PriceLastFilledTrade">
+            <summary>
+            The price of the last filled trade
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.Commission">
+            <summary>
+            The commission payed
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.CommissionAsset">
+            <summary>
+            The asset the commission was taken from
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.OrderCreationTime">
+            <summary>
+            The time of the update
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.TradeId">
+            <summary>
+            The trade id
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesStreamOrderUpdate.BuyerIsMaker">
+            <summary>
+            Whether the buyer is the maker
+            </summary>
+        </member>
+        <member name="T:Binance.Net.Objects.BinanceFuturesSymbol">
+            <summary>
+            Information about an account
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.Filters">
+            <summary>
+            Filters for order on this symbol
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.MaintMarginPercent">
+            <summary>
+            The open margin percent
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.PricePrecision">
+            <summary>
+            The price Precision
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.QuantityPrecision">
+            <summary>
+            The quantity precision
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.RequiredMarginPercent">
+            <summary>
+            The required margin percent
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.BaseAsset">
+            <summary>
+            The base asset
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.QuoteAsset">
+            <summary>
+            The quote asset
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.BaseAssetPrecision">
+            <summary>
+            The precision of the base asset
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.QuoteAssetPrecision">
+            <summary>
+            The precision of the quote asset
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.Status">
+            <summary>
+            The status of the symbol
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.OrderTypes">
+            <summary>
+            Allowed order types
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.Name">
+            <summary>
+            The symbol
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.TimeInForce">
+            <summary>
+            Allowed order time in force
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.PriceFilter">
+            <summary>
+            Filter for the max accuracy of the price for this symbol
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.LotSizeFilter">
+            <summary>
+            Filter for max accuracy of the quantity for this symbol
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.MarketLotSizeFilter">
+            <summary>
+            Filter for max accuracy of the quantity for this symbol, specifically for market orders
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.MaxOrdersFilter">
+            <summary>
+            Filter for max number of orders for this symbol
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.MaxAlgoOrdersFilter">
+            <summary>
+            Filter for max number of orders for this symbol
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.BinanceFuturesSymbol.PricePercentFilter">
+            <summary>
+            Filter for the maximum deviation of the price
             </summary>
         </member>
         <member name="T:Binance.Net.Objects.BinanceInterestHistory">

--- a/Binance.Net/BinanceFuturesClient.cs
+++ b/Binance.Net/BinanceFuturesClient.cs
@@ -20,7 +20,7 @@ using Binance.Net.Interfaces;
 namespace Binance.Net
 {
     /// <summary>
-    /// Client providing access to the Binance REST Api
+    /// Client providing access to the Binance Futures REST Api
     /// </summary>
     public class BinanceFuturesClient : RestClient, IBinanceFuturesClient
     {
@@ -899,7 +899,7 @@ namespace Binance.Net
         }
 
         /// <summary>
-        /// Requests to change the initial leverag of the given symbol
+        /// Requests to change the initial leverage of the given symbol
         /// </summary>
         /// <param name="symbol">Symbol to change the initial leverage for</param>
         /// <param name="leverage">The amount of initial leverage to change to</param>
@@ -909,7 +909,7 @@ namespace Binance.Net
         public WebCallResult<BinanceFuturesInitialLeverageChangeResult> ChangeInitialLeverage(string symbol, int leverage, long? receiveWindow = null, CancellationToken ct = default) => ChangeInitialLeverageAsync(symbol, leverage, receiveWindow, ct).Result;
 
         /// <summary>
-        /// Requests to change the initial leverag of the given symbol
+        /// Requests to change the initial leverage of the given symbol
         /// </summary>
         /// <param name="symbol">Symbol to change the initial leverage for</param>
         /// <param name="leverage">The amount of initial leverage to change to</param>

--- a/Binance.Net/BinanceFuturesClient.cs
+++ b/Binance.Net/BinanceFuturesClient.cs
@@ -1,0 +1,1452 @@
+using Binance.Net.Converters;
+using Binance.Net.Objects;
+using CryptoExchange.Net;
+using CryptoExchange.Net.Authentication;
+using CryptoExchange.Net.Converters;
+using CryptoExchange.Net.Logging;
+using CryptoExchange.Net.Objects;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Binance.Net.Interfaces;
+
+namespace Binance.Net
+{
+    /// <summary>
+    /// Client providing access to the Binance REST Api
+    /// </summary>
+    public class BinanceFuturesClient : RestClient, IBinanceFuturesClient
+    {
+        #region fields 
+        private static BinanceFuturesClientOptions defaultOptions = new BinanceFuturesClientOptions();
+        private static BinanceFuturesClientOptions DefaultOptions => defaultOptions.Copy();
+
+        private readonly bool autoTimestamp;
+        private readonly TimeSpan autoTimestampRecalculationInterval;
+        private readonly TimeSpan timestampOffset;
+        private readonly TradeRulesBehaviour tradeRulesBehaviour;
+        private readonly TimeSpan tradeRulesUpdateInterval;
+        private readonly TimeSpan defaultReceiveWindow;
+
+        private double calculatedTimeOffset;
+        private bool timeSynced;
+        private DateTime lastTimeSync;
+
+        private BinanceFuturesExchangeInfo? exchangeInfo;
+        private DateTime? lastExchangeInfoUpdate;
+
+
+        // Addresses
+        private const string Api = "fapi";
+
+        // Versions
+        private const string PublicVersion = "1";
+        private const string SignedVersion = "1";
+        private const string UserDataStreamVersion = "1";
+
+        // Public
+        private const string PingEndpoint = "ping";
+        private const string CheckTimeEndpoint = "time";
+        private const string ExchangeInfoEndpoint = "exchangeInfo";
+        private const string OrderBookEndpoint = "depth";
+        private const string RecentTradesEndpoint = "trades";
+        private const string HistoricalTradesEndpoint = "historicalTrades";
+        private const string AggregatedTradesEndpoint = "aggTrades";
+        private const string KlinesEndpoint = "klines";
+        private const string Price24HEndpoint = "ticker/24hr";
+        private const string AllPricesEndpoint = "ticker/price";
+        private const string BookPricesEndpoint = "ticker/bookTicker";
+
+        // Orders
+        private const string NewOrderEndpoint = "order";
+        private const string QueryOrderEndpoint = "order";
+        private const string CancelOrderEndpoint = "order";
+        private const string OpenOrdersEndpoint = "openOrders";
+        private const string AllOrdersEndpoint = "allOrders";
+        // Accounts
+        private const string AccountInfoEndpoint = "account";
+        private const string MyFuturesTradesEndpoint = "userTrades";
+
+        // User stream
+        private const string GetFuturesListenKeyEndpoint = "listenKey";
+        private const string KeepFuturesListenKeyAliveEndpoint = "listenKey";
+        private const string CloseFuturesListenKeyEndpoint = "listenKey";
+
+        // Futures Public
+        private const string MarkPriceEndpoint = "premiumIndex";
+        private const string FundingRateHistoryEndpoint = "fundingRate";
+
+        // Futures Private
+        private const string FuturesAccountBalanceEndpoint = "balance";
+        private const string ChangeInitialLeverageEndpoint = "leverage";
+        private const string PositionInformationEndpoint = "positionRisk";
+        private const string IncomeHistoryEndpoint = "income";
+        private const string PositionMarginEndpoint = "positionMargin";
+        private const string PositionMarginChangeHistoryEndpoint = "positionMargin/history";
+        private const string ChangeMarginTypeEndpoint = "marginType ";
+
+
+        #endregion
+
+        #region constructor/destructor
+        /// <summary>
+        /// Create a new instance of BinanceFuturesClient using the default options
+        /// </summary>
+        public BinanceFuturesClient() : this(DefaultOptions)
+        {
+        }
+
+        /// <summary>
+        /// Create a new instance of BinanceFuturesClient using provided options
+        /// </summary>
+        /// <param name="options">The options to use for this client</param>
+        public BinanceFuturesClient(BinanceFuturesClientOptions options) : base(options, options.ApiCredentials == null ? null : new BinanceAuthenticationProvider(options.ApiCredentials, ArrayParametersSerialization.MultipleValues))
+        {
+            arraySerialization = ArrayParametersSerialization.MultipleValues;
+
+            autoTimestamp = options.AutoTimestamp;
+            tradeRulesBehaviour = options.TradeRulesBehaviour;
+            tradeRulesUpdateInterval = options.TradeRulesUpdateInterval;
+            autoTimestampRecalculationInterval = options.AutoTimestampRecalculationInterval;
+            timestampOffset = options.TimestampOffset;
+            defaultReceiveWindow = options.ReceiveWindow;
+
+            postParametersPosition = PostParameters.InUri;
+        }
+        #endregion
+
+        #region methods
+        #region public
+        /// <summary>
+        /// Set the default options to be used when creating new clients
+        /// </summary>
+        /// <param name="options"></param>
+        public static void SetDefaultOptions(BinanceFuturesClientOptions options)
+        {
+            defaultOptions = options;
+        }
+
+        /// <summary>
+        /// Set the API key and secret
+        /// </summary>
+        /// <param name="apiKey">The api key</param>
+        /// <param name="apiSecret">The api secret</param>
+        public void SetApiCredentials(string apiKey, string apiSecret)
+        {
+            SetAuthenticationProvider(new BinanceAuthenticationProvider(new ApiCredentials(apiKey, apiSecret), ArrayParametersSerialization.MultipleValues));
+        }
+
+        /// <summary>
+        /// Pings the Binance Futures API
+        /// </summary>
+        /// <returns>True if successful ping, false if no response</returns>
+        public override CallResult<long> Ping(CancellationToken ct = default) => PingAsync(ct).Result;
+
+        /// <summary>
+        /// Pings the Binance Futures API
+        /// </summary>
+        /// <returns>True if successful ping, false if no response</returns>
+        public override async Task<CallResult<long>> PingAsync(CancellationToken ct = default)
+        {
+            var sw = Stopwatch.StartNew();
+            var result = await SendRequest<object>(GetUrl(PingEndpoint, Api, PublicVersion), HttpMethod.Get, ct).ConfigureAwait(false);
+            sw.Stop();
+            return new CallResult<long>(result.Error == null ? sw.ElapsedMilliseconds : 0, result.Error);
+        }
+
+        /// <summary>
+        /// Requests the server for the local time. This function also determines the offset between server and local time and uses this for subsequent API calls
+        /// </summary>
+        /// <param name="resetAutoTimestamp">Whether the response should be used for a new auto timestamp calculation</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Server time</returns>
+        public WebCallResult<DateTime> GetServerTime(bool resetAutoTimestamp = false, CancellationToken ct = default) => GetServerTimeAsync(resetAutoTimestamp, ct).Result;
+
+        /// <summary>
+        /// Requests the server for the local time. This function also determines the offset between server and local time and uses this for subsequent API calls
+        /// </summary>
+        /// <param name="resetAutoTimestamp">Whether the response should be used for a new auto timestamp calculation</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Server time</returns>
+        public async Task<WebCallResult<DateTime>> GetServerTimeAsync(bool resetAutoTimestamp = false, CancellationToken ct = default)
+        {
+            var url = GetUrl(CheckTimeEndpoint, Api, PublicVersion);
+            if (!autoTimestamp)
+            {
+                var result = await SendRequest<BinanceCheckTime>(url, HttpMethod.Get, ct).ConfigureAwait(false);
+                return new WebCallResult<DateTime>(result.ResponseStatusCode, result.ResponseHeaders, result.Data?.ServerTime ?? default, result.Error);
+            }
+            else
+            {
+                var localTime = DateTime.UtcNow;
+                var result = await SendRequest<BinanceCheckTime>(url, HttpMethod.Get, ct).ConfigureAwait(false);
+                if (!result)
+                    return new WebCallResult<DateTime>(result.ResponseStatusCode, result.ResponseHeaders, default, result.Error);
+
+                if (timeSynced && !resetAutoTimestamp)
+                    return new WebCallResult<DateTime>(result.ResponseStatusCode, result.ResponseHeaders, result.Data.ServerTime, result.Error);
+
+                if (TotalRequestsMade == 1)
+                {
+                    // If this was the first request make another one to calculate the offset since the first one can be slower
+                    localTime = DateTime.UtcNow;
+                    result = await SendRequest<BinanceCheckTime>(url, HttpMethod.Get, ct).ConfigureAwait(false);
+                    if (!result)
+                        return new WebCallResult<DateTime>(result.ResponseStatusCode, result.ResponseHeaders, default, result.Error);
+                }
+
+                // Calculate time offset between local and server
+                var offset = (result.Data.ServerTime - localTime).TotalMilliseconds;
+                if (offset >= 0 && offset < 500)
+                {
+                    // Small offset, probably mainly due to ping. Don't adjust time
+                    calculatedTimeOffset = 0;
+                    timeSynced = true;
+                    lastTimeSync = DateTime.UtcNow;
+                    log.Write(LogVerbosity.Info, $"Time offset between 0 and 500ms ({offset}ms), no adjustment needed");
+                    return new WebCallResult<DateTime>(result.ResponseStatusCode, result.ResponseHeaders, result.Data.ServerTime, result.Error);
+                }
+
+                calculatedTimeOffset = (result.Data.ServerTime - localTime).TotalMilliseconds;
+                timeSynced = true;
+                lastTimeSync = DateTime.UtcNow;
+                log.Write(LogVerbosity.Info, $"Time offset set to {calculatedTimeOffset}ms");
+                return new WebCallResult<DateTime>(result.ResponseStatusCode, result.ResponseHeaders, result.Data.ServerTime, result.Error);
+            }
+        }
+
+        /// <summary>
+        /// Get's information about the exchange including rate limits and symbol list
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Exchange info</returns>
+        public WebCallResult<BinanceFuturesExchangeInfo> GetExchangeInfo(CancellationToken ct = default) => GetExchangeInfoAsync(ct).Result;
+
+        /// <summary>
+        /// Get's information about the exchange including rate limits and symbol list
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Exchange info</returns>
+        public async Task<WebCallResult<BinanceFuturesExchangeInfo>> GetExchangeInfoAsync(CancellationToken ct = default)
+        {
+            var exchangeInfoResult = await SendRequest<BinanceFuturesExchangeInfo>(GetUrl(ExchangeInfoEndpoint, Api, PublicVersion), HttpMethod.Get, ct).ConfigureAwait(false);
+            if (!exchangeInfoResult)
+                return exchangeInfoResult;
+
+            exchangeInfo = exchangeInfoResult.Data;
+            lastExchangeInfoUpdate = DateTime.UtcNow;
+            log.Write(LogVerbosity.Info, "Trade rules updated");
+            return exchangeInfoResult;
+        }
+
+        /// <summary>
+        /// Gets the order book for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the order book for</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The order book for the symbol</returns>
+        public WebCallResult<BinanceOrderBook> GetOrderBook(string symbol, int? limit = null, CancellationToken ct = default) => GetOrderBookAsync(symbol, limit, ct).Result;
+
+        /// <summary>
+        /// Gets the order book for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the order book for</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The order book for the symbol</returns>
+        public async Task<WebCallResult<BinanceOrderBook>> GetOrderBookAsync(string symbol, int? limit = null, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            limit?.ValidateIntValues(nameof(limit), 5, 10, 20, 50, 100, 500, 1000, 5000);
+            var parameters = new Dictionary<string, object> { { "symbol", symbol } };
+            parameters.AddOptionalParameter("limit", limit?.ToString());
+            var result = await SendRequest<BinanceOrderBook>(GetUrl(OrderBookEndpoint, Api, PublicVersion), HttpMethod.Get, ct, parameters).ConfigureAwait(false);
+            if (result)
+                result.Data.Symbol = symbol;
+            return result;
+        }
+
+        /// <summary>
+        /// Gets the recent trades for a symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get recent trades for</param>
+        /// <param name="limit">Result limit</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of recent trades</returns>
+        public WebCallResult<IEnumerable<BinanceRecentTrade>> GetSymbolTrades(string symbol, int? limit = null, CancellationToken ct = default) => GetSymbolTradesAsync(symbol, limit, ct).Result;
+
+        /// <summary>
+        /// Gets the recent trades for a symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get recent trades for</param>
+        /// <param name="limit">Result limit</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of recent trades</returns>
+        public async Task<WebCallResult<IEnumerable<BinanceRecentTrade>>> GetSymbolTradesAsync(string symbol, int? limit = null, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            limit?.ValidateIntBetween(nameof(limit), 1, 1000);
+
+            var parameters = new Dictionary<string, object> { { "symbol", symbol } };
+            parameters.AddOptionalParameter("limit", limit?.ToString());
+            return await SendRequest<IEnumerable<BinanceRecentTrade>>(GetUrl(RecentTradesEndpoint, Api, PublicVersion), HttpMethod.Get, ct, parameters).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets the historical  trades for a symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get recent trades for</param>
+        /// <param name="limit">Result limit</param>
+        /// <param name="fromId">From which trade id on results should be retrieved</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of recent trades</returns>
+        public WebCallResult<IEnumerable<BinanceRecentTrade>> GetHistoricalSymbolTrades(string symbol, int? limit = null, long? fromId = null, CancellationToken ct = default) => GetHistoricalSymbolTradesAsync(symbol, limit, fromId, ct).Result;
+
+        /// <summary>
+        /// Gets the historical  trades for a symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get recent trades for</param>
+        /// <param name="limit">Result limit</param>
+        /// <param name="fromId">From which trade id on results should be retrieved</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of recent trades</returns>
+        public async Task<WebCallResult<IEnumerable<BinanceRecentTrade>>> GetHistoricalSymbolTradesAsync(string symbol, int? limit = null, long? fromId = null, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            limit?.ValidateIntBetween(nameof(limit), 1, 1000);
+            var parameters = new Dictionary<string, object> { { "symbol", symbol } };
+            parameters.AddOptionalParameter("limit", limit?.ToString());
+            parameters.AddOptionalParameter("fromId", fromId?.ToString());
+
+            return await SendRequest<IEnumerable<BinanceRecentTrade>>(GetUrl(HistoricalTradesEndpoint, Api, PublicVersion), HttpMethod.Get, ct, parameters).ConfigureAwait(false);
+        }
+
+
+        /// <summary>
+        /// Gets compressed, aggregate trades. Trades that fill at the time, from the same order, with the same price will have the quantity aggregated.
+        /// </summary>
+        /// <param name="symbol">The symbol to get the trades for</param>
+        /// <param name="fromId">ID to get aggregate trades from INCLUSIVE.</param>
+        /// <param name="startTime">Time to start getting trades from</param>
+        /// <param name="endTime">Time to stop getting trades from</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The aggregated trades list for the symbol</returns>
+        public WebCallResult<IEnumerable<BinanceAggregatedTrades>> GetAggregatedTrades(string symbol, long? fromId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default) => GetAggregatedTradesAsync(symbol, fromId, startTime, endTime, limit, ct).Result;
+
+        /// <summary>
+        /// Gets compressed, aggregate trades. Trades that fill at the time, from the same order, with the same price will have the quantity aggregated.
+        /// </summary>
+        /// <param name="symbol">The symbol to get the trades for</param>
+        /// <param name="fromId">ID to get aggregate trades from INCLUSIVE.</param>
+        /// <param name="startTime">Time to start getting trades from</param>
+        /// <param name="endTime">Time to stop getting trades from</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The aggregated trades list for the symbol</returns>
+        public async Task<WebCallResult<IEnumerable<BinanceAggregatedTrades>>> GetAggregatedTradesAsync(string symbol, long? fromId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            limit?.ValidateIntBetween(nameof(limit), 1, 1000);
+
+            var parameters = new Dictionary<string, object> { { "symbol", symbol } };
+            parameters.AddOptionalParameter("fromId", fromId?.ToString());
+            parameters.AddOptionalParameter("startTime", startTime != null ? ToUnixTimestamp(startTime.Value).ToString() : null);
+            parameters.AddOptionalParameter("endTime", endTime != null ? ToUnixTimestamp(endTime.Value).ToString() : null);
+            parameters.AddOptionalParameter("limit", limit?.ToString());
+
+            return await SendRequest<IEnumerable<BinanceAggregatedTrades>>(GetUrl(AggregatedTradesEndpoint, Api, PublicVersion), HttpMethod.Get, ct, parameters).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Get candlestick data for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the data for</param>
+        /// <param name="interval">The candlestick timespan</param>
+        /// <param name="startTime">Start time to get candlestick data</param>
+        /// <param name="endTime">End time to get candlestick data</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The candlestick data for the provided symbol</returns>
+        public WebCallResult<IEnumerable<BinanceKline>> GetKlines(string symbol, KlineInterval interval, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default) => GetKlinesAsync(symbol, interval, startTime, endTime, limit, ct).Result;
+
+        /// <summary>
+        /// Get candlestick data for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the data for</param>
+        /// <param name="interval">The candlestick timespan</param>
+        /// <param name="startTime">Start time to get candlestick data</param>
+        /// <param name="endTime">End time to get candlestick data</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The candlestick data for the provided symbol</returns>
+        public async Task<WebCallResult<IEnumerable<BinanceKline>>> GetKlinesAsync(string symbol, KlineInterval interval, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            limit?.ValidateIntBetween(nameof(limit), 1, 1000);
+            var parameters = new Dictionary<string, object> {
+                { "symbol", symbol },
+                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+            };
+            parameters.AddOptionalParameter("startTime", startTime != null ? ToUnixTimestamp(startTime.Value).ToString() : null);
+            parameters.AddOptionalParameter("endTime", endTime != null ? ToUnixTimestamp(endTime.Value).ToString() : null);
+            parameters.AddOptionalParameter("limit", limit?.ToString());
+
+            return await SendRequest<IEnumerable<BinanceKline>>(GetUrl(KlinesEndpoint, Api, PublicVersion), HttpMethod.Get, ct, parameters).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Get Mark Price and Funding Rate for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the data for</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Data over the last 24 hours</returns>
+        public WebCallResult<BinanceFuturesMarkPrice> GetMarkPrice(string symbol, CancellationToken ct = default) => GetMarkPriceAsync(symbol, ct).Result;
+
+        /// <summary>
+        /// Get Mark Price and Funding Rate for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the data for</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Data over the last 24 hours</returns>
+        public async Task<WebCallResult<BinanceFuturesMarkPrice>> GetMarkPriceAsync(string symbol, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            var parameters = new Dictionary<string, object> { { "symbol", symbol } };
+
+            return await SendRequest<BinanceFuturesMarkPrice>(GetUrl(MarkPriceEndpoint, Api, PublicVersion), HttpMethod.Get, ct, parameters).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Get Mark Price and Funding Rate for all symbols
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of data over the last 24 hours</returns>
+        public WebCallResult<IEnumerable<BinanceFuturesMarkPrice>> GetMarkPricesList(CancellationToken ct = default) => GetMarkPricesListAsync(ct).Result;
+
+        /// <summary>
+        /// Get Mark Price and Funding Rate for all symbols
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of data over the last 24 hours</returns>
+        public async Task<WebCallResult<IEnumerable<BinanceFuturesMarkPrice>>> GetMarkPricesListAsync(CancellationToken ct = default)
+        {
+            return await SendRequest<IEnumerable<BinanceFuturesMarkPrice>>(GetUrl(MarkPriceEndpoint, Api, PublicVersion), HttpMethod.Get, ct).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Get funding rate history for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the data for</param>
+        /// <param name="startTime">Start time to get funding rate history</param>
+        /// <param name="endTime">End time to get funding rate history</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The funding rate history for the provided symbol</returns>
+        public WebCallResult<IEnumerable<BinanceFuturesFundingRate>> GetFundingRates(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default) => GetFundingRatesAsync(symbol, startTime, endTime, limit, ct).Result;
+
+        /// <summary>
+        /// Get funding rate history for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the data for</param>
+        /// <param name="startTime">Start time to get funding rate history</param>
+        /// <param name="endTime">End time to get funding rate history</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The funding rate history for the provided symbol</returns>
+        public async Task<WebCallResult<IEnumerable<BinanceFuturesFundingRate>>> GetFundingRatesAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            limit?.ValidateIntBetween(nameof(limit), 1, 1000);
+            var parameters = new Dictionary<string, object> {
+                { "symbol", symbol }
+            };
+            parameters.AddOptionalParameter("startTime", startTime != null ? ToUnixTimestamp(startTime.Value).ToString() : null);
+            parameters.AddOptionalParameter("endTime", endTime != null ? ToUnixTimestamp(endTime.Value).ToString() : null);
+            parameters.AddOptionalParameter("limit", limit?.ToString());
+
+            return await SendRequest<IEnumerable<BinanceFuturesFundingRate>>(GetUrl(FundingRateHistoryEndpoint, Api, PublicVersion), HttpMethod.Get, ct, parameters).ConfigureAwait(false);
+        }
+        
+        /// <summary>
+        /// Get data regarding the last 24 hours for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the data for</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Data over the last 24 hours</returns>
+        public WebCallResult<Binance24HPrice> Get24HPrice(string symbol, CancellationToken ct = default) => Get24HPriceAsync(symbol, ct).Result;
+
+        /// <summary>
+        /// Get data regarding the last 24 hours for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the data for</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Data over the last 24 hours</returns>
+        public async Task<WebCallResult<Binance24HPrice>> Get24HPriceAsync(string symbol, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            var parameters = new Dictionary<string, object> { { "symbol", symbol } };
+
+            return await SendRequest<Binance24HPrice>(GetUrl(Price24HEndpoint, Api, PublicVersion), HttpMethod.Get, ct, parameters).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Get data regarding the last 24 hours for all symbols
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of data over the last 24 hours</returns>
+        public WebCallResult<IEnumerable<Binance24HPrice>> Get24HPricesList(CancellationToken ct = default) => Get24HPricesListAsync(ct).Result;
+
+        /// <summary>
+        /// Get data regarding the last 24 hours for all symbols
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of data over the last 24 hours</returns>
+        public async Task<WebCallResult<IEnumerable<Binance24HPrice>>> Get24HPricesListAsync(CancellationToken ct = default)
+        {
+            return await SendRequest<IEnumerable<Binance24HPrice>>(GetUrl(Price24HEndpoint, Api, PublicVersion), HttpMethod.Get, ct).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets the price of a symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the price for</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Price of symbol</returns>
+        public WebCallResult<BinancePrice> GetPrice(string symbol, CancellationToken ct = default) => GetPriceAsync(symbol, ct).Result;
+
+        /// <summary>
+        /// Gets the price of a symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the price for</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Price of symbol</returns>
+        public async Task<WebCallResult<BinancePrice>> GetPriceAsync(string symbol, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            var parameters = new Dictionary<string, object>
+            {
+                { "symbol", symbol }
+            };
+
+            return await SendRequest<BinancePrice>(GetUrl(AllPricesEndpoint, Api, PublicVersion), HttpMethod.Get, ct, parameters).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Get a list of the prices of all symbols
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of prices</returns>
+        public WebCallResult<IEnumerable<BinancePrice>> GetAllPrices(CancellationToken ct = default) => GetAllPricesAsync(ct).Result;
+
+        /// <summary>
+        /// Get a list of the prices of all symbols
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of prices</returns>
+        public async Task<WebCallResult<IEnumerable<BinancePrice>>> GetAllPricesAsync(CancellationToken ct = default)
+        {
+            return await SendRequest<IEnumerable<BinancePrice>>(GetUrl(AllPricesEndpoint, Api, PublicVersion), HttpMethod.Get, ct).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets the best price/quantity on the order book for a symbol.
+        /// </summary>
+        /// <param name="symbol">Symbol to get book price for</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of book prices</returns>
+        public WebCallResult<BinanceBookPrice> GetBookPrice(string symbol, CancellationToken ct = default) => GetBookPriceAsync(symbol, ct).Result;
+
+        /// <summary>
+        /// Gets the best price/quantity on the order book for a symbol.
+        /// </summary>
+        /// <param name="symbol">Symbol to get book price for</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of book prices</returns>
+        public async Task<WebCallResult<BinanceBookPrice>> GetBookPriceAsync(string symbol, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            var parameters = new Dictionary<string, object> { { "symbol", symbol } };
+
+            return await SendRequest<BinanceBookPrice>(GetUrl(BookPricesEndpoint, Api, PublicVersion), HttpMethod.Get, ct, parameters).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets the best price/quantity on the order book for all symbols.
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of book prices</returns>
+        public WebCallResult<IEnumerable<BinanceBookPrice>> GetAllBookPrices(CancellationToken ct = default) => GetAllBookPricesAsync(ct).Result;
+
+        /// <summary>
+        /// Gets the best price/quantity on the order book for all symbols.
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of book prices</returns>
+        public async Task<WebCallResult<IEnumerable<BinanceBookPrice>>> GetAllBookPricesAsync(CancellationToken ct = default)
+        {
+            return await SendRequest<IEnumerable<BinanceBookPrice>>(GetUrl(BookPricesEndpoint, Api, PublicVersion), HttpMethod.Get, ct).ConfigureAwait(false);
+        }
+        #endregion
+
+        #region signed
+        #region orders
+        /// <summary>
+        /// Places a new order
+        /// </summary>
+        /// <param name="symbol">The symbol the order is for</param>
+        /// <param name="side">The order side (buy/sell)</param>
+        /// <param name="type">The order type</param>
+        /// <param name="timeInForce">Lifetime of the order (GoodTillCancel/ImmediateOrCancel/FillOrKill)</param>
+        /// <param name="quantity">The amount of the base symbol</param>
+        /// <param name="reduceOnly">Specify as true if the order is intended to only reduce the position</param>
+        /// <param name="price">The price to use</param>
+        /// <param name="newClientOrderId">Unique id for order</param>
+        /// <param name="stopPrice">Used for stop orders</param>
+        /// <param name="orderResponseType">The type of response to receive</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Id's for the placed order</returns>
+        public WebCallResult<BinancePlacedOrder> PlaceOrder(
+            string symbol,
+            OrderSide side,
+            OrderType type,
+            decimal? quantity,
+            TimeInForce? timeInForce = null,
+            bool? reduceOnly = null,
+            decimal? price = null,
+            string? newClientOrderId = null,
+            decimal? stopPrice = null,
+            OrderResponseType? orderResponseType = null,
+            int? receiveWindow = null,
+            CancellationToken ct = default) => PlaceOrderAsync(symbol, side, type, quantity, timeInForce, reduceOnly, price, newClientOrderId, stopPrice, orderResponseType, receiveWindow, ct).Result;
+
+        /// <summary>
+        /// Places a new order
+        /// </summary>
+        /// <param name="symbol">The symbol the order is for</param>
+        /// <param name="side">The order side (buy/sell)</param>
+        /// <param name="type">The order type</param>
+        /// <param name="timeInForce">Lifetime of the order (GoodTillCancel/ImmediateOrCancel/FillOrKill)</param>
+        /// <param name="quantity">The amount of the base symbol</param>
+        /// <param name="reduceOnly">Specify as true if the order is intended to only reduce the position</param>
+        /// <param name="price">The price to use</param>
+        /// <param name="newClientOrderId">Unique id for order</param>
+        /// <param name="stopPrice">Used for stop orders</param>
+        /// <param name="orderResponseType">The type of response to receive</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Id's for the placed order</returns>
+        public async Task<WebCallResult<BinancePlacedOrder>> PlaceOrderAsync(
+            string symbol,
+            OrderSide side,
+            OrderType type,
+            decimal? quantity,
+            TimeInForce? timeInForce = null,
+            bool? reduceOnly = null,
+            decimal? price = null,
+            string? newClientOrderId = null,
+            decimal? stopPrice = null,
+            OrderResponseType? orderResponseType = null,
+            int? receiveWindow = null,
+            CancellationToken ct = default)
+        {
+            return await PlaceOrderInternal(GetUrl(NewOrderEndpoint, Api, SignedVersion),
+                symbol,
+                side,
+                type,
+                quantity,
+                timeInForce,
+                reduceOnly,
+                price,
+                newClientOrderId,
+                stopPrice,
+                orderResponseType,
+                receiveWindow,
+                ct).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retrieves data for a specific order. Either orderId or origClientOrderId should be provided.
+        /// </summary>
+        /// <param name="symbol">The symbol the order is for</param>
+        /// <param name="orderId">The order id of the order</param>
+        /// <param name="origClientOrderId">The client order id of the order</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The specific order</returns>
+        public WebCallResult<BinanceOrder> GetOrder(string symbol, long? orderId = null, string? origClientOrderId = null, long? receiveWindow = null, CancellationToken ct = default) => GetOrderAsync(symbol, orderId, origClientOrderId, receiveWindow, ct).Result;
+
+        /// <summary>
+        /// Retrieves data for a specific order. Either orderId or origClientOrderId should be provided.
+        /// </summary>
+        /// <param name="symbol">The symbol the order is for</param>
+        /// <param name="orderId">The order id of the order</param>
+        /// <param name="origClientOrderId">The client order id of the order</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The specific order</returns>
+        public async Task<WebCallResult<BinanceOrder>> GetOrderAsync(string symbol, long? orderId = null, string? origClientOrderId = null, long? receiveWindow = null, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            if (orderId == null && origClientOrderId == null)
+                throw new ArgumentException("Either orderId or origClientOrderId must be sent");
+
+            var timestampResult = await CheckAutoTimestamp(ct).ConfigureAwait(false);
+            if (!timestampResult)
+                return new WebCallResult<BinanceOrder>(timestampResult.ResponseStatusCode, timestampResult.ResponseHeaders, null, timestampResult.Error);
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "symbol", symbol },
+                { "timestamp", GetTimestamp() }
+            };
+            parameters.AddOptionalParameter("orderId", orderId?.ToString());
+            parameters.AddOptionalParameter("origClientOrderId", origClientOrderId);
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? defaultReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+
+            return await SendRequest<BinanceOrder>(GetUrl(QueryOrderEndpoint, Api, SignedVersion), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Cancels a pending order
+        /// </summary>
+        /// <param name="symbol">The symbol the order is for</param>
+        /// <param name="orderId">The order id of the order</param>
+        /// <param name="origClientOrderId">The client order id of the order</param>
+        /// <param name="newClientOrderId">The new client order id of the order</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Id's for canceled order</returns>
+        public WebCallResult<BinanceCanceledOrder> CancelOrder(string symbol, long? orderId = null, string? origClientOrderId = null, string? newClientOrderId = null, long? receiveWindow = null, CancellationToken ct = default) => CancelOrderAsync(symbol, orderId, origClientOrderId, newClientOrderId, receiveWindow, ct).Result;
+
+        /// <summary>
+        /// Cancels a pending order
+        /// </summary>
+        /// <param name="symbol">The symbol the order is for</param>
+        /// <param name="orderId">The order id of the order</param>
+        /// <param name="origClientOrderId">The client order id of the order</param>
+        /// <param name="newClientOrderId">Unique identifier for this cancel</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Id's for canceled order</returns>
+        public async Task<WebCallResult<BinanceCanceledOrder>> CancelOrderAsync(string symbol, long? orderId = null, string? origClientOrderId = null, string? newClientOrderId = null, long? receiveWindow = null, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            var timestampResult = await CheckAutoTimestamp(ct).ConfigureAwait(false);
+            if (!timestampResult)
+                return new WebCallResult<BinanceCanceledOrder>(timestampResult.ResponseStatusCode, timestampResult.ResponseHeaders, null, timestampResult.Error);
+
+            if (!orderId.HasValue && string.IsNullOrEmpty(origClientOrderId))
+                throw new ArgumentException("Either orderId or origClientOrderId must be sent");
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "symbol", symbol },
+                { "timestamp", GetTimestamp() }
+            };
+            parameters.AddOptionalParameter("orderId", orderId?.ToString());
+            parameters.AddOptionalParameter("origClientOrderId", origClientOrderId);
+            parameters.AddOptionalParameter("newClientOrderId", newClientOrderId);
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? defaultReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+
+            return await SendRequest<BinanceCanceledOrder>(GetUrl(CancelOrderEndpoint, Api, SignedVersion), HttpMethod.Delete, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets a list of open orders
+        /// </summary>
+        /// <param name="symbol">The symbol to get open orders for</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of open orders</returns>
+        public WebCallResult<IEnumerable<BinanceOrder>> GetOpenOrders(string? symbol = null, int? receiveWindow = null, CancellationToken ct = default) => GetOpenOrdersAsync(symbol, receiveWindow, ct).Result;
+
+        /// <summary>
+        /// Gets a list of open orders
+        /// </summary>
+        /// <param name="symbol">The symbol to get open orders for</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of open orders</returns>
+        public async Task<WebCallResult<IEnumerable<BinanceOrder>>> GetOpenOrdersAsync(string? symbol = null, int? receiveWindow = null, CancellationToken ct = default)
+        {
+            symbol?.ValidateBinanceSymbol();
+            var timestampResult = await CheckAutoTimestamp(ct).ConfigureAwait(false);
+            if (!timestampResult)
+                return new WebCallResult<IEnumerable<BinanceOrder>>(timestampResult.ResponseStatusCode, timestampResult.ResponseHeaders, null, timestampResult.Error);
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "timestamp", GetTimestamp() }
+            };
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? defaultReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptionalParameter("symbol", symbol);
+
+            return await SendRequest<IEnumerable<BinanceOrder>>(GetUrl(OpenOrdersEndpoint, Api, SignedVersion), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets all orders for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get orders for</param>
+        /// <param name="orderId">If set, only orders with an order id higher than the provided will be returned</param>
+        /// <param name="startTime">If set, only orders placed after this time will be returned</param>
+        /// <param name="endTime">If set, only orders placed before this time will be returned</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of orders</returns>
+        public WebCallResult<IEnumerable<BinanceOrder>> GetAllOrders(string symbol, long? orderId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? receiveWindow = null, CancellationToken ct = default) => GetAllOrdersAsync(symbol, orderId, startTime, endTime, limit, receiveWindow, ct).Result;
+
+        /// <summary>
+        /// Gets all orders for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get orders for</param>
+        /// <param name="orderId">If set, only orders with an order id higher than the provided will be returned</param>
+        /// <param name="startTime">If set, only orders placed after this time will be returned</param>
+        /// <param name="endTime">If set, only orders placed before this time will be returned</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of orders</returns>
+        public async Task<WebCallResult<IEnumerable<BinanceOrder>>> GetAllOrdersAsync(string symbol, long? orderId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? receiveWindow = null, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            limit?.ValidateIntBetween(nameof(limit), 1, 1000);
+            var timestampResult = await CheckAutoTimestamp(ct).ConfigureAwait(false);
+            if (!timestampResult)
+                return new WebCallResult<IEnumerable<BinanceOrder>>(timestampResult.ResponseStatusCode, timestampResult.ResponseHeaders, null, timestampResult.Error);
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "symbol", symbol },
+                { "timestamp", GetTimestamp() }
+            };
+            parameters.AddOptionalParameter("orderId", orderId?.ToString());
+            parameters.AddOptionalParameter("startTime", startTime.HasValue ? JsonConvert.SerializeObject(startTime.Value, new TimestampConverter()) : null);
+            parameters.AddOptionalParameter("endTime", endTime.HasValue ? JsonConvert.SerializeObject(endTime.Value, new TimestampConverter()) : null);
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? defaultReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptionalParameter("limit", limit?.ToString());
+
+            return await SendRequest<IEnumerable<BinanceOrder>>(GetUrl(AllOrdersEndpoint, Api, SignedVersion), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets account balances
+        /// </summary>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The account information</returns>
+        public WebCallResult<IEnumerable<BinanceFuturesAccountBalance>> GetFuturesAccountBalance(long? receiveWindow = null, CancellationToken ct = default) => GetFuturesAccountBalanceAsync(receiveWindow, ct).Result;
+
+        /// <summary>.
+        /// Gets account balances
+        /// </summary>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The account information</returns>
+        public async Task<WebCallResult<IEnumerable<BinanceFuturesAccountBalance>>> GetFuturesAccountBalanceAsync(long? receiveWindow = null, CancellationToken ct = default)
+        {
+            var timestampResult = await CheckAutoTimestamp(ct).ConfigureAwait(false);
+            if (!timestampResult)
+                return new WebCallResult<IEnumerable<BinanceFuturesAccountBalance>>(timestampResult.ResponseStatusCode, timestampResult.ResponseHeaders, null, timestampResult.Error);
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "timestamp", GetTimestamp() }
+            };
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? defaultReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+
+            return await SendRequest<IEnumerable<BinanceFuturesAccountBalance>>(GetUrl(FuturesAccountBalanceEndpoint, Api, SignedVersion), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets account information, including balances
+        /// </summary>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The account information</returns>
+        public WebCallResult<BinanceAccountInfo> GetAccountInfo(long? receiveWindow = null, CancellationToken ct = default) => GetAccountInfoAsync(receiveWindow, ct).Result;
+
+        /// <summary>
+        /// Gets account information, including balances
+        /// </summary>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The account information</returns>
+        public async Task<WebCallResult<BinanceAccountInfo>> GetAccountInfoAsync(long? receiveWindow = null, CancellationToken ct = default)
+        {
+            var timestampResult = await CheckAutoTimestamp(ct).ConfigureAwait(false);
+            if (!timestampResult)
+                return new WebCallResult<BinanceAccountInfo>(timestampResult.ResponseStatusCode, timestampResult.ResponseHeaders, null, timestampResult.Error);
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "timestamp", GetTimestamp() }
+            };
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? defaultReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+
+            return await SendRequest<BinanceAccountInfo>(GetUrl(AccountInfoEndpoint, Api, SignedVersion), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Requests to change the initial leverag of the given symbol
+        /// </summary>
+        /// <param name="symbol">Symbol to change the initial leverage for</param>
+        /// <param name="leverage">The amount of initial leverage to change to</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Result of the initial leverage change request</returns>
+        public WebCallResult<BinanceFuturesInitialLeverageChangeResult> ChangeInitialLeverage(string symbol, int leverage, long? receiveWindow = null, CancellationToken ct = default) => ChangeInitialLeverageAsync(symbol, leverage, receiveWindow, ct).Result;
+
+        /// <summary>
+        /// Requests to change the initial leverag of the given symbol
+        /// </summary>
+        /// <param name="symbol">Symbol to change the initial leverage for</param>
+        /// <param name="leverage">The amount of initial leverage to change to</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Result of the initial leverage change request</returns>
+        public async Task<WebCallResult<BinanceFuturesInitialLeverageChangeResult>> ChangeInitialLeverageAsync(string symbol, int leverage, long? receiveWindow = null, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            leverage.ValidateIntBetween(nameof(leverage), 1, 125);
+            var timestampResult = await CheckAutoTimestamp(ct).ConfigureAwait(false);
+            if (!timestampResult)
+                return new WebCallResult<BinanceFuturesInitialLeverageChangeResult>(timestampResult.ResponseStatusCode, timestampResult.ResponseHeaders, null, timestampResult.Error);
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "symbol", symbol },
+                { "leverage", leverage },
+                { "timestamp", GetTimestamp() }
+            };
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? defaultReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+
+            return await SendRequest<BinanceFuturesInitialLeverageChangeResult>(GetUrl(ChangeInitialLeverageEndpoint, Api, SignedVersion), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Change the margin type for an open position
+        /// </summary>
+        /// <param name="symbol">Symbol to change the position type for</param>
+        /// <param name="marginType">The type of margin to use</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Whether the request was successful</returns>
+        public WebCallResult<BinanceFuturesChangeMarginTypeResult> ChangeMarginType(string symbol, FuturesMarginType marginType, long? receiveWindow = null, CancellationToken ct = default) => ChangeMarginTypeAsync(symbol, marginType, receiveWindow, ct).Result;
+
+        /// <summary>
+        /// Change the margin type for an open position
+        /// </summary>
+        /// <param name="symbol">Symbol to change the position type for</param>
+        /// <param name="marginType">The type of margin to use</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Whether the request was successful</returns>
+        public async Task<WebCallResult<BinanceFuturesChangeMarginTypeResult>> ChangeMarginTypeAsync(string symbol, FuturesMarginType marginType, long? receiveWindow = null, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            var timestampResult = await CheckAutoTimestamp(ct).ConfigureAwait(false);
+            if (!timestampResult)
+                return new WebCallResult<BinanceFuturesChangeMarginTypeResult>(timestampResult.ResponseStatusCode, timestampResult.ResponseHeaders, null, timestampResult.Error);
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "symbol", symbol },
+                { "marginType", JsonConvert.SerializeObject(marginType, new FuturesMarginTypeConverter(false)) },
+                { "timestamp", GetTimestamp() }
+            };
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? defaultReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+
+            return await SendRequest<BinanceFuturesChangeMarginTypeResult>(GetUrl(ChangeMarginTypeEndpoint, Api, SignedVersion), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Change the margin on an open position
+        /// </summary>
+        /// <param name="symbol">Symbol to adjust the position margin for</param>
+        /// <param name="amount">The amount of margin to be used</param>
+        /// <param name="type">Whether to reduce or add margin to the position</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The new position margin</returns>
+        public WebCallResult<BinanceFuturesPositionMarginResult> ModifyPositionMargin(string symbol, decimal amount, FuturesMarginChangeDirectionType type, long? receiveWindow = null, CancellationToken ct = default) => ModifyPositionMarginAsync(symbol, amount, type, receiveWindow, ct).Result;
+
+        /// <summary>
+        /// Change the margin on an open position
+        /// </summary>
+        /// <param name="symbol">Symbol to adjust the position margin for</param>
+        /// <param name="amount">The amount of margin to be used</param>
+        /// <param name="type">Whether to reduce or add margin to the position</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The new position margin</returns>
+        public async Task<WebCallResult<BinanceFuturesPositionMarginResult>> ModifyPositionMarginAsync(string symbol, decimal amount, FuturesMarginChangeDirectionType type, long? receiveWindow = null, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            var timestampResult = await CheckAutoTimestamp(ct).ConfigureAwait(false);
+            if (!timestampResult)
+                return new WebCallResult<BinanceFuturesPositionMarginResult>(timestampResult.ResponseStatusCode, timestampResult.ResponseHeaders, null, timestampResult.Error);
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "symbol", symbol },
+                { "amount", amount },
+                { "type", JsonConvert.SerializeObject(type, new FuturesMarginChangeDirectionTypeConverter(false)) },
+                { "timestamp", GetTimestamp() }
+            };
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? defaultReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+
+            return await SendRequest<BinanceFuturesPositionMarginResult>(GetUrl(PositionMarginEndpoint, Api, SignedVersion), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Requests the margin change history for a specific symbol
+        /// </summary>
+        /// <param name="symbol">Symbol to get margin history for</param>
+        /// <param name="type">Filter the history by the direction of margin change</param>
+        /// <param name="startTime">Margin changes newer than this date will be retrieved</param>
+        /// <param name="endTime">Margin changes older than this date will be retrieved</param>
+        /// <param name="limit">The max number of results</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of all margin changes for the symbol</returns>
+        public WebCallResult<IEnumerable<BinanceFuturesMarginChangeHistoryResult>> GetMarginChangeHistory(string symbol, FuturesMarginChangeDirectionType? type = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, long? receiveWindow = null, CancellationToken ct = default) => GetMarginChangeHistoryAsync(symbol, type, startTime, endTime, limit, receiveWindow, ct).Result;
+
+        /// <summary>
+        /// Requests the margin change history for a specific symbol
+        /// </summary>
+        /// <param name="symbol">Symbol to get margin history for</param>
+        /// <param name="type">Filter the history by the direction of margin change</param>
+        /// <param name="startTime">Margin changes newer than this date will be retrieved</param>
+        /// <param name="endTime">Margin changes older than this date will be retrieved</param>
+        /// <param name="limit">The max number of results</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of all margin changes for the symbol</returns>
+        public async Task<WebCallResult<IEnumerable<BinanceFuturesMarginChangeHistoryResult>>> GetMarginChangeHistoryAsync(string symbol, FuturesMarginChangeDirectionType? type = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, long? receiveWindow = null, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            var timestampResult = await CheckAutoTimestamp(ct).ConfigureAwait(false);
+            if (!timestampResult)
+                return new WebCallResult<IEnumerable<BinanceFuturesMarginChangeHistoryResult>>(timestampResult.ResponseStatusCode, timestampResult.ResponseHeaders, null, timestampResult.Error);
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "symbol", symbol },
+                { "timestamp", GetTimestamp() }
+            };
+            parameters.AddOptionalParameter("type", type.HasValue ? JsonConvert.SerializeObject(type, new FuturesMarginChangeDirectionTypeConverter(false)) : null);
+            parameters.AddOptionalParameter("startTime", startTime.HasValue ? JsonConvert.SerializeObject(startTime.Value, new TimestampConverter()) : null);
+            parameters.AddOptionalParameter("endTime", endTime.HasValue ? JsonConvert.SerializeObject(endTime.Value, new TimestampConverter()) : null);
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? defaultReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptionalParameter("limit", limit?.ToString());
+
+            return await SendRequest<IEnumerable<BinanceFuturesMarginChangeHistoryResult>>(GetUrl(PositionMarginChangeHistoryEndpoint, Api, SignedVersion), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets all user trades for provided symbol
+        /// </summary>
+        /// <param name="symbol">Symbol to get trades for</param>
+        /// <param name="limit">The max number of results</param>
+        /// <param name="startTime">Orders newer than this date will be retrieved</param>
+        /// <param name="endTime">Orders older than this date will be retrieved</param>
+        /// <param name="fromId">TradeId to fetch from. Default gets most recent trades</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of trades</returns>
+        public WebCallResult<IEnumerable<BinanceTrade>> GetMyTrades(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, long? fromId = null, long? receiveWindow = null, CancellationToken ct = default) => GetMyTradesAsync(symbol, startTime, endTime, limit, fromId, receiveWindow, ct).Result;
+
+        /// <summary>
+        /// Gets all user trades for provided symbol
+        /// </summary>
+        /// <param name="symbol">Symbol to get trades for</param>
+        /// <param name="limit">The max number of results</param>
+        /// <param name="fromId">TradeId to fetch from. Default gets most recent trades</param>
+        /// <param name="startTime">Orders newer than this date will be retrieved</param>
+        /// <param name="endTime">Orders older than this date will be retrieved</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of trades</returns>
+        public async Task<WebCallResult<IEnumerable<BinanceTrade>>> GetMyTradesAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, long? fromId = null, long? receiveWindow = null, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            limit?.ValidateIntBetween(nameof(limit), 1, 1000);
+
+            var timestampResult = await CheckAutoTimestamp(ct).ConfigureAwait(false);
+            if (!timestampResult)
+                return new WebCallResult<IEnumerable<BinanceTrade>>(timestampResult.ResponseStatusCode, timestampResult.ResponseHeaders, null, timestampResult.Error);
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "symbol", symbol },
+                { "timestamp", GetTimestamp() }
+            };
+            parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptionalParameter("fromId", fromId?.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptionalParameter("startTime", startTime.HasValue ? JsonConvert.SerializeObject(startTime.Value, new TimestampConverter()) : null);
+            parameters.AddOptionalParameter("endTime", endTime.HasValue ? JsonConvert.SerializeObject(endTime.Value, new TimestampConverter()) : null);
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? defaultReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+
+            return await SendRequest<IEnumerable<BinanceTrade>>(GetUrl(MyFuturesTradesEndpoint, Api, SignedVersion), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets the income history for the futures account
+        /// </summary>
+        /// <param name="symbol">The symbol to get income history from</param>
+        /// <param name="incomeType">The income type filter to apply to the request</param>
+        /// <param name="startTime">Time to start getting income history from</param>
+        /// <param name="endTime">Time to stop getting income history from</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The income history for the futures account</returns>
+        public WebCallResult<IEnumerable<BinanceFuturesIncomeHistory>> GetIncomeHistory(string? symbol = null, IncomeType? incomeType = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, long? receiveWindow = null, CancellationToken ct = default) => GetIncomeHistoryAsync(symbol, incomeType, startTime, endTime, limit, receiveWindow, ct).Result;
+
+        /// <summary>
+        /// Gets the income history for the futures account
+        /// </summary>
+        /// <param name="symbol">The symbol to get income history from</param>
+        /// <param name="incomeType">The income type filter to apply to the request</param>
+        /// <param name="startTime">Time to start getting income history from</param>
+        /// <param name="endTime">Time to stop getting income history from</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The income history for the futures account</returns>
+        public async Task<WebCallResult<IEnumerable<BinanceFuturesIncomeHistory>>> GetIncomeHistoryAsync(string? symbol = null, IncomeType? incomeType = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, long? receiveWindow = null, CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+            limit?.ValidateIntBetween(nameof(limit), 1, 1000);
+            var timestampResult = await CheckAutoTimestamp(ct).ConfigureAwait(false);
+            if (!timestampResult)
+                return new WebCallResult<IEnumerable<BinanceFuturesIncomeHistory>>(timestampResult.ResponseStatusCode, timestampResult.ResponseHeaders, null, timestampResult.Error);
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "timestamp", GetTimestamp() }
+            };
+            parameters.AddOptionalParameter("symbol", symbol?.ToString());
+            parameters.AddOptionalParameter("incomeType", incomeType.HasValue ? JsonConvert.SerializeObject(incomeType, new IncomeTypeConverter(false)) : null);
+            parameters.AddOptionalParameter("startTime", startTime.HasValue ? JsonConvert.SerializeObject(startTime.Value, new TimestampConverter()) : null);
+            parameters.AddOptionalParameter("endTime", endTime.HasValue ? JsonConvert.SerializeObject(endTime.Value, new TimestampConverter()) : null);
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? defaultReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptionalParameter("limit", limit?.ToString());
+
+            return await SendRequest<IEnumerable<BinanceFuturesIncomeHistory>>(GetUrl(IncomeHistoryEndpoint, Api, SignedVersion), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets all user positions
+        /// </summary>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of Positions</returns>
+        public WebCallResult<IEnumerable<BinanceFuturesPosition>> GetOpenPositions(long? receiveWindow = null, CancellationToken ct = default) => GetOpenPositionsAsync(receiveWindow).Result;
+
+        /// <summary>
+        /// Gets all user positions
+        /// </summary>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of Positions</returns>
+        public async Task<WebCallResult<IEnumerable<BinanceFuturesPosition>>> GetOpenPositionsAsync(long? receiveWindow = null, CancellationToken ct = default)
+        {
+            var timestampResult = await CheckAutoTimestamp(ct).ConfigureAwait(false);
+            if (!timestampResult)
+                return new WebCallResult<IEnumerable<BinanceFuturesPosition>>(timestampResult.ResponseStatusCode, timestampResult.ResponseHeaders, null, timestampResult.Error);
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "timestamp", GetTimestamp() }
+            };
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? defaultReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+
+            return await SendRequest<IEnumerable<BinanceFuturesPosition>>(GetUrl(PositionInformationEndpoint, Api, SignedVersion), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        #endregion
+
+        #region stream
+        /// <summary>
+        /// Starts a user stream by requesting a listen key. This listen key can be used in subsequent requests to <see cref="BinanceSocketClient.SubscribeToUserDataUpdates"/>. The stream will close after 60 minutes unless a keep alive is send.
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Listen key</returns>
+        public WebCallResult<string> StartUserStream(CancellationToken ct = default) => StartUserStreamAsync(ct).Result;
+
+        /// <summary>
+        /// Starts a user stream by requesting a listen key. This listen key can be used in subsequent requests to <see cref="BinanceSocketClient.SubscribeToUserDataUpdates"/>. The stream will close after 60 minutes unless a keep alive is send.
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Listen key</returns>
+        public async Task<WebCallResult<string>> StartUserStreamAsync(CancellationToken ct = default)
+        {
+            var timestampResult = await CheckAutoTimestamp(ct).ConfigureAwait(false);
+            if (!timestampResult)
+                return new WebCallResult<string>(timestampResult.ResponseStatusCode, timestampResult.ResponseHeaders, null, timestampResult.Error);
+
+            var result = await SendRequest<BinanceListenKey>(GetUrl(GetFuturesListenKeyEndpoint, Api, UserDataStreamVersion), HttpMethod.Post, ct).ConfigureAwait(false);
+            return new WebCallResult<string>(result.ResponseStatusCode, result.ResponseHeaders, result.Data?.ListenKey, result.Error);
+        }
+
+        /// <summary>
+        /// Sends a keep alive for the current user stream listen key to keep the stream from closing. Stream auto closes after 60 minutes if no keep alive is send. 30 minute interval for keep alive is recommended.
+        /// </summary>
+        /// <param name="listenKey">The listen key to keep alive</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        public WebCallResult<object> KeepAliveUserStream(string listenKey, CancellationToken ct = default) => KeepAliveUserStreamAsync(listenKey, ct).Result;
+
+        /// <summary>
+        /// Sends a keep alive for the current user stream listen key to keep the stream from closing. Stream auto closes after 60 minutes if no keep alive is send. 30 minute interval for keep alive is recommended.
+        /// </summary>
+        /// <param name="listenKey">The listen key to keep alive</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        public async Task<WebCallResult<object>> KeepAliveUserStreamAsync(string listenKey, CancellationToken ct = default)
+        {
+            listenKey.ValidateNotNull(nameof(listenKey));
+            var timestampResult = await CheckAutoTimestamp(ct).ConfigureAwait(false);
+            if (!timestampResult)
+                return new WebCallResult<object>(timestampResult.ResponseStatusCode, timestampResult.ResponseHeaders, null, timestampResult.Error);
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "listenKey", listenKey }
+            };
+
+            return await SendRequest<object>(GetUrl(KeepFuturesListenKeyAliveEndpoint, Api, UserDataStreamVersion), HttpMethod.Put, ct, parameters).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Stops the current user stream
+        /// </summary>
+        /// <param name="listenKey">The listen key to keep alive</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        public WebCallResult<object> StopUserStream(string listenKey, CancellationToken ct = default) => StopUserStreamAsync(listenKey, ct).Result;
+
+        /// <summary>
+        /// Stops the current user stream
+        /// </summary>
+        /// <param name="listenKey">The listen key to keep alive</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        public async Task<WebCallResult<object>> StopUserStreamAsync(string listenKey, CancellationToken ct = default)
+        {
+            listenKey.ValidateNotNull(nameof(listenKey));
+            var timestampResult = await CheckAutoTimestamp(ct).ConfigureAwait(false);
+            if (!timestampResult)
+                return new WebCallResult<object>(timestampResult.ResponseStatusCode, timestampResult.ResponseHeaders, null, timestampResult.Error);
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "listenKey", listenKey }
+            };
+
+            return await SendRequest<object>(GetUrl(CloseFuturesListenKeyEndpoint, Api, UserDataStreamVersion), HttpMethod.Delete, ct, parameters).ConfigureAwait(false);
+        }
+
+        #endregion
+
+        #endregion
+
+        #endregion
+
+        #region helpers
+
+        private async Task<WebCallResult<BinancePlacedOrder>> PlaceOrderInternal(Uri uri, 
+            string symbol,
+            OrderSide side,
+            OrderType type,
+            decimal? quantity,
+            TimeInForce? timeInForce = null,
+            bool? reduceOnly = null,
+            decimal? price = null,
+            string? newClientOrderId = null,
+            decimal? stopPrice = null,
+            OrderResponseType? orderResponseType = null,
+            int? receiveWindow = null,
+            CancellationToken ct = default)
+        {
+            symbol.ValidateBinanceSymbol();
+
+            var timestampResult = await CheckAutoTimestamp(ct).ConfigureAwait(false);
+            if (!timestampResult)
+                return new WebCallResult<BinancePlacedOrder>(timestampResult.ResponseStatusCode, timestampResult.ResponseHeaders, null, timestampResult.Error);
+
+            var rulesCheck = await CheckTradeRules(symbol, quantity, price, type, ct).ConfigureAwait(false);
+            if (!rulesCheck.Passed)
+            {
+                log.Write(LogVerbosity.Warning, rulesCheck.ErrorMessage!);
+                return new WebCallResult<BinancePlacedOrder>(null, null, null, new ArgumentError(rulesCheck.ErrorMessage!));
+            }
+
+            quantity = rulesCheck.Quantity;
+            price = rulesCheck.Price;
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "symbol", symbol },
+                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
+                { "type", JsonConvert.SerializeObject(type, new OrderTypeConverter(false)) },
+                { "timestamp", GetTimestamp() }
+            };
+            parameters.AddOptionalParameter("quantity", quantity?.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptionalParameter("newClientOrderId", newClientOrderId);
+            parameters.AddOptionalParameter("price", price?.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, new TimeInForceConverter(false)));
+            parameters.AddOptionalParameter("stopPrice", stopPrice?.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, new OrderResponseTypeConverter(false)));
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? defaultReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+
+            return await SendRequest<BinancePlacedOrder>(uri, HttpMethod.Post, ct, parameters, true).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        protected override Error ParseErrorResponse(JToken error)
+        {
+            if (!error.HasValues)
+                return new ServerError(error.ToString());
+
+            if (error["msg"] == null && error["code"] == null)
+                return new ServerError(error.ToString());
+
+            if (error["msg"] != null && error["code"] == null)
+                return new ServerError((string)error["msg"]);
+
+            var err = new ServerError((int)error["code"], (string)error["msg"]);
+            if (err.Code == -1021)
+            {
+                GetServerTime(true);
+            }
+            return err;
+        }
+
+        private Uri GetUrl(string endpoint, string api, string version)
+        {
+            var result = $"{BaseAddress}/{api}/v{version}/{endpoint}";
+            return new Uri(result);
+        }
+
+        private static long ToUnixTimestamp(DateTime time)
+        {
+            return (long)(time - new DateTime(1970, 1, 1)).TotalMilliseconds;
+        }
+
+        private string GetTimestamp()
+        {
+            var offset = autoTimestamp ? calculatedTimeOffset : 0;
+            offset += timestampOffset.TotalMilliseconds;
+            return ToUnixTimestamp(DateTime.UtcNow.AddMilliseconds(offset)).ToString();
+        }
+
+        private async Task<WebCallResult<DateTime>> CheckAutoTimestamp(CancellationToken ct)
+        {
+            if (autoTimestamp && (!timeSynced || DateTime.UtcNow - lastTimeSync > autoTimestampRecalculationInterval))
+                return await GetServerTimeAsync(timeSynced, ct).ConfigureAwait(false);
+
+            return new WebCallResult<DateTime>(null, null, default, null);
+        }
+
+        private async Task<BinanceTradeRuleResult> CheckTradeRules(string symbol, decimal? quantity, decimal? price, OrderType type, CancellationToken ct)
+        {
+            var outputQuantity = quantity;
+            var outputPrice = price;
+
+            if (tradeRulesBehaviour == TradeRulesBehaviour.None)
+                return BinanceTradeRuleResult.CreatePassed(outputQuantity, outputPrice);
+
+            if (exchangeInfo == null || lastExchangeInfoUpdate == null || (DateTime.UtcNow - lastExchangeInfoUpdate.Value).TotalMinutes > tradeRulesUpdateInterval.TotalMinutes)
+                await GetExchangeInfoAsync(ct).ConfigureAwait(false);
+
+            if (exchangeInfo == null)
+                return BinanceTradeRuleResult.CreateFailed("Unable to retrieve trading rules, validation failed");
+
+            var symbolData = exchangeInfo.Symbols.SingleOrDefault(s => string.Equals(s.Name, symbol, StringComparison.CurrentCultureIgnoreCase));
+            if (symbolData == null)
+                return BinanceTradeRuleResult.CreateFailed($"Trade rules check failed: Symbol {symbol} not found");
+
+            if (!symbolData.OrderTypes.Contains(type))
+                return BinanceTradeRuleResult.CreateFailed($"Trade rules check failed: {type} order type not allowed for {symbol}");
+
+            if (symbolData.LotSizeFilter != null || (symbolData.MarketLotSizeFilter != null && type == OrderType.Market))
+            {
+                var minQty = symbolData.LotSizeFilter?.MinQuantity;
+                var maxQty = symbolData.LotSizeFilter?.MaxQuantity;
+                var stepSize = symbolData.LotSizeFilter?.StepSize;
+                if (type == OrderType.Market && symbolData.MarketLotSizeFilter != null)
+                {
+                    minQty = symbolData.MarketLotSizeFilter.MinQuantity;
+                    if (symbolData.MarketLotSizeFilter.MaxQuantity != 0)
+                        maxQty = symbolData.MarketLotSizeFilter.MaxQuantity;
+
+                    if (symbolData.MarketLotSizeFilter.StepSize != 0)
+                        stepSize = symbolData.MarketLotSizeFilter.StepSize;
+                }
+
+                if (minQty.HasValue && quantity.HasValue)
+                {
+                    outputQuantity = BinanceHelpers.ClampQuantity(minQty.Value, maxQty!.Value, stepSize!.Value, quantity.Value);
+                    if (outputQuantity != quantity.Value)
+                    {
+                        if (tradeRulesBehaviour == TradeRulesBehaviour.ThrowError)
+                        {
+                            return BinanceTradeRuleResult.CreateFailed($"Trade rules check failed: LotSize filter failed. Original quantity: {quantity}, Closest allowed: {outputQuantity}");
+                        }
+
+                        log.Write(LogVerbosity.Info, $"Quantity clamped from {quantity} to {outputQuantity}");
+                    }
+                }
+            }
+
+            if (price == null)
+                return BinanceTradeRuleResult.CreatePassed(outputQuantity, null);
+
+            if (symbolData.PriceFilter != null)
+            {
+                if (symbolData.PriceFilter.MaxPrice != 0 && symbolData.PriceFilter.MinPrice != 0)
+                {
+                    outputPrice = BinanceHelpers.ClampPrice(symbolData.PriceFilter.MinPrice, symbolData.PriceFilter.MaxPrice, price.Value);
+                    if (outputPrice != price)
+                    {
+                        if (tradeRulesBehaviour == TradeRulesBehaviour.ThrowError)
+                            return BinanceTradeRuleResult.CreateFailed($"Trade rules check failed: Price filter max/min failed. Original price: {price}, Closest allowed: {outputPrice}");
+
+                        log.Write(LogVerbosity.Info, $"price clamped from {price} to {outputPrice}");
+                    }
+                }
+
+                if (symbolData.PriceFilter.TickSize != 0)
+                {
+                    var beforePrice = outputPrice;
+                    outputPrice = BinanceHelpers.FloorPrice(symbolData.PriceFilter.TickSize, price.Value);
+                    if (outputPrice != beforePrice)
+                    {
+                        if (tradeRulesBehaviour == TradeRulesBehaviour.ThrowError)
+                            return BinanceTradeRuleResult.CreateFailed($"Trade rules check failed: Price filter tick failed. Original price: {price}, Closest allowed: {outputPrice}");
+
+                        log.Write(LogVerbosity.Info, $"price rounded from {beforePrice} to {outputPrice}");
+                    }
+                }
+            }
+
+            return BinanceTradeRuleResult.CreatePassed(outputQuantity, outputPrice);
+        }
+
+        #endregion
+    }
+}

--- a/Binance.Net/BinanceFuturesClient.cs
+++ b/Binance.Net/BinanceFuturesClient.cs
@@ -451,7 +451,7 @@ namespace Binance.Net
         /// <param name="limit">Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns>The funding rate history for the provided symbol</returns>
-        public WebCallResult<IEnumerable<BinanceFuturesFundingRate>> GetFundingRates(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default) => GetFundingRatesAsync(symbol, startTime, endTime, limit, ct).Result;
+        public WebCallResult<IEnumerable<BinanceFuturesFundingRateHistory>> GetFundingRates(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default) => GetFundingRatesAsync(symbol, startTime, endTime, limit, ct).Result;
 
         /// <summary>
         /// Get funding rate history for the provided symbol
@@ -462,7 +462,7 @@ namespace Binance.Net
         /// <param name="limit">Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns>The funding rate history for the provided symbol</returns>
-        public async Task<WebCallResult<IEnumerable<BinanceFuturesFundingRate>>> GetFundingRatesAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default)
+        public async Task<WebCallResult<IEnumerable<BinanceFuturesFundingRateHistory>>> GetFundingRatesAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default)
         {
             symbol.ValidateBinanceSymbol();
             limit?.ValidateIntBetween(nameof(limit), 1, 1000);
@@ -473,7 +473,7 @@ namespace Binance.Net
             parameters.AddOptionalParameter("endTime", endTime != null ? ToUnixTimestamp(endTime.Value).ToString() : null);
             parameters.AddOptionalParameter("limit", limit?.ToString());
 
-            return await SendRequest<IEnumerable<BinanceFuturesFundingRate>>(GetUrl(FundingRateHistoryEndpoint, Api, PublicVersion), HttpMethod.Get, ct, parameters).ConfigureAwait(false);
+            return await SendRequest<IEnumerable<BinanceFuturesFundingRateHistory>>(GetUrl(FundingRateHistoryEndpoint, Api, PublicVersion), HttpMethod.Get, ct, parameters).ConfigureAwait(false);
         }
         
         /// <summary>

--- a/Binance.Net/BinanceFuturesSocketClient.cs
+++ b/Binance.Net/BinanceFuturesSocketClient.cs
@@ -17,7 +17,7 @@ using Newtonsoft.Json.Linq;
 namespace Binance.Net
 {
     /// <summary>
-    /// Client providing access to the Binance websocket Api
+    /// Client providing access to the Binance Futures Websocket Api
     /// </summary>
     public class BinanceFuturesSocketClient : SocketClient, IBinanceFuturesSocketClient
     {
@@ -28,24 +28,23 @@ namespace Binance.Net
         private readonly string baseCombinedAddress;
 
         private const string AggregatedTradesStreamEndpoint = "@aggTrade";
-        private const string MarkPriceStreamEndpoint = "@markPrice";//TODO
+        private const string MarkPriceStreamEndpoint = "@markPrice";
         private const string AllMarkPriceStreamEndpoint = "!markPrice@arr";
         private const string KlineStreamEndpoint = "@kline";
-        private const string SymbolMiniTickerStreamEndpoint = "@miniTicker";//TODO
+        private const string SymbolMiniTickerStreamEndpoint = "@miniTicker";
         private const string AllMiniTickerStreamEndpoint = "!miniTicker@arr";
         private const string SymbolTickerStreamEndpoint = "@ticker";
-        private const string AllTickerStreamEndpoint = "!ticker@arr";//TODO
+        private const string AllTickerStreamEndpoint = "!ticker@arr";
         private const string BookTickerStreamEndpoint = "@bookTicker";
         private const string AllBookTickerStreamEndpoint = "!bookTicker";
-        private const string LiquidationStreamEndpoint = "@forceOrder";//TODO
+        private const string LiquidationStreamEndpoint = "@forceOrder";
         private const string AllLiquidationStreamEndpoint = "!forceOrder@arr";
         private const string PartialBookDepthStreamEndpoint = "@depth";
         private const string DepthStreamEndpoint = "@depth";
-        private const string DiffBookDepthStreamEndpoint = "@depth";//TODO
 
         private const string AccountUpdateEvent = "ACCOUNT_UPDATE";
         private const string ExecutionUpdateEvent = "executionReport";
-        private const string OcoOrderUpdateEvent = "ORDER_TRADE_UPDATE";
+        private const string OrderUpdateEvent = "ORDER_TRADE_UPDATE";
         private const string AccountPositionUpdateEvent = "outboundAccountPosition";
         private const string BalanceUpdateEvent = "balanceUpdate";
         private const string ListenKeyExpiredEvent = "listenKeyExpired";
@@ -54,14 +53,14 @@ namespace Binance.Net
         #region constructor/destructor
 
         /// <summary>
-        /// Create a new instance of BinanceSocketClient with default options
+        /// Create a new instance of BinanceFuturesSocketClient with default options
         /// </summary>
         public BinanceFuturesSocketClient() : this(DefaultOptions)
         {
         }
 
         /// <summary>
-        /// Create a new instance of BinanceSocketClient using provided options
+        /// Create a new instance of BinanceFuturesSocketClient using provided options
         /// </summary>
         /// <param name="options">The options to use for this client</param>
         public BinanceFuturesSocketClient(BinanceFuturesSocketClientOptions options) : base(options, options.ApiCredentials == null ? null : new BinanceAuthenticationProvider(options.ApiCredentials, ArrayParametersSerialization.MultipleValues))
@@ -632,7 +631,7 @@ namespace Binance.Net
                             log.Write(LogVerbosity.Warning, "Couldn't deserialize data received from account stream: " + result.Error);
                         break;
                     }
-                    case OcoOrderUpdateEvent:
+                    case OrderUpdateEvent:
                     {
                         log.Write(LogVerbosity.Debug, data);
                             var orders = token["o"];
@@ -651,7 +650,7 @@ namespace Binance.Net
                         if (result)
                             onOcoOrderUpdateMessage?.Invoke(result.Data);
                         else
-                            log.Write(LogVerbosity.Warning, "Couldn't deserialize data received from oco order stream: " + result.Error);
+                            log.Write(LogVerbosity.Warning, "Couldn't deserialize data received from execution stream: " + result.Error);
                         break;
                     }
                     case AccountPositionUpdateEvent:
@@ -671,7 +670,7 @@ namespace Binance.Net
                         if (result)
                             onAccountBalanceUpdate?.Invoke(result.Data);
                         else
-                            log.Write(LogVerbosity.Warning, "Couldn't deserialize data received from account position stream: " + result.Error);
+                            log.Write(LogVerbosity.Warning, "Couldn't deserialize data received from account balance stream: " + result.Error);
                         break;
                     }
                     case ListenKeyExpiredEvent:
@@ -681,7 +680,7 @@ namespace Binance.Net
                         if (result)
                             onListenKeyExpired?.Invoke(result.Data);
                         else
-                            log.Write(LogVerbosity.Warning, "Couldn't deserialize data received from account position stream: " + result.Error);
+                            log.Write(LogVerbosity.Warning, "Couldn't deserialize data received from the expried listen key event: " + result.Error);
                         break;
                     }
                     default:

--- a/Binance.Net/BinanceFuturesSocketClient.cs
+++ b/Binance.Net/BinanceFuturesSocketClient.cs
@@ -1,0 +1,744 @@
+using Binance.Net.Converters;
+using Binance.Net.Objects;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Binance.Net.Interfaces;
+using Binance.Net.Objects.Sockets;
+using CryptoExchange.Net;
+using CryptoExchange.Net.Authentication;
+using CryptoExchange.Net.Logging;
+using CryptoExchange.Net.Objects;
+using CryptoExchange.Net.Sockets;
+using Newtonsoft.Json.Linq;
+
+namespace Binance.Net
+{
+    /// <summary>
+    /// Client providing access to the Binance websocket Api
+    /// </summary>
+    public class BinanceFuturesSocketClient : SocketClient, IBinanceFuturesSocketClient
+    {
+        #region fields
+        private static BinanceFuturesSocketClientOptions defaultOptions = new BinanceFuturesSocketClientOptions();
+        private static BinanceFuturesSocketClientOptions DefaultOptions => defaultOptions.Copy();
+
+        private readonly string baseCombinedAddress;
+
+        private const string AggregatedTradesStreamEndpoint = "@aggTrade";
+        private const string MarkPriceStreamEndpoint = "@markPrice";//TODO
+        private const string AllMarkPriceStreamEndpoint = "!markPrice@arr";
+        private const string KlineStreamEndpoint = "@kline";
+        private const string SymbolMiniTickerStreamEndpoint = "@miniTicker";//TODO
+        private const string AllMiniTickerStreamEndpoint = "!miniTicker@arr";
+        private const string SymbolTickerStreamEndpoint = "@ticker";
+        private const string AllTickerStreamEndpoint = "!ticker@arr";//TODO
+        private const string BookTickerStreamEndpoint = "@bookTicker";
+        private const string AllBookTickerStreamEndpoint = "!bookTicker";
+        private const string LiquidationStreamEndpoint = "@forceOrder";//TODO
+        private const string AllLiquidationStreamEndpoint = "!forceOrder@arr";
+        private const string PartialBookDepthStreamEndpoint = "@depth";
+        private const string DepthStreamEndpoint = "@depth";
+        private const string DiffBookDepthStreamEndpoint = "@depth";//TODO
+
+        private const string AccountUpdateEvent = "ACCOUNT_UPDATE";
+        private const string ExecutionUpdateEvent = "executionReport";
+        private const string OcoOrderUpdateEvent = "ORDER_TRADE_UPDATE";
+        private const string AccountPositionUpdateEvent = "outboundAccountPosition";
+        private const string BalanceUpdateEvent = "balanceUpdate";
+        private const string ListenKeyExpiredEvent = "listenKeyExpired";
+        #endregion
+
+        #region constructor/destructor
+
+        /// <summary>
+        /// Create a new instance of BinanceSocketClient with default options
+        /// </summary>
+        public BinanceFuturesSocketClient() : this(DefaultOptions)
+        {
+        }
+
+        /// <summary>
+        /// Create a new instance of BinanceSocketClient using provided options
+        /// </summary>
+        /// <param name="options">The options to use for this client</param>
+        public BinanceFuturesSocketClient(BinanceFuturesSocketClientOptions options) : base(options, options.ApiCredentials == null ? null : new BinanceAuthenticationProvider(options.ApiCredentials, ArrayParametersSerialization.MultipleValues))
+        {
+            baseCombinedAddress = options.BaseSocketCombinedAddress;
+        }
+        #endregion 
+
+        #region methods
+        /// <summary>
+        /// Set the default options to be used when creating new socket clients
+        /// </summary>
+        /// <param name="options"></param>
+        public static void SetDefaultOptions(BinanceFuturesSocketClientOptions options)
+        {
+            defaultOptions = options;
+        }
+
+        /// <summary>
+        /// Set the API key and secret
+        /// </summary>
+        /// <param name="apiKey">The api key</param>
+        /// <param name="apiSecret">The api secret</param>
+        public void SetApiCredentials(string apiKey, string apiSecret)
+        {
+            SetAuthenticationProvider(new BinanceAuthenticationProvider(new ApiCredentials(apiKey, apiSecret), ArrayParametersSerialization.MultipleValues));
+        }
+
+        /// <summary>
+        /// Subscribes to the aggregated trades update stream for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToAggregatedTradeUpdates(string symbol, Action<BinanceStreamAggregatedTrade> onMessage) => SubscribeToAggregatedTradeUpdatesAsync(symbol, onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to the aggregated trades update stream for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToAggregatedTradeUpdatesAsync(string symbol, Action<BinanceStreamAggregatedTrade> onMessage) => await SubscribeToAggregatedTradeUpdatesAsync(new[] { symbol }, onMessage).ConfigureAwait(false);
+
+        /// <summary>
+        /// Subscribes to the aggregated trades update stream for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToAggregatedTradeUpdates(IEnumerable<string> symbols, Action<BinanceStreamAggregatedTrade> onMessage) => SubscribeToAggregatedTradeUpdatesAsync(symbols, onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to the aggregated trades update stream for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToAggregatedTradeUpdatesAsync(IEnumerable<string> symbols, Action<BinanceStreamAggregatedTrade> onMessage)
+        {
+            symbols.ValidateNotNull(nameof(symbols));
+            foreach (var symbol in symbols)
+                symbol.ValidateBinanceSymbol();
+
+            var handler = new Action<BinanceCombinedStream<BinanceStreamAggregatedTrade>>(data => onMessage(data.Data));
+            symbols = symbols.Select(a => a.ToLower() + AggregatedTradesStreamEndpoint).ToArray();
+            return await Subscribe(string.Join("/", symbols), true, handler).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Subscribes to the Mark price update stream for a single symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToMarkPriceUpdates(string symbol, Action<BinanceFuturesStreamMarkPrice> onMessage) => SubscribeToMarkPriceUpdatesAsync(symbol, onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to the Mark price update stream for a single symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToMarkPriceUpdatesAsync(string symbol, Action<BinanceFuturesStreamMarkPrice> onMessage) => await SubscribeToMarkPriceUpdatesAsync(new[] { symbol }, onMessage).ConfigureAwait(false);
+
+        /// <summary>
+        /// Subscribes to the Mark price update stream for a list of symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToMarkPriceUpdates(IEnumerable<string> symbols, Action<BinanceFuturesStreamMarkPrice> onMessage) => SubscribeToMarkPriceUpdatesAsync(symbols, onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to the Mark price update stream for a list of symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToMarkPriceUpdatesAsync(IEnumerable<string> symbols, Action<BinanceFuturesStreamMarkPrice> onMessage)
+        {
+            symbols.ValidateNotNull(nameof(symbols));
+            foreach (var symbol in symbols)
+                symbol.ValidateBinanceSymbol();
+
+            var handler = new Action<BinanceCombinedStream<BinanceFuturesStreamMarkPrice>>(data => onMessage(data.Data));
+            symbols = symbols.Select(a => a.ToLower() + MarkPriceStreamEndpoint).ToArray();
+            return await Subscribe(string.Join("/", symbols), true, handler).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Subscribes to the Mark price update stream for a all symbols
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToAllMarkPriceUpdates(Action<IEnumerable<BinanceFuturesStreamMarkPrice>> onMessage) => SubscribeToAllMarkPriceUpdatesAsync(onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to the Mark price update stream for a all symbols
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToAllMarkPriceUpdatesAsync(Action<IEnumerable<BinanceFuturesStreamMarkPrice>> onMessage)
+        {
+            return await Subscribe(AllMarkPriceStreamEndpoint, false, onMessage).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Subscribes to the candlestick update stream for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="interval">The interval of the candlesticks</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToKlineUpdates(string symbol, KlineInterval interval, Action<BinanceStreamKlineData> onMessage) => SubscribeToKlineUpdatesAsync(symbol, interval, onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to the candlestick update stream for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="interval">The interval of the candlesticks</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<BinanceStreamKlineData> onMessage) => await SubscribeToKlineUpdatesAsync(new [] { symbol }, interval, onMessage).ConfigureAwait(false);
+
+
+        /// <summary>
+        /// Subscribes to the candlestick update stream for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="interval">The interval of the candlesticks</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToKlineUpdates(IEnumerable<string> symbols, KlineInterval interval, Action<BinanceStreamKlineData> onMessage) => SubscribeToKlineUpdatesAsync(symbols, interval, onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to the candlestick update stream for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="interval">The interval of the candlesticks</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols, KlineInterval interval, Action<BinanceStreamKlineData> onMessage)
+        {
+            symbols.ValidateNotNull(nameof(symbols));
+            foreach(var symbol in symbols)
+                symbol.ValidateBinanceSymbol();
+
+            var handler = new Action<BinanceCombinedStream<BinanceStreamKlineData>>(data => onMessage(data.Data));
+            symbols = symbols.Select(a => a.ToLower() + KlineStreamEndpoint + "_" + JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false))).ToArray();
+            return await Subscribe(string.Join("/", symbols), true, handler).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Subscribes to mini ticker updates stream for a specific symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to subscribe to</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToSymbolMiniTickerUpdates(string symbol, Action<BinanceFuturesStreamMiniTick> onMessage) => SubscribeToSymbolMiniTickerUpdatesAsync(symbol, onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to mini ticker updates stream for a specific symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to subscribe to</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToSymbolMiniTickerUpdatesAsync(string symbol, Action<BinanceFuturesStreamMiniTick> onMessage) => await SubscribeToSymbolMiniTickerUpdatesAsync(new[] { symbol }, onMessage).ConfigureAwait(false);
+
+        /// <summary>
+        /// Subscribes to mini ticker updates stream for a list of symbol
+        /// </summary>
+        /// <param name="symbols">The symbols to subscribe to</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToSymbolMiniTickerUpdates(IEnumerable<string> symbols, Action<BinanceFuturesStreamMiniTick> onMessage) => SubscribeToSymbolMiniTickerUpdatesAsync(symbols, onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to mini ticker updates stream for a list of symbol
+        /// </summary>
+        /// <param name="symbols">The symbols to subscribe to</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToSymbolMiniTickerUpdatesAsync(IEnumerable<string> symbols, Action<BinanceFuturesStreamMiniTick> onMessage)
+        {
+            symbols.ValidateNotNull(nameof(symbols));
+            foreach (var symbol in symbols)
+                symbol.ValidateBinanceSymbol();
+
+            var handler = new Action<BinanceCombinedStream<BinanceFuturesStreamMiniTick>>(data => onMessage(data.Data));
+            symbols = symbols.Select(a => a.ToLower() + SymbolMiniTickerStreamEndpoint).ToArray();
+            return await Subscribe(string.Join("/", symbols), true, handler).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Subscribes to mini ticker updates stream for all symbols
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToAllMiniTickerUpdates(Action<IEnumerable<BinanceFuturesStreamMiniTick>> onMessage) => SubscribeToAllMiniTickerUpdatesAsync(onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to mini ticker updates stream for all symbols
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToAllMiniTickerUpdatesAsync(Action<IEnumerable<BinanceFuturesStreamMiniTick>> onMessage)
+        {
+            return await Subscribe(AllMiniTickerStreamEndpoint, false, onMessage).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Subscribes to the order book updates for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToOrderBookUpdates(string symbol, int? updateInterval, Action<BinanceOrderBook> onMessage) => SubscribeToOrderBookUpdatesAsync(symbol, updateInterval, onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to the order book updates for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, int? updateInterval, Action<BinanceOrderBook> onMessage) => await SubscribeToOrderBookUpdatesAsync(new[] { symbol }, updateInterval, onMessage).ConfigureAwait(false);
+
+        /// <summary>
+        /// Subscribes to the depth update stream for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToOrderBookUpdates(IEnumerable<string> symbols, int? updateInterval, Action<BinanceOrderBook> onMessage) => SubscribeToOrderBookUpdatesAsync(symbols, updateInterval, onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to the depth update stream for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, int? updateInterval, Action<BinanceOrderBook> onMessage)
+        {
+            symbols.ValidateNotNull(nameof(symbols));
+            foreach (var symbol in symbols)
+                symbol.ValidateBinanceSymbol();
+
+            updateInterval?.ValidateIntValues(nameof(updateInterval), 100, 1000);
+            var handler = new Action<BinanceCombinedStream<BinanceOrderBook>>(data => onMessage(data.Data));
+            symbols = symbols.Select(a => a.ToLower() + DepthStreamEndpoint + (updateInterval.HasValue ? $"@{updateInterval.Value}ms" : "")).ToArray();
+            return await Subscribe(String.Join("/", symbols), true, handler).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Subscribes to ticker updates stream for a specific symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to subscribe to</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToSymbolTickerUpdates(string symbol, Action<BinanceStreamTick> onMessage) => SubscribeToSymbolTickerUpdatesAsync(symbol, onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to ticker updates stream for a specific symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to subscribe to</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToSymbolTickerUpdatesAsync(string symbol, Action<BinanceStreamTick> onMessage)
+        {
+            symbol.ValidateBinanceSymbol();
+            return await Subscribe(symbol.ToLower() + SymbolTickerStreamEndpoint, false, onMessage).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Subscribes to ticker updates stream for a specific symbol
+        /// </summary>
+        /// <param name="symbols">The symbol to subscribe to</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToSymbolTickerUpdates(IEnumerable<string> symbols, Action<BinanceStreamTick> onMessage) => SubscribeToSymbolTickerUpdatesAsync(symbols, onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to ticker updates stream for a specific symbol
+        /// </summary>
+        /// <param name="symbols">The symbols to subscribe to</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToSymbolTickerUpdatesAsync(IEnumerable<string> symbols, Action<BinanceStreamTick> onMessage)
+        {
+            symbols.ValidateNotNull(nameof(symbols));
+            foreach (var symbol in symbols)
+                symbol.ValidateBinanceSymbol();
+
+            var handler = new Action<BinanceCombinedStream<BinanceStreamTick>>(data => onMessage(data.Data));
+            symbols = symbols.Select(a => a.ToLower() + SymbolTickerStreamEndpoint).ToArray();
+            return await Subscribe(string.Join("/", symbols), true, handler).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Subscribes to ticker updates stream for all symbols
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToAllTickerUpdates(Action<IEnumerable<BinanceStreamTick>> onMessage) => SubscribeToAllTickerUpdatesAsync(onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to ticker updates stream for all symbols
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToAllTickerUpdatesAsync(Action<IEnumerable<BinanceStreamTick>> onMessage)
+        {
+            return await Subscribe(AllTickerStreamEndpoint, false, onMessage).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Subscribes to the book ticker update stream for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToBookTickerUpdates(string symbol, Action<BinanceBookTick> onMessage) => SubscribeToBookTickerUpdatesAsync(symbol, onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to the book ticker update stream for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(string symbol, Action<BinanceBookTick> onMessage) => await SubscribeToBookTickerUpdatesAsync(new[] { symbol }, onMessage).ConfigureAwait(false);
+
+        /// <summary>
+        /// Subscribes to the book ticker update stream for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToBookTickerUpdates(IEnumerable<string> symbols, Action<BinanceBookTick> onMessage) => SubscribeToBookTickerUpdatesAsync(symbols, onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to the book ticker update stream for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(IEnumerable<string> symbols, Action<BinanceBookTick> onMessage)
+        {
+            symbols.ValidateNotNull(nameof(symbols));
+            foreach (var symbol in symbols)
+                symbol.ValidateBinanceSymbol();
+
+            var handler = new Action<BinanceCombinedStream<BinanceBookTick>>(data => onMessage(data.Data));
+            symbols = symbols.Select(a => a.ToLower() + BookTickerStreamEndpoint).ToArray();
+            return await Subscribe(String.Join("/", symbols), true, handler).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Subscribes to all book ticker update streams
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToAllBookTickerUpdates(Action<BinanceBookTick> onMessage) => SubscribeToAllBookTickerUpdatesAsync(onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to all book ticker update streams
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToAllBookTickerUpdatesAsync(Action<BinanceBookTick> onMessage)
+        {
+            return await Subscribe(AllBookTickerStreamEndpoint, false, onMessage).ConfigureAwait(false);
+        }
+        
+        /// <summary>
+        /// Subscribes to specific symbol forced liquidations stream
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToLiquidationUpdates(string symbol, Action<BinanceFuturesStreamLiquidation> onMessage) => SubscribeToLiquidationUpdatesAsync(symbol, onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to specific symbol forced liquidations stream
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(string symbol, Action<BinanceFuturesStreamLiquidation> onMessage) => await SubscribeToLiquidationUpdatesAsync(new[] { symbol }, onMessage).ConfigureAwait(false);
+
+        /// <summary>
+        /// Subscribes to list of symbol forced liquidations stream
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToLiquidationUpdates(IEnumerable<string> symbols, Action<BinanceFuturesStreamLiquidation> onMessage) => SubscribeToLiquidationUpdatesAsync(symbols, onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to list of symbol forced liquidations stream
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(IEnumerable<string> symbols, Action<BinanceFuturesStreamLiquidation> onMessage)
+        {
+            symbols.ValidateNotNull(nameof(symbols));
+            foreach (var symbol in symbols)
+                symbol.ValidateBinanceSymbol();
+
+            var handler = new Action<BinanceCombinedStream<BinanceFuturesStreamLiquidation>>(data => onMessage(data.Data));
+            symbols = symbols.Select(a => a.ToLower() + LiquidationStreamEndpoint).ToArray();
+            return await Subscribe(string.Join("/", symbols), true, handler).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Subscribes to all forced liquidations stream
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToAllLiquidationUpdates(Action<BinanceFuturesStreamLiquidation> onMessage) => SubscribeToAllLiquidationUpdatesAsync(onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to all forced liquidations stream
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToAllLiquidationUpdatesAsync(Action<BinanceFuturesStreamLiquidation> onMessage)
+        {
+            return await Subscribe(AllLiquidationStreamEndpoint, false, onMessage).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Subscribes to the depth updates for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to subscribe on</param>
+        /// <param name="levels">The amount of entries to be returned in the update</param>
+        /// <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToPartialOrderBookUpdates(string symbol, int levels, int? updateInterval, Action<BinanceOrderBook> onMessage) => SubscribeToPartialOrderBookUpdatesAsync(symbol, levels, updateInterval, onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to the depth updates for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to subscribe on</param>
+        /// <param name="levels">The amount of entries to be returned in the update</param>
+        /// <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToPartialOrderBookUpdatesAsync(string symbol, int levels, int? updateInterval, Action<BinanceOrderBook> onMessage) => await SubscribeToPartialOrderBookUpdatesAsync(new[] { symbol }, levels, updateInterval, onMessage).ConfigureAwait(false);
+
+        /// <summary>
+        /// Subscribes to the depth updates for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols to subscribe on</param>
+        /// <param name="levels">The amount of entries to be returned in the update of each symbol</param>
+        /// <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToPartialOrderBookUpdates(IEnumerable<string> symbols, int levels, int? updateInterval, Action<BinanceOrderBook> onMessage) => SubscribeToPartialOrderBookUpdatesAsync(symbols, levels, updateInterval, onMessage).Result;
+
+        /// <summary>
+        /// Subscribes to the depth updates for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols to subscribe on</param>
+        /// <param name="levels">The amount of entries to be returned in the update of each symbol</param>
+        /// <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToPartialOrderBookUpdatesAsync(IEnumerable<string> symbols, int levels, int? updateInterval, Action<BinanceOrderBook> onMessage)
+        {
+            symbols.ValidateNotNull(nameof(symbols));
+            foreach (var symbol in symbols)
+                symbol.ValidateBinanceSymbol();
+
+            levels.ValidateIntValues(nameof(levels), 5, 10, 20);
+            updateInterval?.ValidateIntValues(nameof(updateInterval), 100, 1000);
+
+            var handler = new Action<BinanceCombinedStream<BinanceOrderBook>>(data =>
+            {
+                data.Data.Symbol = data.Stream.Split('@')[0];
+                onMessage(data.Data);
+            });
+
+            symbols = symbols.Select(a => a.ToLower() + PartialBookDepthStreamEndpoint + levels + (updateInterval.HasValue ? $"@{updateInterval.Value}ms" : "")).ToArray();
+            return await Subscribe(string.Join("/", symbols), true, handler).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Subscribes to the account update stream. Prior to using this, the <see cref="BinanceClient.StartUserStream"/> method should be called.
+        /// </summary>
+        /// <param name="listenKey">Listen key retrieved by the StartUserStream method</param>
+        /// <param name="onAccountInfoMessage">The event handler for whenever an account info update is received</param>
+        /// <param name="onOrderUpdateMessage">The event handler for whenever an order status update is received</param>
+        /// <param name="onOcoOrderUpdateMessage">The event handler for whenever an oco status update is received</param>
+        /// <param name="onAccountPositionMessage">The event handler for whenever an account position update is received. Account position updates are a list of changed funds</param>
+        /// <param name="onAccountBalanceUpdate">The event handler for whenever a deposit or withdrawal has been processed and the account balance has changed</param>
+        /// <param name="onListenKeyExpired">Responds when the listen key for the stream has expired. Initiate a new instance of the stream here</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public CallResult<UpdateSubscription> SubscribeToUserDataUpdates(
+            string listenKey, 
+            Action<BinanceFuturesStreamAccountInfo>? onAccountInfoMessage, 
+            Action<BinanceFuturesStreamOrderUpdate>? onOrderUpdateMessage,
+            Action<BinanceStreamOrderList>? onOcoOrderUpdateMessage,
+            Action<IEnumerable<BinanceStreamBalance>>? onAccountPositionMessage,
+            Action<BinanceStreamBalanceUpdate>? onAccountBalanceUpdate,
+            Action<BinanceStreamEvent> onListenKeyExpired) => SubscribeToUserDataUpdatesAsync(listenKey, onAccountInfoMessage, onOrderUpdateMessage, onOcoOrderUpdateMessage, onAccountPositionMessage, onAccountBalanceUpdate, onListenKeyExpired).Result;
+
+        /// <summary>
+        /// Subscribes to the account update stream. Prior to using this, the <see cref="BinanceClient.StartUserStream"/> method should be called.
+        /// </summary>
+        /// <param name="listenKey">Listen key retrieved by the StartUserStream method</param>
+        /// <param name="onAccountInfoMessage">The event handler for whenever an account info update is received</param>
+        /// <param name="onOrderUpdateMessage">The event handler for whenever an order status update is received</param>
+        /// <param name="onOcoOrderUpdateMessage">The event handler for whenever an oco order status update is received</param>
+        /// <param name="onAccountPositionMessage">The event handler for whenever an account position update is received. Account position updates are a list of changed funds</param>
+        /// <param name="onAccountBalanceUpdate">The event handler for whenever a deposit or withdrawal has been processed and the account balance has changed</param>
+        /// <param name="onListenKeyExpired">Responds when the listen key for the stream has expired. Initiate a new instance of the stream here</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToUserDataUpdatesAsync(
+            string listenKey, 
+            Action<BinanceFuturesStreamAccountInfo>? onAccountInfoMessage, 
+            Action<BinanceFuturesStreamOrderUpdate>? onOrderUpdateMessage,
+            Action<BinanceStreamOrderList>? onOcoOrderUpdateMessage,
+            Action<IEnumerable<BinanceStreamBalance>>? onAccountPositionMessage,
+            Action<BinanceStreamBalanceUpdate>? onAccountBalanceUpdate,
+            Action<BinanceStreamEvent> onListenKeyExpired)
+        {
+            listenKey.ValidateNotNull(nameof(listenKey));
+
+            var handler = new Action<string>(data =>
+            {
+                var token = JToken.Parse(data);
+                var evnt = (string)token["e"];
+                switch (evnt)
+                {
+                    case AccountUpdateEvent:
+                        {
+                            var account = token["a"];
+                            var result = Deserialize<BinanceFuturesStreamAccountInfo>(account, false);
+                        if (result.Success)
+                            onAccountInfoMessage?.Invoke(result.Data);
+                        else
+                            log.Write(LogVerbosity.Warning, "Couldn't deserialize data received from account stream: " + result.Error);
+                        break;
+                    }
+                    case OcoOrderUpdateEvent:
+                    {
+                        log.Write(LogVerbosity.Debug, data);
+                            var orders = token["o"];
+                            var result = Deserialize<BinanceFuturesStreamOrderUpdate>(orders, false);
+                        if (result)
+                            onOrderUpdateMessage?.Invoke(result.Data);
+                        else
+                            log.Write(LogVerbosity.Warning, "Couldn't deserialize data received from order stream: " + result.Error);
+                        break;
+                    }
+                    case ExecutionUpdateEvent:
+                        
+                    {
+                        log.Write(LogVerbosity.Debug, data);
+                        var result = Deserialize<BinanceStreamOrderList>(token, false);
+                        if (result)
+                            onOcoOrderUpdateMessage?.Invoke(result.Data);
+                        else
+                            log.Write(LogVerbosity.Warning, "Couldn't deserialize data received from oco order stream: " + result.Error);
+                        break;
+                    }
+                    case AccountPositionUpdateEvent:
+                    {
+                        log.Write(LogVerbosity.Debug, data);
+                        var result = Deserialize<IEnumerable<BinanceStreamBalance>>(token["B"], false);
+                        if (result)
+                            onAccountPositionMessage?.Invoke(result.Data);
+                        else
+                            log.Write(LogVerbosity.Warning, "Couldn't deserialize data received from account position stream: " + result.Error);
+                        break;
+                    }
+                    case BalanceUpdateEvent:
+                    {
+                        log.Write(LogVerbosity.Debug, data);
+                        var result = Deserialize<BinanceStreamBalanceUpdate>(token, false);
+                        if (result)
+                            onAccountBalanceUpdate?.Invoke(result.Data);
+                        else
+                            log.Write(LogVerbosity.Warning, "Couldn't deserialize data received from account position stream: " + result.Error);
+                        break;
+                    }
+                    case ListenKeyExpiredEvent:
+                    {
+                        log.Write(LogVerbosity.Debug, data);
+                        var result = Deserialize<BinanceStreamEvent>(token, false);
+                        if (result)
+                            onListenKeyExpired?.Invoke(result.Data);
+                        else
+                            log.Write(LogVerbosity.Warning, "Couldn't deserialize data received from account position stream: " + result.Error);
+                        break;
+                    }
+                    default:
+                        log.Write(LogVerbosity.Warning, $"Received unknown user data event {evnt}: " + data);
+                        break;
+                }
+            });
+
+            return await Subscribe(listenKey, false, handler).ConfigureAwait(false);
+        }
+
+        private async Task<CallResult<UpdateSubscription>> Subscribe<T>(string url, bool combined, Action<T> onData)
+        {
+            if (combined)
+                url = baseCombinedAddress + "stream?streams=" + url;
+            else
+                url = BaseAddress + url;
+
+            return await Subscribe(url, null, url + NextId(), false, onData).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        protected override bool HandleQueryResponse<T>(SocketConnection s, object request, JToken data, out CallResult<T> callResult)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        protected override bool HandleSubscriptionResponse(SocketConnection s, SocketSubscription subscription, object request, JToken message, out CallResult<object>? callResult)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        protected override bool MessageMatchesHandler(JToken message, object request)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        protected override bool MessageMatchesHandler(JToken message, string identifier)
+        {
+            return true;
+        }
+
+        /// <inheritdoc />
+        protected override Task<CallResult<bool>> AuthenticateSocket(SocketConnection s)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        protected override Task<bool> Unsubscribe(SocketConnection connection, SocketSubscription s)
+        {
+            return Task.FromResult(true);
+        }
+
+        #endregion
+    }
+}

--- a/Binance.Net/Converters/FuturesMarginChangeDirectionTypeConverter.cs
+++ b/Binance.Net/Converters/FuturesMarginChangeDirectionTypeConverter.cs
@@ -1,0 +1,18 @@
+﻿using Binance.Net.Objects;
+using System.Collections.Generic;
+using CryptoExchange.Net.Converters;
+
+namespace Binance.Net.Converters
+{
+    internal class FuturesMarginChangeDirectionTypeConverter : BaseConverter<FuturesMarginChangeDirectionType>
+    {
+        public FuturesMarginChangeDirectionTypeConverter(): this(false) { }
+        public FuturesMarginChangeDirectionTypeConverter(bool quotes) : base(quotes) { }
+
+        protected override List<KeyValuePair<FuturesMarginChangeDirectionType, string>> Mapping => new List<KeyValuePair<FuturesMarginChangeDirectionType, string>>
+        {
+            new KeyValuePair<FuturesMarginChangeDirectionType, string>(FuturesMarginChangeDirectionType.Add, "1"),
+            new KeyValuePair<FuturesMarginChangeDirectionType, string>(FuturesMarginChangeDirectionType.Reduce, "2")
+        };
+    }
+}

--- a/Binance.Net/Converters/FuturesMarginTypeConverter.cs
+++ b/Binance.Net/Converters/FuturesMarginTypeConverter.cs
@@ -1,0 +1,18 @@
+﻿using Binance.Net.Objects;
+using System.Collections.Generic;
+using CryptoExchange.Net.Converters;
+
+namespace Binance.Net.Converters
+{
+    internal class FuturesMarginTypeConverter : BaseConverter<FuturesMarginType>
+    {
+        public FuturesMarginTypeConverter(): this(false) { }
+        public FuturesMarginTypeConverter(bool quotes) : base(quotes) { }
+
+        protected override List<KeyValuePair<FuturesMarginType, string>> Mapping => new List<KeyValuePair<FuturesMarginType, string>>
+        {
+            new KeyValuePair<FuturesMarginType, string>(FuturesMarginType.Isolated, "ISOLATED"),
+            new KeyValuePair<FuturesMarginType, string>(FuturesMarginType.Cross, "CROSSED")
+        };
+    }
+}

--- a/Binance.Net/Converters/IncomeTypeConverter.cs
+++ b/Binance.Net/Converters/IncomeTypeConverter.cs
@@ -1,0 +1,22 @@
+﻿using Binance.Net.Objects;
+using System.Collections.Generic;
+using CryptoExchange.Net.Converters;
+
+namespace Binance.Net.Converters
+{
+    internal class IncomeTypeConverter: BaseConverter<IncomeType>
+    {
+        public IncomeTypeConverter(): this(true) { }
+        public IncomeTypeConverter(bool quotes) : base(quotes) { }
+
+        protected override List<KeyValuePair<IncomeType, string>> Mapping => new List<KeyValuePair<IncomeType, string>>
+        {
+            new KeyValuePair<IncomeType, string>(IncomeType.Transfer, "TRANSFER"),
+            new KeyValuePair<IncomeType, string>(IncomeType.WelcomeBonus, "WELCOME_BONUS"),
+            new KeyValuePair<IncomeType, string>(IncomeType.RealizedPnL, "REALIZED_PNL"),
+            new KeyValuePair<IncomeType, string>(IncomeType.FundingFee, "FUNDING_FEE"),
+            new KeyValuePair<IncomeType, string>(IncomeType.Commission, "COMMISSION"),
+            new KeyValuePair<IncomeType, string>(IncomeType.InsuranceClear, "INSURANCE_CLEAR"),
+        };
+    }
+}

--- a/Binance.Net/Interfaces/IBinanceFuturesClient.cs
+++ b/Binance.Net/Interfaces/IBinanceFuturesClient.cs
@@ -9,7 +9,7 @@ using CryptoExchange.Net.Objects;
 namespace Binance.Net.Interfaces
 {
     /// <summary>
-    /// Interface for the Binance client
+    /// Interface for the Binance Futures client
     /// </summary>
     public interface IBinanceFuturesClient: IRestClient
 
@@ -476,7 +476,7 @@ namespace Binance.Net.Interfaces
         Task<WebCallResult<BinanceAccountInfo>> GetAccountInfoAsync(long? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
-        /// Requests to change the initial leverag of the given symbol
+        /// Requests to change the initial leverage of the given symbol
         /// </summary>
         /// <param name="symbol">Symbol to change the initial leverage for</param>
         /// <param name="leverage">The amount of initial leverage to change to</param>
@@ -486,7 +486,7 @@ namespace Binance.Net.Interfaces
         WebCallResult<BinanceFuturesInitialLeverageChangeResult> ChangeInitialLeverage(string symbol, int leverage, long? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
-        /// Requests to change the initial leverag of the given symbol
+        /// Requests to change the initial leverage of the given symbol
         /// </summary>
         /// <param name="symbol">Symbol to change the initial leverage for</param>
         /// <param name="leverage">The amount of initial leverage to change to</param>

--- a/Binance.Net/Interfaces/IBinanceFuturesClient.cs
+++ b/Binance.Net/Interfaces/IBinanceFuturesClient.cs
@@ -1,0 +1,697 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Binance.Net.Objects;
+using CryptoExchange.Net.Interfaces;
+using CryptoExchange.Net.Objects;
+
+namespace Binance.Net.Interfaces
+{
+    /// <summary>
+    /// Interface for the Binance client
+    /// </summary>
+    public interface IBinanceFuturesClient: IRestClient
+
+    {
+        /// <summary>
+        /// Set the API key and secret
+        /// </summary>
+        /// <param name="apiKey">The api key</param>
+        /// <param name="apiSecret">The api secret</param>
+        void SetApiCredentials(string apiKey, string apiSecret);
+
+        /// <summary>
+        /// Pings the Binance API
+        /// </summary>
+        /// <returns>True if successful ping, false if no response</returns>
+        new CallResult<long> Ping(CancellationToken ct = default);
+
+        /// <summary>
+        /// Pings the Binance API
+        /// </summary>
+        /// <returns>True if successful ping, false if no response</returns>
+        new Task<CallResult<long>> PingAsync(CancellationToken ct = default);
+
+        /// <summary>
+        /// Requests the server for the local time. This function also determines the offset between server and local time and uses this for subsequent API calls
+        /// </summary>
+        /// <param name="resetAutoTimestamp">Whether the response should be used for a new auto timestamp calculation</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Server time</returns>
+        WebCallResult<DateTime> GetServerTime(bool resetAutoTimestamp = false, CancellationToken ct = default);
+
+        /// <summary>
+        /// Requests the server for the local time. This function also determines the offset between server and local time and uses this for subsequent API calls
+        /// </summary>
+        /// <param name="resetAutoTimestamp">Whether the response should be used for a new auto timestamp calculation</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Server time</returns>
+        Task<WebCallResult<DateTime>> GetServerTimeAsync(bool resetAutoTimestamp = false, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get's information about the exchange including rate limits and symbol list
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Exchange info</returns>
+        WebCallResult<BinanceFuturesExchangeInfo> GetExchangeInfo(CancellationToken ct = default);
+
+        /// <summary>
+        /// Get's information about the exchange including rate limits and symbol list
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Exchange info</returns>
+        Task<WebCallResult<BinanceFuturesExchangeInfo>> GetExchangeInfoAsync(CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets the order book for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the order book for</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The order book for the symbol</returns>
+        WebCallResult<BinanceOrderBook> GetOrderBook(string symbol, int? limit = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets the order book for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the order book for</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The order book for the symbol</returns>
+        Task<WebCallResult<BinanceOrderBook>> GetOrderBookAsync(string symbol, int? limit = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets compressed, aggregate trades. Trades that fill at the time, from the same order, with the same price will have the quantity aggregated.
+        /// </summary>
+        /// <param name="symbol">The symbol to get the trades for</param>
+        /// <param name="fromId">ID to get aggregate trades from INCLUSIVE.</param>
+        /// <param name="startTime">Time to start getting trades from</param>
+        /// <param name="endTime">Time to stop getting trades from</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The aggregated trades list for the symbol</returns>
+        WebCallResult<IEnumerable<BinanceAggregatedTrades>> GetAggregatedTrades(string symbol, long? fromId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets compressed, aggregate trades. Trades that fill at the time, from the same order, with the same price will have the quantity aggregated.
+        /// </summary>
+        /// <param name="symbol">The symbol to get the trades for</param>
+        /// <param name="fromId">ID to get aggregate trades from INCLUSIVE.</param>
+        /// <param name="startTime">Time to start getting trades from</param>
+        /// <param name="endTime">Time to stop getting trades from</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The aggregated trades list for the symbol</returns>
+        Task<WebCallResult<IEnumerable<BinanceAggregatedTrades>>> GetAggregatedTradesAsync(string symbol, long? fromId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets the recent trades for a symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get recent trades for</param>
+        /// <param name="limit">Result limit</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of recent trades</returns>
+        WebCallResult<IEnumerable<BinanceRecentTrade>> GetSymbolTrades(string symbol, int? limit = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets the recent trades for a symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get recent trades for</param>
+        /// <param name="limit">Result limit</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of recent trades</returns>
+        Task<WebCallResult<IEnumerable<BinanceRecentTrade>>> GetSymbolTradesAsync(string symbol, int? limit = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets the historical  trades for a symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get recent trades for</param>
+        /// <param name="limit">Result limit</param>
+        /// <param name="fromId">From which trade id on results should be retrieved</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of recent trades</returns>
+        WebCallResult<IEnumerable<BinanceRecentTrade>> GetHistoricalSymbolTrades(string symbol, int? limit = null, long? fromId = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets the historical  trades for a symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get recent trades for</param>
+        /// <param name="limit">Result limit</param>
+        /// <param name="fromId">From which trade id on results should be retrieved</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of recent trades</returns>
+        Task<WebCallResult<IEnumerable<BinanceRecentTrade>>> GetHistoricalSymbolTradesAsync(string symbol, int? limit = null, long? fromId = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get candlestick data for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the data for</param>
+        /// <param name="interval">The candlestick timespan</param>
+        /// <param name="startTime">Start time to get candlestick data</param>
+        /// <param name="endTime">End time to get candlestick data</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The candlestick data for the provided symbol</returns>
+        WebCallResult<IEnumerable<BinanceKline>> GetKlines(string symbol, KlineInterval interval, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get candlestick data for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the data for</param>
+        /// <param name="interval">The candlestick timespan</param>
+        /// <param name="startTime">Start time to get candlestick data</param>
+        /// <param name="endTime">End time to get candlestick data</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The candlestick data for the provided symbol</returns>
+        Task<WebCallResult<IEnumerable<BinanceKline>>> GetKlinesAsync(string symbol, KlineInterval interval, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get Mark Price and Funding Rate for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the data for</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Data over the last 24 hours</returns>
+        WebCallResult<BinanceFuturesMarkPrice> GetMarkPrice(string symbol, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get Mark Price and Funding Rate for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the data for</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Data over the last 24 hours</returns>
+        Task<WebCallResult<BinanceFuturesMarkPrice>> GetMarkPriceAsync(string symbol, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get Mark Price and Funding Rate for all symbols
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of data over the last 24 hours</returns>
+        WebCallResult<IEnumerable<BinanceFuturesMarkPrice>> GetMarkPricesList(CancellationToken ct = default);
+
+        /// <summary>
+        /// Get Mark Price and Funding Rate for all symbols
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of data over the last 24 hours</returns>
+        Task<WebCallResult<IEnumerable<BinanceFuturesMarkPrice>>> GetMarkPricesListAsync(CancellationToken ct = default);
+
+        /// <summary>
+        /// Get funding rate history for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the data for</param>
+        /// <param name="startTime">Start time to get funding rate history</param>
+        /// <param name="endTime">End time to get funding rate history</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The funding rate history for the provided symbol</returns>
+        WebCallResult<IEnumerable<BinanceFuturesFundingRate>> GetFundingRates(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get funding rate history for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the data for</param>
+        /// <param name="startTime">Start time to get funding rate history</param>
+        /// <param name="endTime">End time to get funding rate history</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The funding rate history for the provided symbol</returns>
+        Task<WebCallResult<IEnumerable<BinanceFuturesFundingRate>>> GetFundingRatesAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get data regarding the last 24 hours for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the data for</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Data over the last 24 hours</returns>
+        WebCallResult<Binance24HPrice> Get24HPrice(string symbol, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get data regarding the last 24 hours for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the data for</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Data over the last 24 hours</returns>
+        Task<WebCallResult<Binance24HPrice>> Get24HPriceAsync(string symbol, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get data regarding the last 24 hours for all symbols
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of data over the last 24 hours</returns>
+        WebCallResult<IEnumerable<Binance24HPrice>> Get24HPricesList(CancellationToken ct = default);
+
+        /// <summary>
+        /// Get data regarding the last 24 hours for all symbols
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of data over the last 24 hours</returns>
+        Task<WebCallResult<IEnumerable<Binance24HPrice>>> Get24HPricesListAsync(CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets the price of a symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the price for</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Price of symbol</returns>
+        WebCallResult<BinancePrice> GetPrice(string symbol, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets the price of a symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get the price for</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Price of symbol</returns>
+        Task<WebCallResult<BinancePrice>> GetPriceAsync(string symbol, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get a list of the prices of all symbols
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of prices</returns>
+        WebCallResult<IEnumerable<BinancePrice>> GetAllPrices(CancellationToken ct = default);
+
+        /// <summary>
+        /// Get a list of the prices of all symbols
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of prices</returns>
+        Task<WebCallResult<IEnumerable<BinancePrice>>> GetAllPricesAsync(CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets the best price/quantity on the order book for a symbol.
+        /// </summary>
+        /// <param name="symbol">Symbol to get book price for</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of book prices</returns>
+        WebCallResult<BinanceBookPrice> GetBookPrice(string symbol, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets the best price/quantity on the order book for a symbol.
+        /// </summary>
+        /// <param name="symbol">Symbol to get book price for</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of book prices</returns>
+        Task<WebCallResult<BinanceBookPrice>> GetBookPriceAsync(string symbol, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets the best price/quantity on the order book for all symbols.
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of book prices</returns>
+        WebCallResult<IEnumerable<BinanceBookPrice>> GetAllBookPrices(CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets the best price/quantity on the order book for all symbols.
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of book prices</returns>
+        Task<WebCallResult<IEnumerable<BinanceBookPrice>>> GetAllBookPricesAsync(CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets a list of open orders
+        /// </summary>
+        /// <param name="symbol">The symbol to get open orders for</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of open orders</returns>
+        WebCallResult<IEnumerable<BinanceOrder>> GetOpenOrders(string? symbol = null, int? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets a list of open orders
+        /// </summary>
+        /// <param name="symbol">The symbol to get open orders for</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of open orders</returns>
+        Task<WebCallResult<IEnumerable<BinanceOrder>>> GetOpenOrdersAsync(string? symbol = null, int? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets all orders for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get orders for</param>
+        /// <param name="orderId">If set, only orders with an order id higher than the provided will be returned</param>
+        /// <param name="startTime">If set, only orders placed after this time will be returned</param>
+        /// <param name="endTime">If set, only orders placed before this time will be returned</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of orders</returns>
+        WebCallResult<IEnumerable<BinanceOrder>> GetAllOrders(string symbol, long? orderId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets all orders for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to get orders for</param>
+        /// <param name="orderId">If set, only orders with an order id higher than the provided will be returned</param>
+        /// <param name="startTime">If set, only orders placed after this time will be returned</param>
+        /// <param name="endTime">If set, only orders placed before this time will be returned</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of orders</returns>
+        Task<WebCallResult<IEnumerable<BinanceOrder>>> GetAllOrdersAsync(string symbol, long? orderId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Places a new order
+        /// </summary>
+        /// <param name="symbol">The symbol the order is for</param>
+        /// <param name="side">The order side (buy/sell)</param>
+        /// <param name="type">The order type</param>
+        /// <param name="timeInForce">Lifetime of the order (GoodTillCancel/ImmediateOrCancel/FillOrKill)</param>
+        /// <param name="quantity">The amount of the base symbol</param>
+        /// <param name="reduceOnly">Specify as true if the order is intended to only reduce the position</param>
+        /// <param name="price">The price to use</param>
+        /// <param name="newClientOrderId">Unique id for order</param>
+        /// <param name="stopPrice">Used for stop orders</param>
+        /// <param name="orderResponseType">The type of response to receive</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Id's for the placed order</returns>
+        WebCallResult<BinancePlacedOrder> PlaceOrder(
+            string symbol,
+            OrderSide side,
+            OrderType type,
+            decimal? quantity,
+            TimeInForce? timeInForce = null,
+            bool? reduceOnly = null,
+            decimal? price = null,
+            string? newClientOrderId = null,
+            decimal? stopPrice = null,
+            OrderResponseType? orderResponseType = null,
+            int? receiveWindow = null,
+            CancellationToken ct = default);
+
+        /// <summary>
+        /// Places a new order
+        /// </summary>
+        /// <param name="symbol">The symbol the order is for</param>
+        /// <param name="side">The order side (buy/sell)</param>
+        /// <param name="type">The order type</param>
+        /// <param name="timeInForce">Lifetime of the order (GoodTillCancel/ImmediateOrCancel/FillOrKill)</param>
+        /// <param name="quantity">The amount of the base symbol</param>
+        /// <param name="reduceOnly">Specify as true if the order is intended to only reduce the position</param>
+        /// <param name="price">The price to use</param>
+        /// <param name="newClientOrderId">Unique id for order</param>
+        /// <param name="stopPrice">Used for stop orders</param>
+        /// <param name="orderResponseType">The type of response to receive</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Id's for the placed order</returns>
+        Task<WebCallResult<BinancePlacedOrder>> PlaceOrderAsync(
+            string symbol,
+            OrderSide side,
+            OrderType type,
+            decimal? quantity,
+            TimeInForce? timeInForce = null,
+            bool? reduceOnly = null,
+            decimal? price = null,
+            string? newClientOrderId = null,
+            decimal? stopPrice = null,
+            OrderResponseType? orderResponseType = null,
+            int? receiveWindow = null,
+            CancellationToken ct = default);
+
+        /// <summary>
+        /// Retrieves data for a specific order. Either orderId or origClientOrderId should be provided.
+        /// </summary>
+        /// <param name="symbol">The symbol the order is for</param>
+        /// <param name="orderId">The order id of the order</param>
+        /// <param name="origClientOrderId">The client order id of the order</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The specific order</returns>
+        WebCallResult<BinanceOrder> GetOrder(string symbol, long? orderId = null, string? origClientOrderId = null, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Retrieves data for a specific order. Either orderId or origClientOrderId should be provided.
+        /// </summary>
+        /// <param name="symbol">The symbol the order is for</param>
+        /// <param name="orderId">The order id of the order</param>
+        /// <param name="origClientOrderId">The client order id of the order</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The specific order</returns>
+        Task<WebCallResult<BinanceOrder>> GetOrderAsync(string symbol, long? orderId = null, string? origClientOrderId = null, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Cancels a pending order
+        /// </summary>
+        /// <param name="symbol">The symbol the order is for</param>
+        /// <param name="orderId">The order id of the order</param>
+        /// <param name="origClientOrderId">The client order id of the order</param>
+        /// <param name="newClientOrderId">The new client order id of the order</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Id's for canceled order</returns>
+        WebCallResult<BinanceCanceledOrder> CancelOrder(string symbol, long? orderId = null, string? origClientOrderId = null, string? newClientOrderId = null, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Cancels a pending order
+        /// </summary>
+        /// <param name="symbol">The symbol the order is for</param>
+        /// <param name="orderId">The order id of the order</param>
+        /// <param name="origClientOrderId">The client order id of the order</param>
+        /// <param name="newClientOrderId">Unique identifier for this cancel</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Id's for canceled order</returns>
+        Task<WebCallResult<BinanceCanceledOrder>> CancelOrderAsync(string symbol, long? orderId = null, string? origClientOrderId = null, string? newClientOrderId = null, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets account information, including balances
+        /// </summary>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The account information</returns>
+        WebCallResult<BinanceAccountInfo> GetAccountInfo(long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets account information, including balances
+        /// </summary>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The account information</returns>
+        Task<WebCallResult<BinanceAccountInfo>> GetAccountInfoAsync(long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Requests to change the initial leverag of the given symbol
+        /// </summary>
+        /// <param name="symbol">Symbol to change the initial leverage for</param>
+        /// <param name="leverage">The amount of initial leverage to change to</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Result of the initial leverage change request</returns>
+        WebCallResult<BinanceFuturesInitialLeverageChangeResult> ChangeInitialLeverage(string symbol, int leverage, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Requests to change the initial leverag of the given symbol
+        /// </summary>
+        /// <param name="symbol">Symbol to change the initial leverage for</param>
+        /// <param name="leverage">The amount of initial leverage to change to</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Result of the initial leverage change request</returns>
+        Task<WebCallResult<BinanceFuturesInitialLeverageChangeResult>> ChangeInitialLeverageAsync(string symbol, int leverage, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Change the margin type for an open position
+        /// </summary>
+        /// <param name="symbol">Symbol to change the position type for</param>
+        /// <param name="type">The type of margin to use</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Whether the request was successful</returns>
+        WebCallResult<BinanceFuturesChangeMarginTypeResult> ChangeMarginType(string symbol, FuturesMarginType marginType, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Change the margin type for an open position
+        /// </summary>
+        /// <param name="symbol">Symbol to change the position type for</param>
+        /// <param name="type">The type of margin to use</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Whether the request was successful</returns>
+        Task<WebCallResult<BinanceFuturesChangeMarginTypeResult>> ChangeMarginTypeAsync(string symbol, FuturesMarginType marginType, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Change the margin on an open position
+        /// </summary>
+        /// <param name="symbol">Symbol to adjust the position margin for</param>
+        /// <param name="amount">The amount of margin to be used</param>
+        /// <param name="type">Whether to reduce or add margin to the position</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The new position margin</returns>
+        WebCallResult<BinanceFuturesPositionMarginResult> ModifyPositionMargin(string symbol, decimal amount, FuturesMarginChangeDirectionType type, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Change the margin on an open position
+        /// </summary>
+        /// <param name="symbol">Symbol to adjust the position margin for</param>
+        /// <param name="amount">The amount of margin to be used</param>
+        /// <param name="type">Whether to reduce or add margin to the position</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The new position margin</returns>
+        Task<WebCallResult<BinanceFuturesPositionMarginResult>> ModifyPositionMarginAsync(string symbol, decimal amount, FuturesMarginChangeDirectionType type, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Requests the margin change history for a specific symbol
+        /// </summary>
+        /// <param name="symbol">Symbol to get margin history for</param>
+        /// <param name="type">Filter the history by the direction of margin change</param>
+        /// <param name="startTime">Margin changes newer than this date will be retrieved</param>
+        /// <param name="endTime">Margin changes older than this date will be retrieved</param>
+        /// <param name="limit">The max number of results</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of all margin changes for the symbol</returns>
+        WebCallResult<IEnumerable<BinanceFuturesMarginChangeHistoryResult>> GetMarginChangeHistory(string symbol, FuturesMarginChangeDirectionType? type = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Requests the margin change history for a specific symbol
+        /// </summary>
+        /// <param name="symbol">Symbol to get margin history for</param>
+        /// <param name="type">Filter the history by the direction of margin change</param>
+        /// <param name="startTime">Margin changes newer than this date will be retrieved</param>
+        /// <param name="endTime">Margin changes older than this date will be retrieved</param>
+        /// <param name="limit">The max number of results</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of all margin changes for the symbol</returns>
+        Task<WebCallResult<IEnumerable<BinanceFuturesMarginChangeHistoryResult>>> GetMarginChangeHistoryAsync(string symbol, FuturesMarginChangeDirectionType? type = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets all user trades for provided symbol
+        /// </summary>
+        /// <param name="symbol">Symbol to get trades for</param>
+        /// <param name="limit">The max number of results</param>
+        /// <param name="startTime">Orders newer than this date will be retrieved</param>
+        /// <param name="endTime">Orders older than this date will be retrieved</param>
+        /// <param name="fromId">TradeId to fetch from. Default gets most recent trades</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of trades</returns>
+        WebCallResult<IEnumerable<BinanceTrade>> GetMyTrades(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, long? fromId = null, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets all user trades for provided symbol
+        /// </summary>
+        /// <param name="symbol">Symbol to get trades for</param>
+        /// <param name="limit">The max number of results</param>
+        /// <param name="fromId">TradeId to fetch from. Default gets most recent trades</param>
+        /// <param name="startTime">Orders newer than this date will be retrieved</param>
+        /// <param name="endTime">Orders older than this date will be retrieved</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of trades</returns>
+        Task<WebCallResult<IEnumerable<BinanceTrade>>> GetMyTradesAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, long? fromId = null, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets Futures Account Balance
+        /// </summary>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of Positions</returns>
+        WebCallResult<IEnumerable<BinanceFuturesAccountBalance>> GetFuturesAccountBalance(long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets Futures Account Balance
+        /// </summary>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of Positions</returns>
+        Task<WebCallResult<IEnumerable<BinanceFuturesAccountBalance>>> GetFuturesAccountBalanceAsync(long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets the income history for the futures account
+        /// </summary>
+        /// <param name="symbol">The symbol to get income history from</param>
+        /// <param name="incomeType">The income type filter to apply to the request</param>
+        /// <param name="startTime">Time to start getting income history from</param>
+        /// <param name="endTime">Time to stop getting income history from</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The income history for the futures account</returns>
+        WebCallResult<IEnumerable<BinanceFuturesIncomeHistory>> GetIncomeHistory(string? symbol = null, IncomeType? incomeType = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets the income history for the futures account
+        /// </summary>
+        /// <param name="symbol">The symbol to get income history from</param>
+        /// <param name="incomeType">The income type filter to apply to the request</param>
+        /// <param name="startTime">Time to start getting income history from</param>
+        /// <param name="endTime">Time to stop getting income history from</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>The income history for the futures account</returns>
+        Task<WebCallResult<IEnumerable<BinanceFuturesIncomeHistory>>> GetIncomeHistoryAsync(string? symbol = null, IncomeType? incomeType = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets all user positions
+        /// </summary>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of Positions</returns>
+        WebCallResult<IEnumerable<BinanceFuturesPosition>> GetOpenPositions(long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets all user positions
+        /// </summary>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>List of Positions</returns>
+        Task<WebCallResult<IEnumerable<BinanceFuturesPosition>>> GetOpenPositionsAsync(long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Starts a user stream by requesting a listen key. This listen key can be used in subsequent requests to <see cref="BinanceSocketClient.SubscribeToUserDataUpdates"/>. The stream will close after 60 minutes unless a keep alive is send.
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Listen key</returns>
+        WebCallResult<string> StartUserStream(CancellationToken ct = default);
+
+        /// <summary>
+        /// Starts a user stream by requesting a listen key. This listen key can be used in subsequent requests to <see cref="BinanceSocketClient.SubscribeToUserDataUpdates"/>. The stream will close after 60 minutes unless a keep alive is send.
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Listen key</returns>
+        Task<WebCallResult<string>> StartUserStreamAsync(CancellationToken ct = default);
+
+        /// <summary>
+        /// Sends a keep alive for the current user stream listen key to keep the stream from closing. Stream auto closes after 60 minutes if no keep alive is send. 30 minute interval for keep alive is recommended.
+        /// </summary>
+        /// <param name="listenKey">The listen key to keep alive</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        WebCallResult<object> KeepAliveUserStream(string listenKey, CancellationToken ct = default);
+
+        /// <summary>
+        /// Sends a keep alive for the current user stream listen key to keep the stream from closing. Stream auto closes after 60 minutes if no keep alive is send. 30 minute interval for keep alive is recommended.
+        /// </summary>
+        /// <param name="listenKey">The listen key to keep alive</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<WebCallResult<object>> KeepAliveUserStreamAsync(string listenKey, CancellationToken ct = default);
+
+        /// <summary>
+        /// Stops the current user stream
+        /// </summary>
+        /// <param name="listenKey">The listen key to keep alive</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        WebCallResult<object> StopUserStream(string listenKey, CancellationToken ct = default);
+
+        /// <summary>
+        /// Stops the current user stream
+        /// </summary>
+        /// <param name="listenKey">The listen key to keep alive</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<WebCallResult<object>> StopUserStreamAsync(string listenKey, CancellationToken ct = default);
+
+    }
+}

--- a/Binance.Net/Interfaces/IBinanceFuturesClient.cs
+++ b/Binance.Net/Interfaces/IBinanceFuturesClient.cs
@@ -206,7 +206,7 @@ namespace Binance.Net.Interfaces
         /// <param name="limit">Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns>The funding rate history for the provided symbol</returns>
-        WebCallResult<IEnumerable<BinanceFuturesFundingRate>> GetFundingRates(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default);
+        WebCallResult<IEnumerable<BinanceFuturesFundingRateHistory>> GetFundingRates(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get funding rate history for the provided symbol
@@ -217,7 +217,7 @@ namespace Binance.Net.Interfaces
         /// <param name="limit">Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns>The funding rate history for the provided symbol</returns>
-        Task<WebCallResult<IEnumerable<BinanceFuturesFundingRate>>> GetFundingRatesAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default);
+        Task<WebCallResult<IEnumerable<BinanceFuturesFundingRateHistory>>> GetFundingRatesAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get data regarding the last 24 hours for the provided symbol
@@ -499,7 +499,7 @@ namespace Binance.Net.Interfaces
         /// Change the margin type for an open position
         /// </summary>
         /// <param name="symbol">Symbol to change the position type for</param>
-        /// <param name="type">The type of margin to use</param>
+        /// <param name="marginType">The type of margin to use</param>
         /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns>Whether the request was successful</returns>
@@ -509,7 +509,7 @@ namespace Binance.Net.Interfaces
         /// Change the margin type for an open position
         /// </summary>
         /// <param name="symbol">Symbol to change the position type for</param>
-        /// <param name="type">The type of margin to use</param>
+        /// <param name="marginType">The type of margin to use</param>
         /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns>Whether the request was successful</returns>

--- a/Binance.Net/Interfaces/IBinanceFuturesSocketClient.cs
+++ b/Binance.Net/Interfaces/IBinanceFuturesSocketClient.cs
@@ -10,7 +10,7 @@ using CryptoExchange.Net.Sockets;
 namespace Binance.Net.Interfaces
 {
     /// <summary>
-    /// Interface for the Binance socket client
+    /// Interface for the Binance Futures socket client
     /// </summary>
     public interface IBinanceFuturesSocketClient: ISocketClient
     {

--- a/Binance.Net/Interfaces/IBinanceFuturesSocketClient.cs
+++ b/Binance.Net/Interfaces/IBinanceFuturesSocketClient.cs
@@ -1,0 +1,439 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Binance.Net.Objects;
+using Binance.Net.Objects.Sockets;
+using CryptoExchange.Net.Interfaces;
+using CryptoExchange.Net.Objects;
+using CryptoExchange.Net.Sockets;
+
+namespace Binance.Net.Interfaces
+{
+    /// <summary>
+    /// Interface for the Binance socket client
+    /// </summary>
+    public interface IBinanceFuturesSocketClient: ISocketClient
+    {
+        /// <summary>
+        /// Set the API key and secret
+        /// </summary>
+        /// <param name="apiKey">The api key</param>
+        /// <param name="apiSecret">The api secret</param>
+        void SetApiCredentials(string apiKey, string apiSecret);
+
+        /// <summary>
+        /// Subscribes to the aggregated trades update stream for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToAggregatedTradeUpdates(string symbol, Action<BinanceStreamAggregatedTrade> onMessage);
+
+        /// <summary>
+        /// Subscribes to the aggregated trades update stream for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToAggregatedTradeUpdatesAsync(string symbol, Action<BinanceStreamAggregatedTrade> onMessage);
+
+        /// <summary>
+        /// Subscribes to the aggregated trades update stream for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToAggregatedTradeUpdates(IEnumerable<string> symbols, Action<BinanceStreamAggregatedTrade> onMessage);
+
+        /// <summary>
+        /// Subscribes to the aggregated trades update stream for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToAggregatedTradeUpdatesAsync(IEnumerable<string> symbols, Action<BinanceStreamAggregatedTrade> onMessage);
+
+        /// <summary>
+        /// Subscribes to the Mark price update stream for a single symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToMarkPriceUpdates(string symbol, Action<BinanceFuturesStreamMarkPrice> onMessage);
+
+        /// <summary>
+        /// Subscribes to the Mark price update stream for a single symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToMarkPriceUpdatesAsync(string symbol, Action<BinanceFuturesStreamMarkPrice> onMessage);
+
+        /// <summary>
+        /// Subscribes to the Mark price update stream for a list of symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToMarkPriceUpdates(IEnumerable<string> symbols, Action<BinanceFuturesStreamMarkPrice> onMessage);
+
+        /// <summary>
+        /// Subscribes to the Mark price update stream for a list of symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToMarkPriceUpdatesAsync(IEnumerable<string> symbols, Action<BinanceFuturesStreamMarkPrice> onMessage);
+
+        /// <summary>
+        /// Subscribes to the Mark price update stream for a all symbols
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToAllMarkPriceUpdates(Action<IEnumerable<BinanceFuturesStreamMarkPrice>> onMessage);
+
+        /// <summary>
+        /// Subscribes to the Mark price update stream for a all symbols
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToAllMarkPriceUpdatesAsync(Action<IEnumerable<BinanceFuturesStreamMarkPrice>> onMessage);
+
+        /// <summary>
+        /// Subscribes to the candlestick update stream for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="interval">The interval of the candlesticks</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToKlineUpdates(string symbol, KlineInterval interval, Action<BinanceStreamKlineData> onMessage);
+
+        /// <summary>
+        /// Subscribes to the candlestick update stream for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="interval">The interval of the candlesticks</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<BinanceStreamKlineData> onMessage);
+
+        /// <summary>
+        /// Subscribes to the candlestick update stream for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="interval">The interval of the candlesticks</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToKlineUpdates(IEnumerable<string> symbols, KlineInterval interval, Action<BinanceStreamKlineData> onMessage);
+
+        /// <summary>
+        /// Subscribes to the candlestick update stream for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="interval">The interval of the candlesticks</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols, KlineInterval interval, Action<BinanceStreamKlineData> onMessage);
+
+        /// <summary>
+        /// Subscribes to mini ticker updates stream for a specific symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to subscribe to</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToSymbolMiniTickerUpdates(string symbol, Action<BinanceFuturesStreamMiniTick> onMessage);
+
+        /// <summary>
+        /// Subscribes to mini ticker updates stream for a specific symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to subscribe to</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToSymbolMiniTickerUpdatesAsync(string symbol, Action<BinanceFuturesStreamMiniTick> onMessage);
+
+        /// <summary>
+        /// Subscribes to mini ticker updates stream for a list of symbol
+        /// </summary>
+        /// <param name="symbols">The symbols to subscribe to</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToSymbolMiniTickerUpdates(IEnumerable<string> symbols, Action<BinanceFuturesStreamMiniTick> onMessage);
+
+        /// <summary>
+        /// Subscribes to mini ticker updates stream for a list of symbol
+        /// </summary>
+        /// <param name="symbols">The symbols to subscribe to</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToSymbolMiniTickerUpdatesAsync(IEnumerable<string> symbols, Action<BinanceFuturesStreamMiniTick> onMessage);
+
+        /// <summary>
+        /// Subscribes to mini ticker updates stream for all symbols
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToAllMiniTickerUpdates(Action<IEnumerable<BinanceFuturesStreamMiniTick>> onMessage);
+
+        /// <summary>
+        /// Subscribes to mini ticker updates stream for all symbols
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToAllMiniTickerUpdatesAsync(Action<IEnumerable<BinanceFuturesStreamMiniTick>> onMessage);
+
+        /// <summary>
+        /// Subscribes to ticker updates stream for a specific symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to subscribe to</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToSymbolTickerUpdates(string symbol, Action<BinanceStreamTick> onMessage);
+
+        /// <summary>
+        /// Subscribes to ticker updates stream for a specific symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to subscribe to</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToSymbolTickerUpdatesAsync(string symbol, Action<BinanceStreamTick> onMessage);
+
+        /// <summary>
+        /// Subscribes to ticker updates stream for a specific symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to subscribe to</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToSymbolTickerUpdates(IEnumerable<string> symbol, Action<BinanceStreamTick> onMessage);
+
+        /// <summary>
+        /// Subscribes to ticker updates stream for a specific symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to subscribe to</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToSymbolTickerUpdatesAsync(IEnumerable<string> symbol, Action<BinanceStreamTick> onMessage);
+
+        /// <summary>
+        /// Subscribes to ticker updates stream for all symbols
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToAllTickerUpdates(Action<IEnumerable<BinanceStreamTick>> onMessage);
+
+        /// <summary>
+        /// Subscribes to ticker updates stream for all symbols
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToAllTickerUpdatesAsync(Action<IEnumerable<BinanceStreamTick>> onMessage);
+
+        /// <summary>
+        /// Subscribes to the book ticker update stream for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToBookTickerUpdates(string symbol, Action<BinanceBookTick> onMessage);
+
+        /// <summary>
+        /// Subscribes to the book ticker update stream for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(string symbol, Action<BinanceBookTick> onMessage);
+
+        /// <summary>
+        /// Subscribes to the book ticker update stream for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToBookTickerUpdates(IEnumerable<string> symbols, Action<BinanceBookTick> onMessage);
+
+        /// <summary>
+        /// Subscribes to the book ticker update stream for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(IEnumerable<string> symbols, Action<BinanceBookTick> onMessage);
+
+        /// <summary>
+        /// Subscribes to all book ticker update streams
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToAllBookTickerUpdates(Action<BinanceBookTick> onMessage);
+
+        /// <summary>
+        /// Subscribes to all book ticker update streams
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToAllBookTickerUpdatesAsync(Action<BinanceBookTick> onMessage);
+
+        //TODO Liquidation Order Streams
+        /// <summary>
+        /// Subscribes to specific symbol forced liquidations stream
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToLiquidationUpdates(string symbol, Action<BinanceFuturesStreamLiquidation> onMessage);
+
+        /// <summary>
+        /// Subscribes to specific symbol forced liquidations stream
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(string symbol, Action<BinanceFuturesStreamLiquidation> onMessage);
+
+        /// <summary>
+        /// Subscribes to list of symbol forced liquidations stream
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToLiquidationUpdates(IEnumerable<string> symbols, Action<BinanceFuturesStreamLiquidation> onMessage);
+
+        /// <summary>
+        /// Subscribes to list of symbol forced liquidations stream
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(IEnumerable<string> symbols, Action<BinanceFuturesStreamLiquidation> onMessage);
+
+        /// <summary>
+        /// Subscribes to all forced liquidations stream
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToAllLiquidationUpdates(Action<BinanceFuturesStreamLiquidation> onMessage);
+
+        /// <summary>
+        /// Subscribes to all forced liquidations stream
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToAllLiquidationUpdatesAsync(Action<BinanceFuturesStreamLiquidation> onMessage);
+
+        /// <summary>
+        /// Subscribes to the depth updates for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to subscribe on</param>
+        /// <param name="levels">The amount of entries to be returned in the update</param>
+        /// <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToPartialOrderBookUpdates(string symbol, int levels, int? updateInterval, Action<BinanceOrderBook> onMessage);
+
+        /// <summary>
+        /// Subscribes to the depth updates for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol to subscribe on</param>
+        /// <param name="levels">The amount of entries to be returned in the update</param>
+        /// <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToPartialOrderBookUpdatesAsync(string symbol, int levels, int? updateInterval, Action<BinanceOrderBook> onMessage);
+
+        /// <summary>
+        /// Subscribes to the depth updates for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols to subscribe on</param>
+        /// <param name="levels">The amount of entries to be returned in the update of each symbol</param>
+        /// <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToPartialOrderBookUpdates(IEnumerable<string> symbols, int levels, int? updateInterval, Action<BinanceOrderBook> onMessage);
+
+        /// <summary>
+        /// Subscribes to the depth updates for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols to subscribe on</param>
+        /// <param name="levels">The amount of entries to be returned in the update of each symbol</param>
+        /// <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToPartialOrderBookUpdatesAsync(IEnumerable<string> symbols, int levels, int? updateInterval, Action<BinanceOrderBook> onMessage);
+
+        /// <summary>
+        /// Subscribes to the order book updates for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToOrderBookUpdates(string symbol, int? updateInterval, Action<BinanceOrderBook> onMessage);
+
+        /// <summary>
+        /// Subscribes to the order book updates for the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, int? updateInterval, Action<BinanceOrderBook> onMessage);
+
+        /// <summary>
+        /// Subscribes to the depth update stream for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToOrderBookUpdates(IEnumerable<string> symbols, int? updateInterval, Action<BinanceOrderBook> onMessage);
+
+        /// <summary>
+        /// Subscribes to the depth update stream for the provided symbols
+        /// </summary>
+        /// <param name="symbols">The symbols</param>
+        /// <param name="updateInterval">Update interval in milliseconds, either 100 or 1000. Defaults to 1000</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, int? updateInterval, Action<BinanceOrderBook> onMessage);
+        //TODO BinanceStreamPositionUpdate
+        /// <summary>
+        /// Subscribes to the account update stream. Prior to using this, the <see cref="BinanceClient.StartUserStream"/> method should be called.
+        /// </summary>
+        /// <param name="listenKey">Listen key retrieved by the StartUserStream method</param>
+        /// <param name="onAccountInfoMessage">The event handler for whenever an account info update is received</param>
+        /// <param name="onOrderUpdateMessage">The event handler for whenever an order status update is received</param>
+        /// <param name="onOcoOrderUpdateMessage">The event handler for whenever an oco status update is received</param>
+        /// <param name="onAccountPositionMessage">The event handler for whenever an account position update is received. Account position updates are a list of changed funds</param>
+        /// <param name="onAccountBalanceUpdate">The event handler for whenever a deposit or withdrawal has been processed and the account balance has changed</param>
+        /// <param name="onListenKeyExpired">Responds when the listen key for the stream has expired. Initiate a new instance of the stream here</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        CallResult<UpdateSubscription> SubscribeToUserDataUpdates(
+            string listenKey, 
+            Action<BinanceFuturesStreamAccountInfo> onAccountInfoMessage, 
+            Action<BinanceFuturesStreamOrderUpdate> onOrderUpdateMessage,
+            Action<BinanceStreamOrderList> onOcoOrderUpdateMessage,
+            Action<IEnumerable<BinanceStreamBalance>> onAccountPositionMessage,
+            Action<BinanceStreamBalanceUpdate>? onAccountBalanceUpdate,
+            Action<BinanceStreamEvent> onListenKeyExpired);
+
+        /// <summary>
+        /// Subscribes to the account update stream. Prior to using this, the <see cref="BinanceClient.StartUserStream"/> method should be called.
+        /// </summary>
+        /// <param name="listenKey">Listen key retrieved by the StartUserStream method</param>
+        /// <param name="onAccountInfoMessage">The event handler for whenever an account info update is received</param>
+        /// <param name="onOrderUpdateMessage">The event handler for whenever an order status update is received</param>
+        /// <param name="onOcoOrderUpdateMessage">The event handler for whenever an oco order status update is received</param>
+        /// <param name="onAccountPositionMessage">The event handler for whenever an account position update is received. Account position updates are a list of changed funds</param>
+        /// <param name="onAccountBalanceUpdate">The event handler for whenever a deposit or withdrawal has been processed and the account balance has changed</param>
+        /// <param name="onListenKeyExpired">Responds when the listen key for the stream has expired. Initiate a new instance of the stream here</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToUserDataUpdatesAsync(
+            string listenKey, 
+            Action<BinanceFuturesStreamAccountInfo> onAccountInfoMessage, 
+            Action<BinanceFuturesStreamOrderUpdate> onOrderUpdateMessage,
+            Action<BinanceStreamOrderList> onOcoOrderUpdateMessage,
+            Action<IEnumerable<BinanceStreamBalance>> onAccountPositionMessage,
+            Action<BinanceStreamBalanceUpdate>? onAccountBalanceUpdate,
+            Action<BinanceStreamEvent> onListenKeyExpired);
+    }
+}

--- a/Binance.Net/Objects/BinanceFuturesAccountBalance.cs
+++ b/Binance.Net/Objects/BinanceFuturesAccountBalance.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using CryptoExchange.Net.Converters;
+
+namespace Binance.Net.Objects
+{
+    /// <summary>
+    /// Information about an account
+    /// </summary>
+    public class BinanceFuturesAccountBalance
+    {
+        /// <summary>
+        /// The asset this balance is for
+        /// </summary>
+        public string? Asset { get; set; }
+        /// <summary>
+        /// The total balance of this asset
+        /// </summary>
+        public decimal Balance { get; set; }
+        /// <summary>
+        /// The total balance available for withdraw for this asset
+        /// </summary>
+        public decimal WithdrawAvailable { get; set; }
+    }
+
+}

--- a/Binance.Net/Objects/BinanceFuturesChangeMarginType.cs
+++ b/Binance.Net/Objects/BinanceFuturesChangeMarginType.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using CryptoExchange.Net.Converters;
+using Newtonsoft.Json;
+
+namespace Binance.Net.Objects
+{
+    /// <summary>
+    /// Result from a change margin type request
+    /// </summary>
+    public class BinanceFuturesChangeMarginTypeResult
+    {
+        /// <summary>
+        /// Response code
+        /// </summary>
+        public int Code { get; set; }
+        /// <summary>
+        /// Response message
+        /// </summary>
+        [JsonProperty("msg")]
+        public string? Message { get; set; }
+    }
+}

--- a/Binance.Net/Objects/BinanceFuturesClientOptions.cs
+++ b/Binance.Net/Objects/BinanceFuturesClientOptions.cs
@@ -45,6 +45,14 @@ namespace Binance.Net.Objects
         }
 
         /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="baseAddress">Сustom url to connect via mirror website</param>
+        public BinanceFuturesClientOptions(string baseAddress): base(baseAddress)
+        {
+        }
+
+        /// <summary>
         /// Return a copy of these options
         /// </summary>
         /// <returns></returns>
@@ -91,7 +99,15 @@ namespace Binance.Net.Objects
         /// </summary>
         public BinanceFuturesSocketClientOptions(): base("wss://fstream.binance.com/ws/")
         {
-        }        
+        }  
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="baseAddress">Сustom url to connect via mirror website</param>
+        public BinanceFuturesSocketClientOptions(string baseAddress): base(baseAddress)
+        {
+        }      
 
         /// <summary>
         /// Return a copy of these options

--- a/Binance.Net/Objects/BinanceFuturesClientOptions.cs
+++ b/Binance.Net/Objects/BinanceFuturesClientOptions.cs
@@ -1,0 +1,108 @@
+using System;
+using CryptoExchange.Net.Objects;
+
+namespace Binance.Net.Objects
+{
+    /// <summary>
+    /// Options for the binance client
+    /// </summary>
+    public class BinanceFuturesClientOptions : RestClientOptions
+    {
+        /// <summary>
+        /// Whether or not to automatically sync the local time with the server time
+        /// </summary>
+        public bool AutoTimestamp { get; set; } = true;
+
+        /// <summary>
+        /// Interval for refreshing the auto timestamp calculation
+        /// </summary>
+        public TimeSpan AutoTimestampRecalculationInterval { get; set; } = TimeSpan.FromHours(3);
+
+        /// <summary>
+        /// A manual offset for the timestamp. Should only be used if AutoTimestamp and regular time synchronization on the OS is not reliable enough
+        /// </summary>
+        public TimeSpan TimestampOffset { get; set; } = TimeSpan.Zero;
+
+        /// <summary>
+        /// Whether to check the trade rules when placing new orders and what to do if the trade isn't valid
+        /// </summary>
+        public TradeRulesBehaviour TradeRulesBehaviour { get; set; } = TradeRulesBehaviour.None;
+        /// <summary>
+        /// How often the trade rules should be updated. Only used when TradeRulesBehaviour is not None
+        /// </summary>
+        public TimeSpan TradeRulesUpdateInterval { get; set; } = TimeSpan.FromMinutes(60);
+
+        /// <summary>
+        /// The default receive window for requests
+        /// </summary>
+        public TimeSpan ReceiveWindow { get; set; } = TimeSpan.FromSeconds(5);
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        public BinanceFuturesClientOptions(): base("https://fapi.binance.com")
+        {
+        }
+
+        /// <summary>
+        /// Return a copy of these options
+        /// </summary>
+        /// <returns></returns>
+        public BinanceFuturesClientOptions Copy()
+        {
+            var copy = Copy<BinanceFuturesClientOptions>();
+            copy.AutoTimestamp = AutoTimestamp;
+            copy.AutoTimestampRecalculationInterval = AutoTimestampRecalculationInterval;
+            copy.TimestampOffset = TimestampOffset;
+            copy.TradeRulesBehaviour = TradeRulesBehaviour;
+            copy.TradeRulesUpdateInterval = TradeRulesUpdateInterval;
+            copy.ReceiveWindow = ReceiveWindow;
+            return copy;
+        }
+    }
+
+    /// <summary>
+    /// Binance socket client options
+    /// </summary>
+    public class BinanceFuturesSocketClientOptions : SocketClientOptions
+    {
+        /// <summary>
+        /// The base address for combined data in socket connections
+        /// </summary>
+        public string BaseSocketCombinedAddress { get; set; } = "wss://fstream.binance.com/";
+
+        /// <summary>
+        /// The amount of subscriptions that should be made on a single socket connection. Not all exchanges support multiple subscriptions on a single socket.
+        /// Setting this to a higher number increases subscription speed, but having more subscriptions on a single connection will also increase the amount of traffic on that single connection.
+        /// Not available on Binance.
+        /// </summary>
+        public new int? SocketSubscriptionsCombineTarget
+        {
+            get => 1;
+            set
+            {
+                if (value != 1)
+                    throw new ArgumentException("Can't change SocketSubscriptionsCombineTarget; server implementation does not allow multiple subscription on a socket");
+            }
+        }
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        public BinanceFuturesSocketClientOptions(): base("wss://fstream.binance.com/ws/")
+        {
+        }        
+
+        /// <summary>
+        /// Return a copy of these options
+        /// </summary>
+        /// <returns></returns>
+        public BinanceFuturesSocketClientOptions Copy()
+        {
+            var copy = Copy<BinanceFuturesSocketClientOptions>();
+            copy.BaseSocketCombinedAddress = BaseSocketCombinedAddress;
+            return copy;
+        }
+    }
+
+}

--- a/Binance.Net/Objects/BinanceFuturesExchangeInfo.cs
+++ b/Binance.Net/Objects/BinanceFuturesExchangeInfo.cs
@@ -1,0 +1,35 @@
+﻿using Newtonsoft.Json;
+using System;
+using CryptoExchange.Net.Converters;
+using System.Collections.Generic;
+
+namespace Binance.Net.Objects
+{
+    /// <summary>
+    /// Exchange info
+    /// </summary>
+    public class BinanceFuturesExchangeInfo
+    {
+        /// <summary>
+        /// The timezone the server uses
+        /// </summary>
+        public string TimeZone { get; set; } = "";
+        /// <summary>
+        /// The current server time
+        /// </summary>
+        [JsonConverter(typeof(TimestampConverter))]
+        public DateTime ServerTime { get; set; }
+        /// <summary>
+        /// The rate limits used
+        /// </summary>
+        public IEnumerable<BinanceRateLimit> RateLimits { get; set; } = new List<BinanceRateLimit>();
+        /// <summary>
+        /// All symbols supported
+        /// </summary>
+        public IEnumerable<BinanceFuturesSymbol> Symbols { get; set; } = new List<BinanceFuturesSymbol>();
+        /// <summary>
+        /// Filters
+        /// </summary>
+        public IEnumerable<object> ExchangeFilters { get; set; } = new List<object>();
+    }
+}

--- a/Binance.Net/Objects/BinanceFuturesFundingRateHistory.cs
+++ b/Binance.Net/Objects/BinanceFuturesFundingRateHistory.cs
@@ -1,0 +1,26 @@
+using CryptoExchange.Net.Converters;
+using Newtonsoft.Json;
+using System;
+
+namespace Binance.Net.Objects
+{
+    /// <summary>
+    /// Funding rate information for Futures trading
+    /// </summary>
+    public class BinanceFuturesFundingRateHistory
+    {
+        /// <summary>
+        /// The symbol the information is about
+        /// </summary>
+        public string Symbol { get; set; } = "";
+        /// <summary>
+        /// The finding rate for the given symbol and time
+        /// </summary>
+        public decimal FundingRate { get; set; }
+        /// <summary>
+        /// The time the funding rate is applied
+        /// </summary>
+        [JsonConverter(typeof(TimestampConverter))]
+        public DateTime FundingTime { get; set; }
+    }
+}

--- a/Binance.Net/Objects/BinanceFuturesIncomeHistory.cs
+++ b/Binance.Net/Objects/BinanceFuturesIncomeHistory.cs
@@ -1,0 +1,41 @@
+﻿using Newtonsoft.Json;
+using System;
+using CryptoExchange.Net.Converters;
+using Binance.Net.Converters;
+
+namespace Binance.Net.Objects
+{
+    /// <summary>
+    /// Futures income history result
+    /// </summary>
+    public class BinanceFuturesIncomeHistory
+    {
+        /// <summary>
+        /// Symbol for the resulting income history, may be null if not associated with a trading pair
+        /// </summary>
+        public string? Symbol { get; set; }
+        /// <summary>
+        /// Type of income
+        /// </summary>
+        [JsonProperty("incomeType"), JsonConverter(typeof(IncomeTypeConverter))]
+        public IncomeType IncomeType { get; set; }
+        /// <summary>
+        /// Amount of income
+        /// </summary>
+        public decimal Income { get; set; }
+        /// <summary>
+        /// Base asset for the income
+        /// </summary>
+        public string? Asset { get; set; }
+        /// <summary>
+        /// Additional info
+        /// </summary>
+        public string? Info { get; set; }
+        /// <summary>
+        /// Time of the income
+        /// </summary>
+        [JsonConverter(typeof(TimestampConverter))]
+        public DateTime Time { get; set; }
+    }
+
+}

--- a/Binance.Net/Objects/BinanceFuturesInitialLeverageChangeResult.cs
+++ b/Binance.Net/Objects/BinanceFuturesInitialLeverageChangeResult.cs
@@ -1,0 +1,22 @@
+﻿namespace Binance.Net.Objects
+{
+    /// <summary>
+    /// Response to the change in initial leverage request
+    /// </summary>
+    public class BinanceFuturesInitialLeverageChangeResult
+    {
+        /// <summary>
+        /// New leverage multiplier
+        /// </summary>
+        public int Leverage { get; set; }
+        /// <summary>
+        /// Maximum value that can be held
+        /// </summary>
+        public decimal MaxNotionalValue { get; set; }
+        /// <summary>
+        /// Symbol the request is for
+        /// </summary>
+        public string? Symbol { get; set; }
+    }
+
+}

--- a/Binance.Net/Objects/BinanceFuturesMarginChangeHistoryResult.cs
+++ b/Binance.Net/Objects/BinanceFuturesMarginChangeHistoryResult.cs
@@ -1,0 +1,37 @@
+﻿using Newtonsoft.Json;
+using Binance.Net.Converters;
+using CryptoExchange.Net.Converters;
+using System;
+
+namespace Binance.Net.Objects
+{
+    /// <summary>
+    /// Result of the margin change history request
+    /// </summary>
+    public class BinanceFuturesMarginChangeHistoryResult
+    {
+        /// <summary>
+        /// Request amount of margin used
+        /// </summary>
+        public decimal Amount { get; set; }
+        /// <summary>
+        /// Base asset used for margin
+        /// </summary>
+        public string? Asset { get; set; }
+        /// <summary>
+        /// Symbol margin is placed on
+        /// </summary>
+        public string? Symbol { get; set; }
+        /// <summary>
+        /// Time of the margin change request
+        /// </summary>
+        [JsonConverter(typeof(TimestampConverter))]
+        public DateTime Time { get; set; }
+        /// <summary>
+        /// Direction of the margin change request
+        /// </summary>
+        [JsonConverter(typeof(FuturesMarginChangeDirectionTypeConverter))]
+        public FuturesMarginChangeDirectionType Type { get; set; }
+    }
+
+}

--- a/Binance.Net/Objects/BinanceFuturesMarkPrice.cs
+++ b/Binance.Net/Objects/BinanceFuturesMarkPrice.cs
@@ -1,0 +1,30 @@
+using Newtonsoft.Json;
+using CryptoExchange.Net.Converters;
+using System;
+
+namespace Binance.Net.Objects
+{
+    /// <summary>
+    /// Mark Price and Funding Rate
+    /// </summary>
+    public class BinanceFuturesMarkPrice
+    {
+        /// <summary>
+        /// The symbol the information is about
+        /// </summary>
+        public string Symbol { get; set; } = "";
+        /// <summary>
+        /// The current market price
+        /// </summary>
+        public decimal MarkPrice { get; set; }
+        /// <summary>
+        /// The last funding rate
+        /// </summary>
+        public decimal LastFundingRate { get; set; }
+        /// <summary>
+        /// The time the funding rate is applied
+        /// </summary>
+        [JsonConverter(typeof(TimestampConverter))]
+        public DateTime NextFundingTime { get; set; }
+    }
+}

--- a/Binance.Net/Objects/BinanceFuturesPosition.cs
+++ b/Binance.Net/Objects/BinanceFuturesPosition.cs
@@ -1,0 +1,61 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using CryptoExchange.Net.Converters;
+
+namespace Binance.Net.Objects
+{
+    /// <summary>
+    /// Information about an account
+    /// </summary>
+    public class BinanceFuturesPosition
+    {
+        /// <summary>
+        /// The entry price of the position
+        /// </summary>
+        public decimal EntryPrice { get; set; }
+        /// <summary>
+        /// Type of margin used for the position
+        /// </summary>
+        public FuturesMarginType MarginType { get; set; }
+        /// <summary>
+        /// Does the position add margin automatically?
+        /// </summary>
+        public bool IsAutoAddMargin { get; set; }
+        /// <summary>
+        /// Amount of isolated margin
+        /// </summary>
+        public decimal IsolatedMargin { get; set; }
+        /// <summary>
+        /// The current initial leverage of the position
+        /// </summary>
+        public int Leverage { get; set; }
+        /// <summary>
+        /// The Liquidation price of the position
+        /// </summary>
+        public decimal LiquidationPrice { get; set; }
+        /// <summary>
+        /// The Market price of the position
+        /// </summary>
+        public decimal MarkPrice { get; set; }
+        /// <summary>
+        /// The notional value limit of current initial leverage
+        /// </summary>
+        public decimal MaxNotionalValue { get; set; }
+        /// <summary>
+        /// The quantity of the position
+        /// </summary>
+        [JsonProperty("positionAmt")]
+        public decimal Quantity { get; set; }
+        /// <summary>
+        /// The symbol the position is for
+        /// </summary>
+        public string Symbol { get; set; } = "";
+        /// <summary>
+        /// The price of the unrealized PnL
+        /// </summary>
+        [JsonProperty("unRealizedProfit")]
+        public decimal UnrealizedPnL { get; set; }
+    }
+
+}

--- a/Binance.Net/Objects/BinanceFuturesPositionMarginResult.cs
+++ b/Binance.Net/Objects/BinanceFuturesPositionMarginResult.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json;
+using Binance.Net.Converters;
+
+namespace Binance.Net.Objects
+{
+    /// <summary>
+    /// Result of the requested margin amount change
+    /// </summary>
+    public class BinanceFuturesPositionMarginResult
+    {
+        /// <summary>
+        /// New margin amount
+        /// </summary>
+        public decimal Amount { get; set; }
+        /// <summary>
+        /// Request response code
+        /// </summary>
+        public int Code { get; set; }
+        /// <summary>
+        /// Maximum margin value
+        /// </summary>
+        public decimal MaxNotionalValue { get; set; }
+        /// <summary>
+        /// Direction of the requested margin change
+        /// </summary>
+        [JsonConverter(typeof(FuturesMarginChangeDirectionTypeConverter))]
+        public FuturesMarginChangeDirectionType Type { get; set; }
+    }
+
+}

--- a/Binance.Net/Objects/BinanceFuturesStreamAccountInfo.cs
+++ b/Binance.Net/Objects/BinanceFuturesStreamAccountInfo.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using CryptoExchange.Net.Converters;
+using Newtonsoft.Json;
+
+namespace Binance.Net.Objects
+{
+    /// <summary>
+    /// Information about an account
+    /// </summary>
+    public class BinanceFuturesStreamAccountInfo: BinanceStreamEvent
+    {
+        /// <summary>
+        /// List of assets with their current balances
+        /// </summary>
+        [JsonProperty("B")]
+        public List<BinanceFuturesStreamBalance>? Balances { get; set; }
+        /// <summary>
+        /// List of assets with their current positions
+        /// </summary>
+        [JsonProperty("P")]
+        public List<BinanceFuturesStreamPosition>? Positions { get; set; }
+    }
+
+    /// <summary>
+    /// Information about an asset balance
+    /// </summary>
+    public class BinanceFuturesStreamBalance
+    {
+        /// <summary>
+        /// The asset this balance is for
+        /// </summary>
+        [JsonProperty("a")]
+        public string? Asset { get; set; }
+        /// <summary>
+        /// The amount that isn't locked in a trade
+        /// </summary>
+        [JsonProperty("wb")]
+        public decimal WalletBalance { get; set; }
+    }
+
+    /// <summary>
+    /// Information about an asset position
+    /// </summary>
+    public class BinanceFuturesStreamPosition
+    {
+        /// <summary>
+        /// The symbol this balance is for
+        /// </summary>
+        [JsonProperty("s")]
+        public string? Symbol { get; set; }
+        /// <summary>
+        /// The amount of the position
+        /// </summary>
+        [JsonProperty("pa")]
+        public decimal PositionAmount { get; set; }
+        /// <summary>
+        /// The entry price
+        /// </summary>
+        [JsonProperty("ep")]
+        public decimal EntryPrice { get; set; }
+        /// <summary>
+        /// The accumulated realized PnL
+        /// </summary>
+        [JsonProperty("cr")]
+        public decimal RealizedPnL { get; set; }
+    }
+}

--- a/Binance.Net/Objects/BinanceFuturesStreamLiquidation.cs
+++ b/Binance.Net/Objects/BinanceFuturesStreamLiquidation.cs
@@ -17,7 +17,7 @@ namespace Binance.Net.Objects
         public string? Symbol { get; set; }
 
         /// <summary>
-        /// Liquidation Side
+        /// Liquidation Sided
         /// </summary>
         [JsonProperty("S")]
         public OrderSide Side { get; set; }
@@ -59,7 +59,7 @@ namespace Binance.Net.Objects
         public OrderStatus OrderStatus { get; set; }
         
         /// <summary>
-        /// Liquidation Last Fille Quantity
+        /// Liquidation Last Filled Quantity
         /// </summary>
         [JsonProperty("l")]
         public decimal LastFilledQty { get; set; }

--- a/Binance.Net/Objects/BinanceFuturesStreamLiquidation.cs
+++ b/Binance.Net/Objects/BinanceFuturesStreamLiquidation.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using CryptoExchange.Net.Converters;
+using Newtonsoft.Json;
+
+namespace Binance.Net.Objects
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class BinanceFuturesStreamLiquidation: BinanceStreamEvent
+    {
+        /// <summary>
+        /// Symbol
+        /// </summary>
+        [JsonProperty("s")]
+        public string? Symbol { get; set; }
+
+        /// <summary>
+        /// Liquidation Side
+        /// </summary>
+        [JsonProperty("S")]
+        public OrderSide Side { get; set; }
+        
+        /// <summary>
+        /// Liquidation order type
+        /// </summary>
+        [JsonProperty("o")]
+        public OrderType OrderType { get; set; }
+        
+        /// <summary>
+        /// Liquidation Time in Force
+        /// </summary>
+        [JsonProperty("f")]
+        public TimeInForce TimeInForce { get; set; }
+        
+        /// <summary>
+        /// Liquidation Original Quantity
+        /// </summary>
+        [JsonProperty("q")]
+        public decimal OriginalQuantity { get; set; }
+        
+        /// <summary>
+        /// Liquidation order price
+        /// </summary>
+        [JsonProperty("p")]
+        public decimal Price { get; set; }
+        
+        /// <summary>
+        /// Liquidation Average Price
+        /// </summary>
+        [JsonProperty("ap")]
+        public decimal AveragePrice { get; set; }
+        
+        /// <summary>
+        /// Liquidation Order Status
+        /// </summary>
+        [JsonProperty("X")]
+        public OrderStatus OrderStatus { get; set; }
+        
+        /// <summary>
+        /// Liquidation Last Fille Quantity
+        /// </summary>
+        [JsonProperty("l")]
+        public decimal LastFilledQty { get; set; }
+        
+        /// <summary>
+        /// Liquidation Accumulated fill quantity
+        /// </summary>
+        [JsonProperty("z")]
+        public decimal CumulativeFilledQty { get; set; }
+        
+        /// <summary>
+        /// Liquidation Trade Time
+        /// </summary>
+        [JsonProperty("T"), JsonConverter(typeof(TimestampConverter))]
+        public DateTime Time { get; set; }
+    }
+}

--- a/Binance.Net/Objects/BinanceFuturesStreamMarkPrice.cs
+++ b/Binance.Net/Objects/BinanceFuturesStreamMarkPrice.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using CryptoExchange.Net.Converters;
+using Newtonsoft.Json;
+
+namespace Binance.Net.Objects
+{
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public class BinanceFuturesStreamMarkPrice: BinanceStreamEvent
+    {
+        /// <summary>
+        /// Symbol
+        /// </summary>
+        [JsonProperty("s")]
+        public string? Symbol { get; set; }
+
+        /// <summary>
+        /// Mark Price
+        /// </summary>
+        [JsonProperty("p")]
+        public decimal MarkPrice { get; set; }
+        
+        /// <summary>
+        /// Next Funding Rate
+        /// </summary>
+        [JsonProperty("p")]
+        public decimal FundingRate { get; set; }
+        
+        /// <summary>
+        /// Next Funding Time
+        /// </summary>
+        [JsonProperty("T"), JsonConverter(typeof(TimestampConverter))]
+        public DateTime FundingTime { get; set; }
+    }
+}

--- a/Binance.Net/Objects/BinanceFuturesStreamMiniTick.cs
+++ b/Binance.Net/Objects/BinanceFuturesStreamMiniTick.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using CryptoExchange.Net.Converters;
+using Newtonsoft.Json;
+
+namespace Binance.Net.Objects
+{
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public class BinanceFuturesStreamMiniTick
+    {
+        /// <summary>
+        /// Symbol
+        /// </summary>
+        [JsonProperty("s")]
+        public string? Symbol { get; set; }
+
+        /// <summary>
+        /// Close Price
+        /// </summary>
+        [JsonProperty("c")]
+        public decimal Close { get; set; }
+        
+        /// <summary>
+        /// Open Price
+        /// </summary>
+        [JsonProperty("o")]
+        public decimal Open { get; set; }
+        
+        /// <summary>
+        /// High
+        /// </summary>
+        [JsonProperty("h")]
+        public decimal High { get; set; }
+        
+        /// <summary>
+        /// Low
+        /// </summary>
+        [JsonProperty("l")]
+        public decimal Low { get; set; }
+        
+        /// <summary>
+        /// Total traded base asset volume
+        /// </summary>
+        [JsonProperty("v")]
+        public decimal BaseVolume { get; set; }
+        
+        /// <summary>
+        /// Total traded quote asset volume
+        /// </summary>
+        [JsonProperty("q")]
+        public decimal QuoteVolume { get; set; }
+        
+    }
+}

--- a/Binance.Net/Objects/BinanceFuturesStreamOrderUpdate.cs
+++ b/Binance.Net/Objects/BinanceFuturesStreamOrderUpdate.cs
@@ -1,0 +1,114 @@
+using System;
+using Newtonsoft.Json;
+using Binance.Net.Converters;
+using CryptoExchange.Net.Converters;
+
+namespace Binance.Net.Objects
+{
+    /// <summary>
+    /// Update data about an order
+    /// </summary>
+    public class BinanceFuturesStreamOrderUpdate: BinanceStreamEvent
+    {
+        /// <summary>
+        /// The symbol the order is for
+        /// </summary>
+        [JsonProperty("s")]
+        public string Symbol { get; set; } = "";
+        /// <summary>
+        /// The new client order id
+        /// </summary>
+        [JsonProperty("c")]
+        public string ClientOrderId { get; set; } = "";
+        /// <summary>
+        /// The side of the order
+        /// </summary>
+        [JsonProperty("S"), JsonConverter(typeof(OrderSideConverter))]
+        public OrderSide Side { get; set; }
+        /// <summary>
+        /// The type of the order
+        /// </summary>
+        [JsonProperty("o"), JsonConverter(typeof(OrderTypeConverter))]
+        public OrderType Type { get; set; }
+        /// <summary>
+        /// The timespan the order is active
+        /// </summary>
+        [JsonProperty("f"), JsonConverter(typeof(TimeInForceConverter))]
+        public TimeInForce TimeInForce { get; set; }
+        /// <summary>
+        /// The quantity of the order
+        /// </summary>
+        [JsonProperty("q")]
+        public decimal Quantity { get; set; }
+        /// <summary>
+        /// The price of the order
+        /// </summary>
+        [JsonProperty("p")]
+        public decimal Price { get; set; }
+        /// <summary>
+        /// The average price of the order
+        /// </summary>
+        [JsonProperty("ap")]
+        public decimal AveragePrice { get; set; }
+        /// <summary>
+        /// The stop price of the order
+        /// </summary>
+        [JsonProperty("sp")]
+        public decimal StopPrice { get; set; }
+        /// <summary>
+        /// The execution type
+        /// </summary>
+        [JsonProperty("x"), JsonConverter(typeof(ExecutionTypeConverter))]
+        public ExecutionType ExecutionType { get; set; }
+        /// <summary>
+        /// The status of the order
+        /// </summary>
+        [JsonProperty("X"), JsonConverter(typeof(OrderStatusConverter))]
+        public OrderStatus Status { get; set; }
+        /// <summary>
+        /// The id of the order as assigned by Binance
+        /// </summary>
+        [JsonProperty("i")]
+        public long OrderId { get; set; }
+        /// <summary>
+        /// The quantity of the last filled trade of this order
+        /// </summary>
+        [JsonProperty("l")]
+        public decimal QuantityOfLastFilledTrade { get; set; }
+        /// <summary>
+        /// The quantity of all trades that were filled for this order
+        /// </summary>
+        [JsonProperty("z")]
+        public decimal AccumulatedQuantityOfFilledTrades { get; set; }
+        /// <summary>
+        /// The price of the last filled trade
+        /// </summary>
+        [JsonProperty("L")]
+        public decimal PriceLastFilledTrade { get; set; }
+        /// <summary>
+        /// The commission payed
+        /// </summary>
+        [JsonProperty("n")]
+        public decimal Commission { get; set; }
+        /// <summary>
+        /// The asset the commission was taken from
+        /// </summary>
+        [JsonProperty("N")]
+        public string CommissionAsset { get; set; } = "";
+        /// <summary>
+        /// The time of the update
+        /// </summary>
+        [JsonProperty("T"), JsonConverter(typeof(TimestampConverter))]
+        public DateTime OrderCreationTime { get; set; }
+        /// <summary>
+        /// The trade id
+        /// </summary>
+        [JsonProperty("t")]
+        public long TradeId { get; set; }
+        /// <summary>
+        /// Whether the buyer is the maker
+        /// </summary>
+        [JsonProperty("m")]
+        public bool BuyerIsMaker { get; set; }
+    }
+}

--- a/Binance.Net/Objects/BinanceFuturesSymbol.cs
+++ b/Binance.Net/Objects/BinanceFuturesSymbol.cs
@@ -1,0 +1,106 @@
+﻿using Newtonsoft.Json;
+using System.Linq;
+using System.Collections.Generic;
+using Binance.Net.Converters;
+
+namespace Binance.Net.Objects
+{
+    /// <summary>
+    /// Information about an account
+    /// </summary>
+    public class BinanceFuturesSymbol
+    {
+        /// <summary>
+        /// Filters for order on this symbol
+        /// </summary>
+        public IEnumerable<BinanceSymbolFilter> Filters { get; set; } = new List<BinanceSymbolFilter>();
+        /// <summary>
+        /// The open margin percent
+        /// </summary>
+        public decimal MaintMarginPercent { get; set; }
+        /// <summary>
+        /// The price Precision
+        /// </summary>
+        public int PricePrecision { get; set; }
+        /// <summary>
+        /// The quantity precision
+        /// </summary>
+        public int QuantityPrecision { get; set; }
+        /// <summary>
+        /// The required margin percent
+        /// </summary>
+        public decimal RequiredMarginPercent { get; set; }
+        /// <summary>
+        /// The base asset
+        /// </summary>
+        public string BaseAsset { get; set; } = "";
+        /// <summary>
+        /// The quote asset
+        /// </summary>
+        public string QuoteAsset { get; set; } = "";
+        /// <summary>
+        /// The precision of the base asset
+        /// </summary>
+        public int BaseAssetPrecision { get; set; }
+        /// <summary>
+        /// The precision of the quote asset
+        /// </summary>
+        [JsonProperty("quotePrecision")]
+        public int QuoteAssetPrecision { get; set; }
+        /// <summary>
+        /// The status of the symbol
+        /// </summary>
+        [JsonConverter(typeof(SymbolStatusConverter))]
+        public SymbolStatus Status { get; set; }
+        /// <summary>
+        /// Allowed order types
+        /// </summary>
+        [JsonProperty(ItemConverterType = typeof(OrderTypeConverter))]
+        public IEnumerable<OrderType> OrderTypes { get; set; } = new List<OrderType>();
+        /// <summary>
+        /// The symbol
+        /// </summary>
+        [JsonProperty("symbol")]
+        public string Name { get; set; } = "";
+        /// <summary>
+        /// Allowed order time in force
+        /// </summary>
+        [JsonProperty(ItemConverterType = typeof(TimeInForceConverter))]
+        public IEnumerable<TimeInForce> TimeInForce { get; set; } = new List<TimeInForce>();
+        /// <summary>
+        /// Filter for the max accuracy of the price for this symbol
+        /// </summary>
+        [JsonIgnore]
+        public BinanceSymbolPriceFilter PriceFilter => Filters.OfType<BinanceSymbolPriceFilter>().FirstOrDefault();
+        /// <summary>
+        /// Filter for max accuracy of the quantity for this symbol
+        /// </summary>
+        [JsonIgnore]
+        public BinanceSymbolLotSizeFilter LotSizeFilter => Filters.OfType<BinanceSymbolLotSizeFilter>().FirstOrDefault();
+
+        /// <summary>
+        /// Filter for max accuracy of the quantity for this symbol, specifically for market orders
+        /// </summary>
+        [JsonIgnore]
+        public BinanceSymbolMarketLotSizeFilter MarketLotSizeFilter => Filters.OfType<BinanceSymbolMarketLotSizeFilter>().FirstOrDefault();
+
+        /// <summary>
+        /// Filter for max number of orders for this symbol
+        /// </summary>
+        [JsonIgnore]
+        public BinanceSymbolMaxOrdersFilter MaxOrdersFilter => Filters.OfType<BinanceSymbolMaxOrdersFilter>().FirstOrDefault();
+
+        /// <summary>
+        /// Filter for max number of orders for this symbol
+        /// </summary>
+        [JsonIgnore]
+        public BinanceSymbolMaxAlgorithmicOrdersFilter MaxAlgoOrdersFilter => Filters.OfType<BinanceSymbolMaxAlgorithmicOrdersFilter>().FirstOrDefault();
+
+        /// <summary>
+        /// Filter for the maximum deviation of the price
+        /// </summary>
+        [JsonIgnore]
+        public BinanceSymbolPercentPriceFilter PricePercentFilter => Filters.OfType<BinanceSymbolPercentPriceFilter>().FirstOrDefault();
+    }
+
+}

--- a/Binance.Net/Objects/BinanceFuturesSymbol.cs
+++ b/Binance.Net/Objects/BinanceFuturesSymbol.cs
@@ -15,7 +15,7 @@ namespace Binance.Net.Objects
         /// </summary>
         public IEnumerable<BinanceSymbolFilter> Filters { get; set; } = new List<BinanceSymbolFilter>();
         /// <summary>
-        /// The open margin percent
+        /// The maintenance margin percent
         /// </summary>
         public decimal MaintMarginPercent { get; set; }
         /// <summary>

--- a/Binance.Net/Objects/Enums.cs
+++ b/Binance.Net/Objects/Enums.cs
@@ -604,4 +604,65 @@ namespace Binance.Net.Objects
         /// </summary>
         RollOut
     }
+
+    /// <summary>
+    /// Type of futures income
+    /// </summary>
+    public enum IncomeType
+    {
+        /// <summary>
+        /// Transfer into account
+        /// </summary>
+        Transfer,
+        /// <summary>
+        /// Futures welcome bonus
+        /// </summary>
+        WelcomeBonus,
+        /// <summary>
+        /// Futures realized profit
+        /// </summary>
+        RealizedPnL,
+        /// <summary>
+        /// Futures funding fee
+        /// </summary>
+        FundingFee,
+        /// <summary>
+        /// Futures trading commission
+        /// </summary>
+        Commission,
+        /// <summary>
+        /// Insurance clear
+        /// </summary>
+        InsuranceClear
+    }
+
+    /// <summary>
+    /// The direction to change futures margin
+    /// </summary>
+    public enum FuturesMarginChangeDirectionType
+    {
+        /// <summary>
+        /// Add margin
+        /// </summary>
+        Add,
+        /// <summary>
+        /// Reduce Margin
+        /// </summary>
+        Reduce
+    }
+
+    /// <summary>
+    /// Type of Margin
+    /// </summary>
+    public enum FuturesMarginType
+    {
+        /// <summary>
+        /// Isolated margin
+        /// </summary>
+        Isolated,
+        /// <summary>
+        /// Crossed margin
+        /// </summary>
+        Cross
+    }
 }


### PR DESCRIPTION
Creates a new Client and Socket for Futures trading. Also adds in new objects for those classes that are different in the Futures API. Order of commits:

- [x] Futures Rest Client - Including Interface and necessary objects
- [x] Futures Socket Client - Including Interface and necessary stream objects
- [ ] Futures Rest Client Tests
- [ ] Futures Socket Client Tests
- [ ] Any additional items that may have been missed