### PR TITLE
UniversalTransferType align to latest

### DIFF
--- a/Binance.Net/Binance.Net.xml
+++ b/Binance.Net/Binance.Net.xml
@@ -1893,9 +1893,9 @@
             Universal transfer type
             </summary>
         </member>
-        <member name="F:Binance.Net.Enums.UniversalTransferType.MainToC2C">
+        <member name="F:Binance.Net.Enums.UniversalTransferType.MainToFunding">
             <summary>
-            Main (spot) to C2C
+            Main (spot) to Funding
             </summary>
         </member>
         <member name="F:Binance.Net.Enums.UniversalTransferType.MainToUsdFutures">
@@ -1918,24 +1918,19 @@
             Main (spot) to Mining
             </summary>
         </member>
-        <member name="F:Binance.Net.Enums.UniversalTransferType.C2CToMain">
+        <member name="F:Binance.Net.Enums.UniversalTransferType.FundingToMain">
             <summary>
-            C2C to Main (spot)
+            Funding to Main (spot)
             </summary>
         </member>
-        <member name="F:Binance.Net.Enums.UniversalTransferType.C2CToUsdFutures">
+        <member name="F:Binance.Net.Enums.UniversalTransferType.FundingToUsdFutures">
             <summary>
-            C2C to Usd futures
+            Funding to Usd futures
             </summary>
         </member>
-        <member name="F:Binance.Net.Enums.UniversalTransferType.C2CToMining">
+        <member name="F:Binance.Net.Enums.UniversalTransferType.FundingToMargin">
             <summary>
-            C2C to mining
-            </summary>
-        </member>
-        <member name="F:Binance.Net.Enums.UniversalTransferType.C2CToMargin">
-            <summary>
-            C2C to margin
+            Funding to margin
             </summary>
         </member>
         <member name="F:Binance.Net.Enums.UniversalTransferType.UsdFuturesToMain">
@@ -1943,9 +1938,9 @@
             Usd futures to Main (spot)
             </summary>
         </member>
-        <member name="F:Binance.Net.Enums.UniversalTransferType.UsdFuturesToC2C">
+        <member name="F:Binance.Net.Enums.UniversalTransferType.UsdFuturesToFunding">
             <summary>
-            Usd futures to C2C
+            Usd futures to Funding
             </summary>
         </member>
         <member name="F:Binance.Net.Enums.UniversalTransferType.UsdFuturesToMargin">
@@ -1983,9 +1978,9 @@
             Margin to Mining
             </summary>
         </member>
-        <member name="F:Binance.Net.Enums.UniversalTransferType.MarginToC2C">
+        <member name="F:Binance.Net.Enums.UniversalTransferType.MarginToFunding">
             <summary>
-            Margin to C2C
+            Margin to Funding
             </summary>
         </member>
         <member name="F:Binance.Net.Enums.UniversalTransferType.IsolatedMarginToMargin">
@@ -1998,6 +1993,11 @@
             Margin to isolated margin
             </summary>
         </member>
+        <member name="F:Binance.Net.Enums.UniversalTransferType.IsolatedMarginToIsolatedMargin">
+            <summary>
+            Isolated margin to Isolated margin
+            </summary>
+        </member>
         <member name="F:Binance.Net.Enums.UniversalTransferType.MiningToMain">
             <summary>
             Mining to Main (spot)
@@ -2008,24 +2008,19 @@
             Mining to Usd futures
             </summary>
         </member>
-        <member name="F:Binance.Net.Enums.UniversalTransferType.MiningToC2C">
-            <summary>
-            Mining to C2C
-            </summary>
-        </member>
         <member name="F:Binance.Net.Enums.UniversalTransferType.MiningToMargin">
             <summary>
             Mining to Margin
             </summary>
         </member>
-        <member name="F:Binance.Net.Enums.UniversalTransferType.MainToPay">
+        <member name="F:Binance.Net.Enums.UniversalTransferType.FundingToCoinFutures">
             <summary>
-            Main to pay
+            Funding to Coin futures
             </summary>
         </member>
-        <member name="F:Binance.Net.Enums.UniversalTransferType.PayToMain">
+        <member name="F:Binance.Net.Enums.UniversalTransferType.CoinFuturesToFunding">
             <summary>
-            Pay to main
+            Coin futures to Funding
             </summary>
         </member>
         <member name="T:Binance.Net.Enums.WithdrawalStatus">

--- a/Binance.Net/Converters/UniversalTransferTypeConverter.cs
+++ b/Binance.Net/Converters/UniversalTransferTypeConverter.cs
@@ -11,20 +11,18 @@ namespace Binance.Net.Converters
 
         protected override List<KeyValuePair<UniversalTransferType, string>> Mapping => new List<KeyValuePair<UniversalTransferType, string>>
         {
-            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.MainToC2C, "MAIN_C2C"),
+            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.MainToFunding, "MAIN_FUNDING"),
             new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.MainToUsdFutures, "MAIN_UMFUTURE"),
             new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.MainToCoinFutures, "MAIN_CMFUTURE"),
             new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.MainToMargin, "MAIN_MARGIN"),
             new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.MainToMining, "MAIN_MINING"),
-            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.MainToPay, "MAIN_PAY"),
 
-            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.C2CToMain, "C2C_MAIN"),
-            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.C2CToUsdFutures, "C2C_UMFUTURE"),
-            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.C2CToMining, "C2C_MINING"),
-            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.C2CToMargin, "C2C_MARGIN"),
+            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.FundingToMain, "FUNDING_MAIN"),
+            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.FundingToUsdFutures, "FUNDING_UMFUTURE"),
+            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.FundingToMargin, "FUNDING_MARGIN"),
 
             new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.UsdFuturesToMain, "UMFUTURE_MAIN"),
