### PR TITLE
Deserialization Fix

### DIFF
--- a/Binance.Net/Objects/Spot/MarginData/BinanceInterestHistoryResult.cs
+++ b/Binance.Net/Objects/Spot/MarginData/BinanceInterestHistoryResult.cs
@@ -26,6 +26,7 @@ namespace Binance.Net.Objects.Spot.MarginData
         /// <summary>
         /// Interest rate
         /// </summary>
+        [JsonProperty("interestRate")]
         public decimal InterestRate { get; set; }
         /// <summary>
         /// Principal


### PR DESCRIPTION
Fixes `InterestRate` in `BinanceInterestHistory` returning `0`