### PR TITLE
Allow multiple intervals for kline subscription

### DIFF
--- a/Binance.Net/Binance.Net.xml
+++ b/Binance.Net/Binance.Net.xml
@@ -2824,6 +2824,15 @@
             <param name="onMessage">The event handler for the received data</param>
             <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         </member>
+        <member name="M:Binance.Net.Interfaces.SocketSubClient.IBinanceSocketClientBase.SubscribeToKlineUpdatesAsync(System.String,System.Collections.Generic.IEnumerable{Binance.Net.Enums.KlineInterval},System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
+            <summary>
+            Subscribes to the candlestick update stream for the provided symbol and intervals
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="intervals">The intervals of the candlesticks</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
         <member name="M:Binance.Net.Interfaces.SocketSubClient.IBinanceSocketClientBase.SubscribeToKlineUpdates(System.Collections.Generic.IEnumerable{System.String},Binance.Net.Enums.KlineInterval,System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
             <summary>
             Subscribes to the candlestick update stream for the provided symbols
@@ -2833,12 +2842,12 @@
             <param name="onMessage">The event handler for the received data</param>
             <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         </member>
-        <member name="M:Binance.Net.Interfaces.SocketSubClient.IBinanceSocketClientBase.SubscribeToKlineUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},Binance.Net.Enums.KlineInterval,System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
+        <member name="M:Binance.Net.Interfaces.SocketSubClient.IBinanceSocketClientBase.SubscribeToKlineUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},System.Collections.Generic.IEnumerable{Binance.Net.Enums.KlineInterval},System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
             <summary>
-            Subscribes to the candlestick update stream for the provided symbols
+            Subscribes to the candlestick update stream for the provided symbols and intervals
             </summary>
             <param name="symbols">The symbols</param>
-            <param name="interval">The interval of the candlesticks</param>
+            <param name="intervals">The intervals of the candlesticks</param>
             <param name="onMessage">The event handler for the received data</param>
             <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         </member>