-            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.UsdFuturesToC2C, "UMFUTURE_C2C"),
+            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.UsdFuturesToFunding, "UMFUTURE_FUNDING"),
             new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.UsdFuturesToMargin, "UMFUTURE_MARGIN"),
 
             new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.CoinFuturesToMain, "CMFUTURE_MAIN"),
@@ -37,14 +35,15 @@ namespace Binance.Net.Converters
             new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.MarginToUsdFutures, "MARGIN_UMFUTURE"),
             new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.MarginToCoinFutures, "MARGIN_CMFUTURE"),
             new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.MarginToMining, "MARGIN_MINING"),
-            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.MarginToC2C, "MARGIN_C2C"),
+            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.MarginToFunding, "MARGIN_FUNDING"),
 
             new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.MiningToMain, "MINING_MAIN"),
             new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.MiningToUsdFutures, "MINING_UMFUTURE"),
-            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.MiningToC2C, "MINING_C2C"),
             new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.MiningToMargin, "MINING_MARGIN"),
 
-            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.PayToMain, "PAY_MAIN"),
+            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.FundingToCoinFutures, "FUNDING_CMFUTURE"),
+            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.CoinFuturesToFunding, "CMFUTURE_FUNDING"),
+            new KeyValuePair<UniversalTransferType, string>(UniversalTransferType.IsolatedMarginToIsolatedMargin, "ISOLATEDMARGIN_ISOLATEDMARGIN"),
         };
     }
 }

--- a/Binance.Net/Enums/UniversalTransferType.cs
+++ b/Binance.Net/Enums/UniversalTransferType.cs
@@ -6,9 +6,9 @@
     public enum UniversalTransferType
     {
         /// <summary>
-        /// Main (spot) to C2C
+        /// Main (spot) to Funding
         /// </summary>
-        MainToC2C,
+        MainToFunding,
         /// <summary>
         /// Main (spot) to Usd Futures
         /// </summary>
@@ -27,30 +27,26 @@
         MainToMining,
 
         /// <summary>
-        /// C2C to Main (spot)
+        /// Funding to Main (spot)
         /// </summary>
-        C2CToMain,
+        FundingToMain,
         /// <summary>
-        /// C2C to Usd futures
+        /// Funding to Usd futures
         /// </summary>
-        C2CToUsdFutures,
+        FundingToUsdFutures,
         /// <summary>
-        /// C2C to mining
+        /// Funding to margin
         /// </summary>
-        C2CToMining,
-        /// <summary>
-        /// C2C to margin
-        /// </summary>
-        C2CToMargin,
+        FundingToMargin,
         
         /// <summary>
         /// Usd futures to Main (spot)
         /// </summary>
         UsdFuturesToMain,
         /// <summary>
-        /// Usd futures to C2C
+        /// Usd futures to Funding
         /// </summary>
-        UsdFuturesToC2C,
+        UsdFuturesToFunding,
         /// <summary>
         /// Usd futures to Margin
         /// </summary>
@@ -82,9 +78,9 @@
         /// </summary>
         MarginToMining,
         /// <summary>
-        /// Margin to C2C
+        /// Margin to Funding
         /// </summary>
-        MarginToC2C,
+        MarginToFunding,
 
         /// <summary>
         /// Isolated margin to margin
@@ -94,6 +90,10 @@
         /// Margin to isolated margin
         /// </summary>
         MarginToIsolatedMargin,
+        /// <summary>
+        /// Isolated margin to Isolated margin
+        /// </summary>
+        IsolatedMarginToIsolatedMargin,
 
         /// <summary>
         /// Mining to Main (spot)
@@ -104,21 +104,16 @@
         /// </summary>
         MiningToUsdFutures,
         /// <summary>
-        /// Mining to C2C
-        /// </summary>
-        MiningToC2C,
-        /// <summary>
         /// Mining to Margin
         /// </summary>
         MiningToMargin,
-
         /// <summary>
-        /// Main to pay
+        /// Funding to Coin futures
         /// </summary>
-        MainToPay,
+        FundingToCoinFutures,
         /// <summary>
-        /// Pay to main
+        /// Coin futures to Funding
         /// </summary>
-        PayToMain        
+        CoinFuturesToFunding,
     }
 }


### PR DESCRIPTION
According to changes in Binance API.

> Update endpoint for Wallet:
New transfer types MAIN_FUNDING,FUNDING_MAIN,FUNDING_UMFUTURE,UMFUTURE_FUNDING,MARGIN_FUNDING,FUNDING_MARGIN,FUNDING_CMFUTUREand CMFUTURE_FUNDING added in Universal Transfer endpoint POST /sapi/v1/asset/transfer and GET /sapi/v1/asset/transfer to support trasnfer assets among funding account and other accounts
As the C2C account, Binance Payment, Binance Card and other businesses account are merged into a Funding account, transfer types MAIN_C2C,C2C_MAIN,C2C_UMFUTURE,C2C_MINING,UMFUTURE_C2C,MINING_C2C,MARGIN_C2C,C2C_MARGIN,MAIN_PAYand PAY_MAIN will be discontinued in Universal Transfer endpoint POST /sapi/v1/asset/transfer and GET /sapi/v1/asset/transfer on November 04, 2021 08:00 AM UTC