### PR TITLE
Query Isolated Margin Fee Data (USER_DATA)

### DIFF
--- a/Binance.Net/Clients/SpotApi/BinanceClientSpotApiAccount.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceClientSpotApiAccount.cs
@@ -59,6 +59,7 @@ namespace Binance.Net.Clients.SpotApi
         private const string transferHistoryEndpoint = "margin/transfer";
         private const string interestHistoryEndpoint = "margin/interestHistory";
         private const string interestRateHistoryEndpoint = "margin/interestRateHistory";
+        private const string interestMarginDataEndpoint = "margin/crossMarginData";
         private const string forceLiquidationHistoryEndpoint = "margin/forceLiquidationRec";
 
         private const string isolatedMarginTransferHistoryEndpoint = "margin/isolated/transfer";
@@ -705,6 +706,23 @@ namespace Binance.Net.Clients.SpotApi
             return await _baseClient.SendRequestInternal<IEnumerable<BinanceInterestRateHistory>>(_baseClient.GetUrl(interestRateHistoryEndpoint, marginApi, marginVersion), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
         }
 
+        #endregion
+
+        #region Get Interest Rate Margin Data
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<IEnumerable<BinanceInterestMarginData>>> GetInterestMarginDataAsync(string? asset = null, string? vipLevel = null, long? receiveWindow = null, CancellationToken ct = default)
+        {
+            asset?.ValidateNotNull(nameof(asset));
+
+            var parameters = new Dictionary<string, object>();
+
+            parameters.AddOptionalParameter("coin", asset);
+            parameters.AddOptionalParameter("vipLevel", vipLevel?.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.Options.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+
+            return await _baseClient.SendRequestInternal<IEnumerable<BinanceInterestMarginData>>(_baseClient.GetUrl(interestMarginDataEndpoint, marginApi, marginVersion), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
+        }
         #endregion
 
         #region Get Force Liquidation Record

--- a/Binance.Net/Interfaces/Clients/SpotApi/IBinanceClientSpotApiAccount.cs
+++ b/Binance.Net/Interfaces/Clients/SpotApi/IBinanceClientSpotApiAccount.cs
@@ -449,6 +449,17 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         Task<WebCallResult<IEnumerable<BinanceInterestRateHistory>>> GetMarginInterestRateHistoryAsync(string asset, string? vipLevel = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, long? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
+        /// Get interest margin data
+        /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#query-cross-margin-fee-data-user_data" /></para>
+        /// </summary>
+        /// <param name="asset">Filter by asset</param>
+        /// <param name="vipLevel">Vip level</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<WebCallResult<IEnumerable<BinanceInterestMarginData>>> GetInterestMarginDataAsync(string? asset = null, string? vipLevel = null, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
         /// Get history of forced liquidations
         /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#get-force-liquidation-record-user_data" /></para>
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Margin/BinanceInterestMarginData.cs
+++ b/Binance.Net/Objects/Models/Spot/Margin/BinanceInterestMarginData.cs
@@ -1,0 +1,59 @@
+﻿using Newtonsoft.Json;
+
+namespace Binance.Net.Objects.Models.Spot.Margin
+{
+    /// <summary>
+    /// Interest rate history
+    /// </summary>
+    public class BinanceInterestMarginData
+    {
+        /// <summary>
+        /// Vip level
+        /// </summary>
+        [JsonProperty("vipLevel")]
+        public string VipLevel { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The coin
+        /// </summary>        
+        [JsonProperty("coin")]
+        public string Coin { get; set; } = string.Empty;
+
+        /// <summary>
+        /// If coin can be transferred into cross
+        /// </summary>
+        [JsonProperty("transferIn")]
+        public bool TransferIn { get; set; } = false;
+
+        /// <summary>
+        /// If coin can be borrowed in cross
+        /// </summary>        
+        [JsonProperty("borrowable")]
+        public bool Borrowable { get; set; } = false;
+
+        /// <summary>
+        /// The daily interest
+        /// </summary>
+        [JsonProperty("dailyInterest")]
+        public decimal DailyInterest { get; set; }
+
+        /// <summary>
+        /// The yearly interest
+        /// </summary>
+        [JsonProperty("yearlyInterest")]
+        public decimal YearlyInterest { get; set; }
+
+        /// <summary>
+        /// The yearly interest
+        /// </summary>
+        [JsonProperty("borrowLimit")]
+        public decimal BorrowLimit { get; set; }
+
+        /// <summary>
+        /// Cross marginable pairs for this coin
+        /// </summary>
+        [JsonProperty("marginablePairs")]
+        public string[]? MarginablePairs { get; set; }
+
+    }
+}


### PR DESCRIPTION
Query Isolated Margin Fee Data (USER_DATA)

[e-data-user_data](https://binance-docs.github.io/apidocs/spot/en/#query-cross-margin-fee-data-user_data)

Get isolated margin fee data collection with any vip level or user's current specific data as https://www.binance.com/en/margin-fee