@@ -19117,10 +19126,13 @@
         <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientFutures.SubscribeToKlineUpdatesAsync(System.String,Binance.Net.Enums.KlineInterval,System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
             <inheritdoc />
         </member>
+        <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientFutures.SubscribeToKlineUpdatesAsync(System.String,System.Collections.Generic.IEnumerable{Binance.Net.Enums.KlineInterval},System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
+            <inheritdoc />
+        </member>
         <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientFutures.SubscribeToKlineUpdates(System.Collections.Generic.IEnumerable{System.String},Binance.Net.Enums.KlineInterval,System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
             <inheritdoc />
         </member>
-        <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientFutures.SubscribeToKlineUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},Binance.Net.Enums.KlineInterval,System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
+        <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientFutures.SubscribeToKlineUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},System.Collections.Generic.IEnumerable{Binance.Net.Enums.KlineInterval},System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
             <inheritdoc />
         </member>
         <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientFutures.SubscribeToSymbolMiniTickerUpdates(System.String,System.Action{Binance.Net.Interfaces.IBinanceMiniTick})">
@@ -19438,28 +19450,37 @@
         </member>
         <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientFuturesCoin.SubscribeToKlineUpdatesAsync(System.String,Binance.Net.Enums.KlineInterval,System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
             <summary>
-            Subscribes to the candlestick update stream for the provided symbol
+            Subscribes to the candlestick update stream for the provided symbol and interval
             </summary>
             <param name="symbol">The symbol</param>
             <param name="interval">The interval of the candlesticks</param>
             <param name="onMessage">The event handler for the received data</param>
             <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         </member>
+        <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientFuturesCoin.SubscribeToKlineUpdatesAsync(System.String,System.Collections.Generic.IEnumerable{Binance.Net.Enums.KlineInterval},System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
+            <summary>
+            Subscribes to the candlestick update stream for the provided symbol and intervals
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="intervals">The intervals of the candlesticks</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
         <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientFuturesCoin.SubscribeToKlineUpdates(System.Collections.Generic.IEnumerable{System.String},Binance.Net.Enums.KlineInterval,System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
             <summary>
-            Subscribes to the candlestick update stream for the provided symbols
+            Subscribes to the candlestick update stream for the provided symbols and interval
             </summary>
             <param name="symbols">The symbols</param>
             <param name="interval">The interval of the candlesticks</param>
             <param name="onMessage">The event handler for the received data</param>
             <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         </member>
-        <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientFuturesCoin.SubscribeToKlineUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},Binance.Net.Enums.KlineInterval,System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
+        <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientFuturesCoin.SubscribeToKlineUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},System.Collections.Generic.IEnumerable{Binance.Net.Enums.KlineInterval},System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
             <summary>
-            Subscribes to the candlestick update stream for the provided symbols
+            Subscribes to the candlestick update stream for the provided symbols and intervals
             </summary>
             <param name="symbols">The symbols</param>
-            <param name="interval">The interval of the candlesticks</param>
+            <param name="intervals">The intervals of the candlesticks</param>
             <param name="onMessage">The event handler for the received data</param>
             <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         </member>
@@ -19812,28 +19833,37 @@
         </member>
         <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientFuturesUsdt.SubscribeToKlineUpdatesAsync(System.String,Binance.Net.Enums.KlineInterval,System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
             <summary>
-            Subscribes to the candlestick update stream for the provided symbol
+            Subscribes to the candlestick update stream for the provided symbol and interval
             </summary>
             <param name="symbol">The symbol</param>
             <param name="interval">The interval of the candlesticks</param>
             <param name="onMessage">The event handler for the received data</param>
             <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         </member>
+        <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientFuturesUsdt.SubscribeToKlineUpdatesAsync(System.String,System.Collections.Generic.IEnumerable{Binance.Net.Enums.KlineInterval},System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
+            <summary>
+            Subscribes to the candlestick update stream for the provided symbol and intervals
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="intervals">The intervals of the candlesticks</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
         <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientFuturesUsdt.SubscribeToKlineUpdates(System.Collections.Generic.IEnumerable{System.String},Binance.Net.Enums.KlineInterval,System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
             <summary>
-            Subscribes to the candlestick update stream for the provided symbols
+            Subscribes to the candlestick update stream for the provided symbols and interval
             </summary>
             <param name="symbols">The symbols</param>
             <param name="interval">The interval of the candlesticks</param>
             <param name="onMessage">The event handler for the received data</param>
             <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         </member>
-        <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientFuturesUsdt.SubscribeToKlineUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},Binance.Net.Enums.KlineInterval,System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
+        <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientFuturesUsdt.SubscribeToKlineUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},System.Collections.Generic.IEnumerable{Binance.Net.Enums.KlineInterval},System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
             <summary>
-            Subscribes to the candlestick update stream for the provided symbols
+            Subscribes to the candlestick update stream for the provided symbols and intervals
             </summary>
             <param name="symbols">The symbols</param>
-            <param name="interval">The interval of the candlesticks</param>
+            <param name="intervals">The intervals of the candlesticks</param>
             <param name="onMessage">The event handler for the received data</param>
             <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         </member>
@@ -20025,28 +20055,37 @@
         </member>
         <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientSpot.SubscribeToKlineUpdatesAsync(System.String,Binance.Net.Enums.KlineInterval,System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
             <summary>
-            Subscribes to the candlestick update stream for the provided symbol
+            Subscribes to the candlestick update stream for the provided symbol and interval
             </summary>
             <param name="symbol">The symbol</param>
             <param name="interval">The interval of the candlesticks</param>
             <param name="onMessage">The event handler for the received data</param>
             <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         </member>
+        <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientSpot.SubscribeToKlineUpdatesAsync(System.String,System.Collections.Generic.IEnumerable{Binance.Net.Enums.KlineInterval},System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
+            <summary>
+            Subscribes to the candlestick update stream for the provided symbol and intervals
+            </summary>
+            <param name="symbol">The symbol</param>
+            <param name="intervals">The intervals of the candlesticks</param>
+            <param name="onMessage">The event handler for the received data</param>
+            <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        </member>
         <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientSpot.SubscribeToKlineUpdates(System.Collections.Generic.IEnumerable{System.String},Binance.Net.Enums.KlineInterval,System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
             <summary>
-            Subscribes to the candlestick update stream for the provided symbols
+            Subscribes to the candlestick update stream for the provided symbols and interval
             </summary>
             <param name="symbols">The symbols</param>
             <param name="interval">The interval of the candlesticks</param>
             <param name="onMessage">The event handler for the received data</param>
             <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         </member>
-        <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientSpot.SubscribeToKlineUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},Binance.Net.Enums.KlineInterval,System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
+        <member name="M:Binance.Net.SocketSubClients.BinanceSocketClientSpot.SubscribeToKlineUpdatesAsync(System.Collections.Generic.IEnumerable{System.String},System.Collections.Generic.IEnumerable{Binance.Net.Enums.KlineInterval},System.Action{Binance.Net.Interfaces.IBinanceStreamKlineData})">
             <summary>
-            Subscribes to the candlestick update stream for the provided symbols
+            Subscribes to the candlestick update stream for the provided symbols and intervals
             </summary>
             <param name="symbols">The symbols</param>
-            <param name="interval">The interval of the candlesticks</param>
+            <param name="intervals">The intervals of the candlesticks</param>
             <param name="onMessage">The event handler for the received data</param>
             <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         </member>

--- a/Binance.Net/Interfaces/SocketSubClient/IBinanceSocketClientBase.cs
+++ b/Binance.Net/Interfaces/SocketSubClient/IBinanceSocketClientBase.cs
@@ -64,6 +64,15 @@ namespace Binance.Net.Interfaces.SocketSubClient
         Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<IBinanceStreamKlineData> onMessage);
 
         /// <summary>
+        /// Subscribes to the candlestick update stream for the provided symbol and intervals
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="intervals">The intervals of the candlesticks</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, IEnumerable<KlineInterval> intervals, Action<IBinanceStreamKlineData> onMessage);
+
+        /// <summary>
         /// Subscribes to the candlestick update stream for the provided symbols
         /// </summary>
         /// <param name="symbols">The symbols</param>
@@ -73,13 +82,13 @@ namespace Binance.Net.Interfaces.SocketSubClient
         CallResult<UpdateSubscription> SubscribeToKlineUpdates(IEnumerable<string> symbols, KlineInterval interval, Action<IBinanceStreamKlineData> onMessage);
 
         /// <summary>
-        /// Subscribes to the candlestick update stream for the provided symbols
+        /// Subscribes to the candlestick update stream for the provided symbols and intervals
         /// </summary>
         /// <param name="symbols">The symbols</param>
-        /// <param name="interval">The interval of the candlesticks</param>
+        /// <param name="intervals">The intervals of the candlesticks</param>
         /// <param name="onMessage">The event handler for the received data</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols, KlineInterval interval, Action<IBinanceStreamKlineData> onMessage);
+        Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols, IEnumerable<KlineInterval> intervals, Action<IBinanceStreamKlineData> onMessage);
 
         /// <summary>
         /// Subscribes to mini ticker updates stream for a specific symbol

--- a/Binance.Net/SocketSubClients/BinanceSocketClientFutures.cs
+++ b/Binance.Net/SocketSubClients/BinanceSocketClientFutures.cs
@@ -109,13 +109,18 @@ namespace Binance.Net.SocketSubClients
         public abstract Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval,
             Action<IBinanceStreamKlineData> onMessage);
 
+
+        /// <inheritdoc />
+        public abstract Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, IEnumerable<KlineInterval> intervals,
+            Action<IBinanceStreamKlineData> onMessage);
+
         /// <inheritdoc />
         public abstract CallResult<UpdateSubscription> SubscribeToKlineUpdates(IEnumerable<string> symbols,
             KlineInterval interval, Action<IBinanceStreamKlineData> onMessage);
 
         /// <inheritdoc />
         public abstract Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols,
