### PR TITLE
fix method documentation: "Invalidate listen key" instead of "Keep alive"

### DIFF
--- a/Binance.Net/Binance.Net.xml
+++ b/Binance.Net/Binance.Net.xml
@@ -24537,7 +24537,7 @@
             Close the user stream for margin account
             </summary>
             <param name="symbol">The isolated symbol</param>
-            <param name="listenKey">The listen key to keep alive</param>
+            <param name="listenKey">The listen key to invalidate</param>
             <param name="ct">Cancellation token</param>
             <returns></returns>
         </member>
@@ -24546,7 +24546,7 @@
             Close the user stream for margin account
             </summary>
             <param name="symbol">The isolated symbol</param>
-            <param name="listenKey">The listen key to keep alive</param>
+            <param name="listenKey">The listen key to invalidate</param>
             <param name="ct">Cancellation token</param>
             <returns></returns>
         </member>
@@ -25889,7 +25889,7 @@
             <summary>
             Stops the current user stream
             </summary>
-            <param name="listenKey">The listen key to keep alive</param>
+            <param name="listenKey">The listen key to invalidate</param>
             <param name="ct">Cancellation token</param>
             <returns></returns>
         </member>
@@ -25897,7 +25897,7 @@
             <summary>
             Stops the current user stream
             </summary>
-            <param name="listenKey">The listen key to keep alive</param>
+            <param name="listenKey">The listen key to invalidate</param>
             <param name="ct">Cancellation token</param>
             <returns></returns>
         </member>

--- a/Binance.Net/SubClients/Margin/BinanceClientMarginIsolatedUserStream.cs
+++ b/Binance.Net/SubClients/Margin/BinanceClientMarginIsolatedUserStream.cs
@@ -103,13 +103,13 @@ namespace Binance.Net.SubClients.Margin
 
         #endregion
 
-        #region Close a ListenKey 
+        #region Invalidate a ListenKey
 
         /// <summary>
         /// Close the user stream for margin account
         /// </summary>
         /// <param name="symbol">The isolated symbol</param>
-        /// <param name="listenKey">The listen key to keep alive</param>
+        /// <param name="listenKey">The listen key to invalidate</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
         public WebCallResult<object> CloseIsolatedMarginUserStream(string symbol, string listenKey, CancellationToken ct = default) => CloseIsolatedMarginUserStreamAsync(symbol, listenKey, ct).Result;
@@ -118,7 +118,7 @@ namespace Binance.Net.SubClients.Margin
         /// Close the user stream for margin account
         /// </summary>
         /// <param name="symbol">The isolated symbol</param>
-        /// <param name="listenKey">The listen key to keep alive</param>
+        /// <param name="listenKey">The listen key to invalidate</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
         public async Task<WebCallResult<object>> CloseIsolatedMarginUserStreamAsync(string symbol, string listenKey, CancellationToken ct = default)

--- a/Binance.Net/SubClients/Margin/BinanceClientMarginUserStream.cs
+++ b/Binance.Net/SubClients/Margin/BinanceClientMarginUserStream.cs
@@ -92,7 +92,7 @@ namespace Binance.Net.SubClients.Margin
 
         #endregion
 
-        #region Close a ListenKey 
+        #region Invalidate a ListenKey
 
         /// <summary>
         /// Close the user stream for margin account

--- a/Binance.Net/SubClients/Spot/BinanceClientSpotUserStream.cs
+++ b/Binance.Net/SubClients/Spot/BinanceClientSpotUserStream.cs
@@ -88,12 +88,12 @@ namespace Binance.Net.SubClients.Spot
 
         #endregion
 
-        #region Close a ListenKey
+        #region Invalidate a ListenKey
 
         /// <summary>
         /// Stops the current user stream
         /// </summary>
-        /// <param name="listenKey">The listen key to keep alive</param>
+        /// <param name="listenKey">The listen key to invalidate</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
         public WebCallResult<object> StopUserStream(string listenKey, CancellationToken ct = default) => StopUserStreamAsync(listenKey, ct).Result;
@@ -101,7 +101,7 @@ namespace Binance.Net.SubClients.Spot
         /// <summary>
         /// Stops the current user stream
         /// </summary>
-        /// <param name="listenKey">The listen key to keep alive</param>
+        /// <param name="listenKey">The listen key to invalidate</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
         public async Task<WebCallResult<object>> StopUserStreamAsync(string listenKey, CancellationToken ct = default)


### PR DESCRIPTION
A small copy paste error in the method documentation.

![image](https://user-images.githubusercontent.com/6564082/121200454-0a547200-c874-11eb-88a0-ea0683413410.png)

https://binance-docs.github.io/apidocs/spot/en/#user-data-streams