### PR TITLE
Add startTime and endTime not mandatory parameter to GetDustLogAsync

### DIFF
--- a/Binance.Net/Binance.Net.xml
+++ b/Binance.Net/Binance.Net.xml
@@ -4777,10 +4777,12 @@
              <param name="ct">Cancellation token</param>
              <returns></returns>
         </member>
-        <member name="M:Binance.Net.Interfaces.SubClients.IBinanceClientGeneral.GetDustLogAsync(System.Nullable{System.Int32},System.Threading.CancellationToken)">
+        <member name="M:Binance.Net.Interfaces.SubClients.IBinanceClientGeneral.GetDustLogAsync(System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Threading.CancellationToken)">
             <summary>
             Gets the history of dust conversions
             </summary>
+            <param name="startTime">The start time</param>
+            <param name="endTime">The end time</param>
             <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
             <param name="ct">Cancellation token</param>
             <returns>The history of dust conversions</returns>
@@ -18815,10 +18817,12 @@
              <param name="ct">Cancellation token</param>
              <returns></returns>
         </member>
-        <member name="M:Binance.Net.SubClients.BinanceClientGeneral.GetDustLogAsync(System.Nullable{System.Int32},System.Threading.CancellationToken)">
+        <member name="M:Binance.Net.SubClients.BinanceClientGeneral.GetDustLogAsync(System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Threading.CancellationToken)">
             <summary>
             Gets the history of dust conversions
             </summary>
+            <param name="startTime">The start time</param>
+            <param name="endTime">The end time</param>
             <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
             <param name="ct">Cancellation token</param>
             <returns>The history of dust conversions</returns>

--- a/Binance.Net/Interfaces/SubClients/IBinanceClientGeneral.cs
+++ b/Binance.Net/Interfaces/SubClients/IBinanceClientGeneral.cs
@@ -134,10 +134,12 @@ namespace Binance.Net.Interfaces.SubClients
         /// <summary>
         /// Gets the history of dust conversions
         /// </summary>
+        /// <param name="startTime">The start time</param>
+        /// <param name="endTime">The end time</param>
         /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns>The history of dust conversions</returns>
-        Task<WebCallResult<BinanceDustLogList>> GetDustLogAsync(int? receiveWindow = null, CancellationToken ct = default);
+        Task<WebCallResult<BinanceDustLogList>> GetDustLogAsync(DateTime? startTime = null, DateTime? endTime = null, int? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
         /// Converts dust (small amounts of) assets to BNB 

--- a/Binance.Net/SubClients/BinanceClientGeneral.cs
+++ b/Binance.Net/SubClients/BinanceClientGeneral.cs
@@ -358,10 +358,12 @@ namespace Binance.Net.SubClients
         /// <summary>
         /// Gets the history of dust conversions
         /// </summary>
+        /// <param name="startTime">The start time</param>
+        /// <param name="endTime">The end time</param>
         /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns>The history of dust conversions</returns>
-        public async Task<WebCallResult<BinanceDustLogList>> GetDustLogAsync(int? receiveWindow = null, CancellationToken ct = default)
+        public async Task<WebCallResult<BinanceDustLogList>> GetDustLogAsync(DateTime? startTime = null, DateTime? endTime = null, int? receiveWindow = null, CancellationToken ct = default)
         {
             var timestampResult = await _baseClient.CheckAutoTimestamp(ct).ConfigureAwait(false);
             if (!timestampResult)
@@ -372,6 +374,8 @@ namespace Binance.Net.SubClients
                 { "timestamp", _baseClient.GetTimestamp() }
             };
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.DefaultReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptionalParameter("startTime", startTime.HasValue ? JsonConvert.SerializeObject(startTime.Value, new TimestampConverter()) : null);
+            parameters.AddOptionalParameter("endTime", endTime.HasValue ? JsonConvert.SerializeObject(endTime.Value, new TimestampConverter()) : null);
             var result = await _baseClient.SendRequestInternal<BinanceDustLogList>(_baseClient.GetUrlSpot(dustLogEndpoint, "sapi", "1"), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
             return result;
         }


### PR DESCRIPTION
Dust log supports startTime and endTime not mandatory parameters: [binance-docs](https://binance-docs.github.io/apidocs/spot/en/#dustlog-user_data).