-            KlineInterval interval, Action<IBinanceStreamKlineData> onMessage);
+            IEnumerable<KlineInterval> intervals, Action<IBinanceStreamKlineData> onMessage);
         
 
         #endregion

--- a/Binance.Net/SocketSubClients/BinanceSocketClientFuturesCoin.cs
+++ b/Binance.Net/SocketSubClients/BinanceSocketClientFuturesCoin.cs
@@ -59,36 +59,44 @@ namespace Binance.Net.SocketSubClients
         public override CallResult<UpdateSubscription> SubscribeToKlineUpdates(string symbol, KlineInterval interval, Action<IBinanceStreamKlineData> onMessage) => SubscribeToKlineUpdatesAsync(symbol, interval, onMessage).Result;
 
         /// <summary>
-        /// Subscribes to the candlestick update stream for the provided symbol
+        /// Subscribes to the candlestick update stream for the provided symbol and interval
         /// </summary>
         /// <param name="symbol">The symbol</param>
         /// <param name="interval">The interval of the candlesticks</param>
         /// <param name="onMessage">The event handler for the received data</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        public override async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<IBinanceStreamKlineData> onMessage) => await SubscribeToKlineUpdatesAsync(new[] { symbol }, interval, onMessage).ConfigureAwait(false);
-
+        public override async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<IBinanceStreamKlineData> onMessage) => await SubscribeToKlineUpdatesAsync(new[] { symbol }, new[] { interval }, onMessage).ConfigureAwait(false);
 
         /// <summary>
