### PR TITLE
add support for the v2 sub account futures details endpoint

### DIFF
--- a/Binance.Net/Clients/GeneralApi/BinanceClientGeneralApiSubAccount.cs
+++ b/Binance.Net/Clients/GeneralApi/BinanceClientGeneralApiSubAccount.cs
@@ -342,6 +342,20 @@ namespace Binance.Net.Clients.GeneralApi
             return await _baseClient.SendRequestInternal<IEnumerable<BinanceSubAccountFuturesPositionRisk>>(_baseClient.GetUrl(subAccountFuturesPositionRiskEndpoint, "sapi", "1"), HttpMethod.Get, ct, parameters, true, weight: 10).ConfigureAwait(false);
         }
 
+        /// <inheritdoc />
+        public async Task<WebCallResult<BinanceSubAccountFuturesPositionRiskV2>> GetSubAccountsFuturesPositionRiskAsync(FuturesAccountType futuresAccountType, string email, int? receiveWindow = null, CancellationToken ct = default)
+        {
+            var parameters = new Dictionary<string, object>
+            {
+                { "email", email },
+                { "futuresType", JsonConvert.SerializeObject(futuresAccountType, new FuturesAccountTypeConverter(false)) }
+            };
+
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.Options.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+
+            return await _baseClient.SendRequestInternal<BinanceSubAccountFuturesPositionRiskV2>(_baseClient.GetUrl(subAccountFuturesPositionRiskEndpoint, "sapi", "2"), HttpMethod.Get, ct, parameters, true, weight: 10).ConfigureAwait(false);
+        }
+
         #endregion
 
         #region Futures Transfer for Sub-account (For Master Account)

--- a/Binance.Net/Clients/GeneralApi/BinanceClientGeneralApiSubAccount.cs
+++ b/Binance.Net/Clients/GeneralApi/BinanceClientGeneralApiSubAccount.cs
@@ -297,6 +297,21 @@ namespace Binance.Net.Clients.GeneralApi
             return await _baseClient.SendRequestInternal<BinanceSubAccountFuturesDetails>(_baseClient.GetUrl(subAccountFuturesDetailsEndpoint, "sapi", "1"), HttpMethod.Get, ct, parameters, true, weight: 10).ConfigureAwait(false);
         }
 
+        public async Task<WebCallResult<BinanceSubAccountFuturesDetailsV2>> GetSubAccountFuturesDetailsAsync(FuturesAccountType futuresAccountType, string email, int? receiveWindow = null, CancellationToken ct = default)
+        {
+            email.ValidateNotNull(nameof(email));
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "email", email },
+                { "futuresType", JsonConvert.SerializeObject(futuresAccountType, new FuturesAccountTypeConverter(false)) }
+            };
+
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.Options.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+
+            return await _baseClient.SendRequestInternal<BinanceSubAccountFuturesDetailsV2>(_baseClient.GetUrl(subAccountFuturesDetailsEndpoint, "sapi", "2"), HttpMethod.Get, ct, parameters, true, weight: 1).ConfigureAwait(false);
+        }
+
         #endregion
 
         #region Get Summary of Sub-account's Futures Account (For Master Account)

--- a/Binance.Net/Clients/GeneralApi/BinanceClientGeneralApiSubAccount.cs
+++ b/Binance.Net/Clients/GeneralApi/BinanceClientGeneralApiSubAccount.cs
@@ -353,7 +353,7 @@ namespace Binance.Net.Clients.GeneralApi
 
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.Options.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
-            return await _baseClient.SendRequestInternal<BinanceSubAccountFuturesPositionRiskV2>(_baseClient.GetUrl(subAccountFuturesPositionRiskEndpoint, "sapi", "2"), HttpMethod.Get, ct, parameters, true, weight: 10).ConfigureAwait(false);
+            return await _baseClient.SendRequestInternal<BinanceSubAccountFuturesPositionRiskV2>(_baseClient.GetUrl(subAccountFuturesPositionRiskEndpoint, "sapi", "2"), HttpMethod.Get, ct, parameters, true, weight: 1).ConfigureAwait(false);
         }
 
         #endregion

