### PR TITLE
Deserialization Fix

### DIFF
--- a/Binance.Net/Objects/Spot/MarginData/BinanceInterestRateHistory.cs
+++ b/Binance.Net/Objects/Spot/MarginData/BinanceInterestRateHistory.cs
@@ -16,6 +16,7 @@ namespace Binance.Net.Objects.Spot.MarginData
         /// <summary>
         /// The daily interest
         /// </summary>
+        [JsonProperty("dailyInterestRate")]
         public decimal DailyInterest { get; set; }
         /// <summary>
         /// Timestamp


### PR DESCRIPTION
Fixes `DailyInterest` in `BinanceInterestRateHistory` returning `0`