-        /// Subscribes to the candlestick update stream for the provided symbols
+        /// Subscribes to the candlestick update stream for the provided symbol and intervals
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="intervals">The intervals of the candlesticks</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public override async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, IEnumerable<KlineInterval> intervals, Action<IBinanceStreamKlineData> onMessage) => await SubscribeToKlineUpdatesAsync(new[] { symbol }, intervals, onMessage).ConfigureAwait(false);
+
+        /// <summary>
+        /// Subscribes to the candlestick update stream for the provided symbols and interval
         /// </summary>
         /// <param name="symbols">The symbols</param>
         /// <param name="interval">The interval of the candlesticks</param>
         /// <param name="onMessage">The event handler for the received data</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        public override CallResult<UpdateSubscription> SubscribeToKlineUpdates(IEnumerable<string> symbols, KlineInterval interval, Action<IBinanceStreamKlineData> onMessage) => SubscribeToKlineUpdatesAsync(symbols, interval, onMessage).Result;
+        public override CallResult<UpdateSubscription> SubscribeToKlineUpdates(IEnumerable<string> symbols, KlineInterval interval, Action<IBinanceStreamKlineData> onMessage) => SubscribeToKlineUpdatesAsync(symbols, new[] { interval }, onMessage).Result;
 
         /// <summary>
-        /// Subscribes to the candlestick update stream for the provided symbols
+        /// Subscribes to the candlestick update stream for the provided symbols and intervals
         /// </summary>
         /// <param name="symbols">The symbols</param>
-        /// <param name="interval">The interval of the candlesticks</param>
+        /// <param name="intervals">The intervals of the candlesticks</param>
         /// <param name="onMessage">The event handler for the received data</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        public override async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols, KlineInterval interval, Action<IBinanceStreamKlineData> onMessage)
+        public override async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols, IEnumerable<KlineInterval> intervals, Action<IBinanceStreamKlineData> onMessage)
         {
             symbols.ValidateNotNull(nameof(symbols));
             var handler = new Action<BinanceCombinedStream<BinanceFuturesStreamCoinKlineData>>(data => onMessage(data.Data));
-            symbols = symbols.Select(a => a.ToLower(CultureInfo.InvariantCulture) + klineStreamEndpoint + "_" + JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false))).ToArray();
+            symbols = symbols.SelectMany(a => intervals.Select(i => a.ToLower(CultureInfo.InvariantCulture) + klineStreamEndpoint + "_" + JsonConvert.SerializeObject(i, new KlineIntervalConverter(false)))).ToArray();
             return await Subscribe(string.Join("/", symbols), true, handler).ConfigureAwait(false);
         }
 