--- a/Binance.Net/Converters/FuturesAccountTypeConverter.cs
+++ b/Binance.Net/Converters/FuturesAccountTypeConverter.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using Binance.Net.Enums;
+using CryptoExchange.Net.Converters;
+
+namespace Binance.Net.Converters
+{
+    internal class FuturesAccountTypeConverter : BaseConverter<FuturesAccountType>
+    {
+        public FuturesAccountTypeConverter() : this(false) { }
+        public FuturesAccountTypeConverter(bool quotes) : base(quotes) { }
+
+        protected override List<KeyValuePair<FuturesAccountType, string>> Mapping => new List<KeyValuePair<FuturesAccountType, string>>
+        {
+            new KeyValuePair<FuturesAccountType, string>(FuturesAccountType.UsdtMarginedFutures, "1"),
+            new KeyValuePair<FuturesAccountType, string>(FuturesAccountType.CoinMarginedFutures, "2"),
+        };
+    }
+}

--- a/Binance.Net/Enums/FuturesAccountType.cs
+++ b/Binance.Net/Enums/FuturesAccountType.cs
@@ -1,0 +1,18 @@
+﻿
+namespace Binance.Net.Enums
+{
+    /// <summary>
+    /// Futures account type
+    /// </summary>
+    public enum FuturesAccountType
+    {
+        /// <summary>
+        /// USDT Margined Futures
+        /// </summary>
+        UsdtMarginedFutures,
+        /// <summary>
+        /// COIN Margined Futures
+        /// </summary>
+        CoinMarginedFutures
+    }
+}

--- a/Binance.Net/Interfaces/Clients/GeneralApi/IBinanceClientGeneralApiSubAccount.cs
+++ b/Binance.Net/Interfaces/Clients/GeneralApi/IBinanceClientGeneralApiSubAccount.cs
@@ -173,6 +173,7 @@ namespace Binance.Net.Interfaces.Clients.GeneralApi
         /// <param name="ct">Cancellation token</param>
         /// <returns>Futures summary</returns>
         Task<WebCallResult<BinanceSubAccountsFuturesSummary>> GetSubAccountsFuturesSummaryAsync(int? receiveWindow = null, CancellationToken ct = default);
+        
         /// <summary>
         /// Gets futures position risk for a sub account
         /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#get-futures-position-risk-of-sub-account-for-master-account" /></para>
