### PR TITLE
Fix GetSubAccountTransferHistoryForSubAccountAsync and GetUniversalTransferHistoryAsync

### DIFF
--- a/Binance.Net.UnitTests/JsonResponses/Spot/SubAccount/GetUniversalTransferHistory.txt
+++ b/Binance.Net.UnitTests/JsonResponses/Spot/SubAccount/GetUniversalTransferHistory.txt
@@ -1,24 +1,27 @@
-[
-  {
-    "tranId":11945860693,
-    "fromEmail":"master@test.com",
-    "toEmail":"subaccount1@test.com",
-    "asset":"BTC",
-    "amount":"0.1",
-    "fromAccountType":"SPOT",
-    "toAccountType":"COIN_FUTURE",
-    "status":"SUCCESS",
-    "createTimeStamp":1544433325000
-  },
-  {
-    "tranId":11945857955,
-    "fromEmail":"master@test.com",
-    "toEmail":"subaccount2@test.com",                               
-    "asset":"ETH",
-    "amount":"0.2",
-    "fromAccountType":"SPOT",
-    "toAccountType":"USDT_FUTURE",
-    "status":"SUCCESS",
-    "createTimeStamp":1544433326000
-  }
-]
+{
+  "result": [
+    {
+      "tranId": 11945860693,
+      "fromEmail": "master@test.com",
+      "toEmail": "subaccount1@test.com",
+      "asset": "BTC",
+      "amount": "0.1",
+      "fromAccountType": "SPOT",
+      "toAccountType": "COIN_FUTURE",
+      "status": "SUCCESS",
+      "createTimeStamp": 1544433325000
+    },
+    {
+      "tranId": 11945857955,
+      "fromEmail": "master@test.com",
+      "toEmail": "subaccount2@test.com",
+      "asset": "ETH",
+      "amount": "0.2",
+      "fromAccountType": "SPOT",
+      "toAccountType": "USDT_FUTURE",
+      "status": "SUCCESS",
+      "createTimeStamp": 1544433326000
+    }
+  ],
+  "totalCount": 2
+}

--- a/Binance.Net/Clients/GeneralApi/BinanceClientGeneralApiSubAccount.cs
+++ b/Binance.Net/Clients/GeneralApi/BinanceClientGeneralApiSubAccount.cs
@@ -450,7 +450,6 @@ namespace Binance.Net.Clients.GeneralApi
         {
             var parameters = new Dictionary<string, object>();
             parameters.AddOptionalParameter("asset", asset);
-            parameters.AddOptionalParameter("type", type);
             parameters.AddOptionalParameter("type", type == null ? null : JsonConvert.SerializeObject(type, new SubAccountTransferSubAccountTypeConverter(false)));
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));

--- a/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountFuturesDetailsV2.cs
+++ b/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountFuturesDetailsV2.cs
@@ -1,4 +1,7 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using System.Collections.Generic;
+using CryptoExchange.Net.Converters;
+using Newtonsoft.Json;
 
 namespace Binance.Net.Objects.Models.Spot.SubAccountData
 {

--- a/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountFuturesDetailsV2.cs
+++ b/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountFuturesDetailsV2.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using CryptoExchange.Net.Converters;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Binance.Net.Objects.Models.Spot.SubAccountData
 {

--- a/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountUniversalTransferTransaction.cs
+++ b/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountUniversalTransferTransaction.cs
@@ -12,6 +12,7 @@ namespace Binance.Net.Objects.Models.Spot.SubAccountData
         /// <summary>
         /// Transactions
         /// </summary>
+        [JsonProperty("result")]
         public IEnumerable<BinanceSubAccountUniversalTransferTransaction> Transactions { get; set; } =
             new List<BinanceSubAccountUniversalTransferTransaction>();
 

--- a/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountUniversalTransferTransaction.cs
+++ b/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountUniversalTransferTransaction.cs
@@ -26,7 +26,7 @@ namespace Binance.Net.Objects.Models.Spot.SubAccountData
         /// <summary>
         /// Transaction id
         /// </summary>
-        [JsonProperty("transId")]
+        [JsonProperty("tranId")]
         public long TransactionId { get; set; }
 
         /// <summary>


### PR DESCRIPTION
This fixes GetSubAccountTransferHistoryForSubAccountAsync and GetUniversalTransferHistoryAsync. 
The binance api docs are not correct for the json response returned in GetUniversalTransferHistory.txt, I've let them know and they are going to correct. 

The behaviour of the client when requesting universal transfer history before this change was to return no results, this PR fixes this.