--- a/Binance.Net/SocketSubClients/BinanceSocketClientFuturesUsdt.cs
+++ b/Binance.Net/SocketSubClients/BinanceSocketClientFuturesUsdt.cs
@@ -132,36 +132,44 @@ namespace Binance.Net.SocketSubClients
         public override CallResult<UpdateSubscription> SubscribeToKlineUpdates(string symbol, KlineInterval interval, Action<IBinanceStreamKlineData> onMessage) => SubscribeToKlineUpdatesAsync(symbol, interval, onMessage).Result;
 
         /// <summary>
-        /// Subscribes to the candlestick update stream for the provided symbol
+        /// Subscribes to the candlestick update stream for the provided symbol and interval
         /// </summary>
         /// <param name="symbol">The symbol</param>
         /// <param name="interval">The interval of the candlesticks</param>
         /// <param name="onMessage">The event handler for the received data</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        public override async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<IBinanceStreamKlineData> onMessage) => await SubscribeToKlineUpdatesAsync(new[] { symbol }, interval, onMessage).ConfigureAwait(false);
-
+        public override async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<IBinanceStreamKlineData> onMessage) => await SubscribeToKlineUpdatesAsync(new[] { symbol }, new[] { interval }, onMessage).ConfigureAwait(false);
 
         /// <summary>
-        /// Subscribes to the candlestick update stream for the provided symbols
+        /// Subscribes to the candlestick update stream for the provided symbol and intervals
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="intervals">The intervals of the candlesticks</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public override async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, IEnumerable<KlineInterval> intervals, Action<IBinanceStreamKlineData> onMessage) => await SubscribeToKlineUpdatesAsync(new[] { symbol }, intervals, onMessage).ConfigureAwait(false);
+
+        /// <summary>
+        /// Subscribes to the candlestick update stream for the provided symbols and interval
         /// </summary>
         /// <param name="symbols">The symbols</param>
         /// <param name="interval">The interval of the candlesticks</param>
         /// <param name="onMessage">The event handler for the received data</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        public override CallResult<UpdateSubscription> SubscribeToKlineUpdates(IEnumerable<string> symbols, KlineInterval interval, Action<IBinanceStreamKlineData> onMessage) => SubscribeToKlineUpdatesAsync(symbols, interval, onMessage).Result;
+        public override CallResult<UpdateSubscription> SubscribeToKlineUpdates(IEnumerable<string> symbols, KlineInterval interval, Action<IBinanceStreamKlineData> onMessage) => SubscribeToKlineUpdatesAsync(symbols, new[] { interval }, onMessage).Result;
 
         /// <summary>
-        /// Subscribes to the candlestick update stream for the provided symbols
+        /// Subscribes to the candlestick update stream for the provided symbols and intervals
         /// </summary>
         /// <param name="symbols">The symbols</param>
-        /// <param name="interval">The interval of the candlesticks</param>
+        /// <param name="intervals">The intervals of the candlesticks</param>
         /// <param name="onMessage">The event handler for the received data</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        public override async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols, KlineInterval interval, Action<IBinanceStreamKlineData> onMessage)
+        public override async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols, IEnumerable<KlineInterval> intervals, Action<IBinanceStreamKlineData> onMessage)
         {
             symbols.ValidateNotNull(nameof(symbols));
             var handler = new Action<BinanceCombinedStream<BinanceStreamKlineData>>(data => onMessage(data.Data));
-            symbols = symbols.Select(a => a.ToLower(CultureInfo.InvariantCulture) + klineStreamEndpoint + "_" + JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false))).ToArray();
+            symbols = symbols.SelectMany(a => intervals.Select(i => a.ToLower(CultureInfo.InvariantCulture) + klineStreamEndpoint + "_" + JsonConvert.SerializeObject(i, new KlineIntervalConverter(false)))).ToArray();
             return await Subscribe(string.Join("/", symbols), true, handler).ConfigureAwait(false);
         }
 