@@ -182,6 +183,17 @@ namespace Binance.Net.Interfaces.Clients.GeneralApi
         /// <param name="ct">Cancellation token</param>
         /// <returns>Position risk</returns>
         Task<WebCallResult<IEnumerable<BinanceSubAccountFuturesPositionRisk>>> GetSubAccountsFuturesPositionRiskAsync(string email, int? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets futures position risk for a sub account
+        /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#get-futures-position-risk-of-sub-account-v2-for-master-account" /></para>
+        /// </summary>
+        /// <param name="email">Email of the sub account</param>
+        /// <param name="futuresType">The account type to get future details for</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Position risk</returns>
+        Task<WebCallResult<BinanceSubAccountFuturesPositionRiskV2>> GetSubAccountsFuturesPositionRiskAsync(FuturesAccountType futuresType, string email, int? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
         /// Transfers from or to a futures sub account

--- a/Binance.Net/Interfaces/Clients/GeneralApi/IBinanceClientGeneralApiSubAccount.cs
+++ b/Binance.Net/Interfaces/Clients/GeneralApi/IBinanceClientGeneralApiSubAccount.cs
@@ -155,6 +155,17 @@ namespace Binance.Net.Interfaces.Clients.GeneralApi
         Task<WebCallResult<BinanceSubAccountFuturesDetails>> GetSubAccountFuturesDetailsAsync(string email, int? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
+        /// Gets futures details for a sub account
+        /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#get-detail-on-sub-account-39-s-futures-account-v2-for-master-account" /></para>
+        /// </summary>
+        /// <param name="email">The email of the account to get future details for</param>
+        /// <param name="futuresType">The account type to get future details for</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Futures details</returns>
+        Task<WebCallResult<BinanceSubAccountFuturesDetailsV2>> GetSubAccountFuturesDetailsAsync(FuturesAccountType futuresType, string email, int? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
         /// Gets futures summary for sub accounts
         /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#get-summary-of-sub-account-39-s-futures-account-for-master-account" /></para>
         /// </summary>
@@ -162,7 +173,6 @@ namespace Binance.Net.Interfaces.Clients.GeneralApi
         /// <param name="ct">Cancellation token</param>
         /// <returns>Futures summary</returns>
         Task<WebCallResult<BinanceSubAccountsFuturesSummary>> GetSubAccountsFuturesSummaryAsync(int? receiveWindow = null, CancellationToken ct = default);
-
         /// <summary>
         /// Gets futures position risk for a sub account
         /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#get-futures-position-risk-of-sub-account-for-master-account" /></para>

--- a/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountFuturesDetailsV2.cs
+++ b/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountFuturesDetailsV2.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using CryptoExchange.Net.Converters;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Binance.Net.Objects.Models.Spot.SubAccountData
 {

--- a/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountFuturesDetailsV2.cs
+++ b/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountFuturesDetailsV2.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using CryptoExchange.Net.Converters;
+using Newtonsoft.Json;
+
+namespace Binance.Net.Objects.Models.Spot.SubAccountData
+{
+    /// <summary>
+    /// Sub account futures details
+    /// </summary>
+    public class BinanceSubAccountFuturesDetailsV2
+    {
+        /// <summary>
+        /// Futures account response (USDT margined)
+        /// </summary>
+        [JsonProperty("futureAccountResp")]
+        public BinanceSubAccountFuturesDetails UsdtMarginedFutures { get; set; }
+
+        /// <summary>
+        /// Delivery account response (COIN margined)
+        /// </summary>
+        [JsonProperty("deliveryAccountResp")]
+        public BinanceSubAccountFuturesDetails CoinMarginedFutures { get; set; }
+    }
+}

--- a/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountFuturesDetailsV2.cs
+++ b/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountFuturesDetailsV2.cs
@@ -1,4 +1,7 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using System.Collections.Generic;
+using CryptoExchange.Net.Converters;
+using Newtonsoft.Json;
 
 namespace Binance.Net.Objects.Models.Spot.SubAccountData
 {
@@ -11,12 +14,88 @@ namespace Binance.Net.Objects.Models.Spot.SubAccountData
         /// Futures account response (USDT margined)
         /// </summary>
         [JsonProperty("futureAccountResp")]
-        public BinanceSubAccountFuturesDetails UsdtMarginedFutures { get; set; }
+        public BinanceSubAccountFuturesDetailV2Usdt UsdtMarginedFutures { get; set; }
 
         /// <summary>
         /// Delivery account response (COIN margined)
         /// </summary>
         [JsonProperty("deliveryAccountResp")]
-        public BinanceSubAccountFuturesDetails CoinMarginedFutures { get; set; }
+        public BinanceSubAccountFuturesDetailV2 CoinMarginedFutures { get; set; }
+    }
+
+    /// <summary>
+    /// Sub account futures details
+    /// </summary>
+    public class BinanceSubAccountFuturesDetailV2
+    {
+        /// <summary>
+        /// Email of the sub account
+        /// </summary>
+        public string Email { get; set; } = string.Empty;
+        /// <summary>
+        /// List of asset details
+        /// </summary>
+        public IEnumerable<BinanceSubAccountFuturesAsset> Assets { get; set; } = Array.Empty<BinanceSubAccountFuturesAsset>();
+        /// <summary>
+        /// Can deposit
+        /// </summary>
+        public bool CanDeposit { get; set; }
+        /// <summary>
+        /// Can trade
+        /// </summary>
+        public bool CanTrade { get; set; }
+        /// <summary>
+        /// Can withdraw
+        /// </summary>
+        public bool CanWithdraw { get; set; }
+        /// <summary>
+        /// Fee tier
+        /// </summary>
+        public int FeeTier { get; set; }
+        /// <summary>
+        /// Time of the data
+        /// </summary>
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime UpdateTime { get; set; }
+    }
+
+    /// <summary>
+    /// Sub account futures details
+    /// </summary>
+    public class BinanceSubAccountFuturesDetailV2Usdt : BinanceSubAccountFuturesDetailV2
+    {
+        /// <summary>
+        /// Max quantity which can be withdrawn
+        /// </summary>
+        [JsonProperty("maxWithdrawAmount")]
+        public decimal MaxWithdrawQuantity { get; set; }
+        /// <summary>
+        /// Total initial margin
+        /// </summary>
+        public decimal TotalInitialMargin { get; set; }
+        /// <summary>
+        /// Total maintenance margin
+        /// </summary>
+        public decimal TotalMaintenanceMargin { get; set; }
+        /// <summary>
+        /// Total margin balance
+        /// </summary>
+        public decimal TotalMarginBalance { get; set; }
+        /// <summary>
+        /// Total open order initial margin
+        /// </summary>
+        public decimal TotalOpenOrderInitialMargin { get; set; }
+        /// <summary>
+        /// Total position initial margin
+        /// </summary>
+        public decimal TotalPositionInitialMargin { get; set; }
+        /// <summary>
+        /// Total unrealized profit
+        /// </summary>
+        public decimal TotalUnrealizedProfit { get; set; }
+        /// <summary>
+        /// Total wallet balance
+        /// </summary>
+        public decimal TotalWalletBalance { get; set; }
     }
 }

--- a/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountFuturesPositionRiskV2.cs
+++ b/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountFuturesPositionRiskV2.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using Binance.Net.Converters;
+using Binance.Net.Enums;
+using Newtonsoft.Json;
+
+namespace Binance.Net.Objects.Models.Spot.SubAccountData
+{
+    /// <summary>
+    /// Sub account position risk
+    /// </summary>
+    public class BinanceSubAccountFuturesPositionRiskV2
+    {
+        /// <summary>
+        /// Futures account response (USDT margined)
+        /// </summary>
+        [JsonProperty("futurePositionRiskVos")]
+        public IEnumerable<BinanceSubAccountFuturesPositionRisk> UsdtMarginedFutures { get; set; }
+
+        /// <summary>
+        /// Delivery account response (COIN margined)
+        /// </summary>
+        [JsonProperty("deliveryPositionRiskVos")]
+        public IEnumerable<BinanceSubAccountFuturesPositionRiskCoin> CoinMarginedFutures { get; set; }
+    }
+
+    /// <summary>
+    /// Sub account position risk
+    /// </summary>
+    public class BinanceSubAccountFuturesPositionRiskCoin
+    {
+        /// <summary>
+        /// The entry price
+        /// </summary>
+        public decimal EntryPrice { get; set; }
+
+        /// <summary>
+        /// Mark price
+        /// </summary>
+        public decimal MarkPrice { get; set; }
+
+        /// <summary>
+        /// Leverage
+        /// </summary>
+        public decimal Leverage { get; set; }
+
+        /// <summary>
+        /// Isolated
+        /// </summary>
+        public bool Isolated { get; set; }
+
+        /// <summary>
+        /// Isolated wallet
+        /// </summary>
+        public decimal IsolatedWallet { get; set; }
+
+        /// <summary>
+        /// Isolated margin
+        /// </summary>
+        public decimal IsolatedMargin { get; set; }
+
+        /// <summary>
+        /// Is auto add margin
+        /// </summary>
+        public bool IsAutoAddMargin { get; set; }
+
+        /// <summary>
+        /// Position side
+        /// </summary>
+        [JsonConverter(typeof(PositionSideConverter))]
+        public PositionSide PositionSide { get; set; }
+
+        /// <summary>
+        /// Position amount
+        /// </summary>
+        [JsonProperty("positionAmount")]
+        public decimal PositionQuantity { get; set; }
+
+        /// <summary>
+        /// Symbol
+        /// </summary>
+        public string Symbol { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Unrealized profit
+        /// </summary>
+        public decimal UnrealizedProfit { get; set; }
+    }
+}


### PR DESCRIPTION
support the v2 endpoint: https://binance-docs.github.io/apidocs/spot/en/#get-detail-on-sub-account-39-s-futures-account-v2-for-master-account