### PR TITLE
Added IndexPrice field to BinanceFuturesMarkPrice

### DIFF
--- a/Binance.Net/Binance.Net.xml
+++ b/Binance.Net/Binance.Net.xml
@@ -11539,6 +11539,11 @@
             The current market price
             </summary>
         </member>
+        <member name="P:Binance.Net.Objects.Futures.MarketData.BinanceFuturesMarkPrice.IndexPrice">
+            <summary>
+            The current index price
+            </summary>
+        </member>
         <member name="P:Binance.Net.Objects.Futures.MarketData.BinanceFuturesMarkPrice.FundingRate">
             <summary>
             The last funding rate

--- a/Binance.Net/Objects/Futures/MarketData/BinanceFuturesMarkPrice.cs
+++ b/Binance.Net/Objects/Futures/MarketData/BinanceFuturesMarkPrice.cs
@@ -19,6 +19,10 @@ namespace Binance.Net.Objects.Futures.MarketData
         /// </summary>
         public decimal MarkPrice { get; set; }
         /// <summary>
+        /// The current index price
+        /// </summary>
+        public decimal IndexPrice { get; set; }
+        /// <summary>
         /// The last funding rate
         /// </summary>
         [JsonProperty("lastFundingRate")]


### PR DESCRIPTION
Mark price endpoint for both USDT and Coin-M futures have indexPrice field in response, so I've added it to the model.

Reference:
[https://binance-docs.github.io/apidocs/futures/en/#mark-price](https://binance-docs.github.io/apidocs/futures/en/#mark-price)
[https://fapi.binance.com/fapi/v1/premiumIndex](https://fapi.binance.com/fapi/v1/premiumIndex)
[https://dapi.binance.com/dapi/v1/premiumIndex](https://dapi.binance.com/dapi/v1/premiumIndex)