--- a/Binance.Net/SocketSubClients/BinanceSocketClientSpot.cs
+++ b/Binance.Net/SocketSubClients/BinanceSocketClientSpot.cs
@@ -175,7 +175,7 @@ namespace Binance.Net.SocketSubClients
             SubscribeToKlineUpdatesAsync(symbol, interval, onMessage).Result;
 
         /// <summary>
-        /// Subscribes to the candlestick update stream for the provided symbol
+        /// Subscribes to the candlestick update stream for the provided symbol and interval
         /// </summary>
         /// <param name="symbol">The symbol</param>
         /// <param name="interval">The interval of the candlesticks</param>
@@ -183,11 +183,21 @@ namespace Binance.Net.SocketSubClients
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         public async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol,
             KlineInterval interval, Action<IBinanceStreamKlineData> onMessage) =>
-            await SubscribeToKlineUpdatesAsync(new[] {symbol}, interval, onMessage).ConfigureAwait(false);
-
+            await SubscribeToKlineUpdatesAsync(new[] {symbol}, new[] {interval}, onMessage).ConfigureAwait(false);
 
         /// <summary>
-        /// Subscribes to the candlestick update stream for the provided symbols
+        /// Subscribes to the candlestick update stream for the provided symbol and intervals
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="intervals">The intervals of the candlesticks</param>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        public async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol,
+            IEnumerable<KlineInterval> intervals, Action<IBinanceStreamKlineData> onMessage) =>
+            await SubscribeToKlineUpdatesAsync(new[] {symbol}, intervals, onMessage).ConfigureAwait(false);
+
+        /// <summary>
+        /// Subscribes to the candlestick update stream for the provided symbols and interval
         /// </summary>
         /// <param name="symbols">The symbols</param>
         /// <param name="interval">The interval of the candlesticks</param>
@@ -195,26 +205,27 @@ namespace Binance.Net.SocketSubClients
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         public CallResult<UpdateSubscription> SubscribeToKlineUpdates(IEnumerable<string> symbols,
             KlineInterval interval, Action<IBinanceStreamKlineData> onMessage) =>
-            SubscribeToKlineUpdatesAsync(symbols, interval, onMessage).Result;
+            SubscribeToKlineUpdatesAsync(symbols, new [] {interval}, onMessage).Result;
 
         /// <summary>
-        /// Subscribes to the candlestick update stream for the provided symbols
+        /// Subscribes to the candlestick update stream for the provided symbols and intervals
         /// </summary>
         /// <param name="symbols">The symbols</param>
-        /// <param name="interval">The interval of the candlesticks</param>
+        /// <param name="intervals">The intervals of the candlesticks</param>
         /// <param name="onMessage">The event handler for the received data</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         public async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols,
-            KlineInterval interval, Action<IBinanceStreamKlineData> onMessage)
+            IEnumerable<KlineInterval> intervals, Action<IBinanceStreamKlineData> onMessage)
         {
             symbols.ValidateNotNull(nameof(symbols));
             foreach (var symbol in symbols)
                 symbol.ValidateBinanceSymbol();
 
             var handler = new Action<BinanceCombinedStream<BinanceStreamKlineData>>(data => onMessage(data.Data));
-            symbols = symbols.Select(a =>
-                a.ToLower(CultureInfo.InvariantCulture) + klineStreamEndpoint + "_" +
-                JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false))).ToArray();
+            symbols = symbols.SelectMany(a =>
+                intervals.Select(i => 
+                    a.ToLower(CultureInfo.InvariantCulture) + klineStreamEndpoint + "_" +
+                    JsonConvert.SerializeObject(i, new KlineIntervalConverter(false)))).ToArray();
             return await Subscribe(string.Join("/", symbols), true, handler).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
Allows the passing of multiple intervals in SubscribeToKlineUpdatesAsync.

* Extended the IBinanceSocketClientBase with additional method to allow passing multiple intervals for a Symbols
* Implemented methods in ClientSpot, ClientFuturesCoin & ClientFuturesUsdt
* Updated SubscribeToKlineUpdatesAsync to allow for generation of multiple intervals into subscribe command