### PR TITLE
Fixed MaxWithdrawQuantity field for CoinM GetBalances() return type

### DIFF
--- a/Binance.Net/Binance.Net.xml
+++ b/Binance.Net/Binance.Net.xml
@@ -10582,6 +10582,51 @@
         <member name="P:Binance.Net.Objects.Models.Futures.BinanceFuturesCoin24HPrice.QuoteVolume">
             <inheritdoc />
         </member>
+        <member name="T:Binance.Net.Objects.Models.Futures.BinanceFuturesCoinAccountBalance">
+            <summary>
+            Information about an account
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Futures.BinanceFuturesCoinAccountBalance.AccountAlias">
+            <summary>
+            Account alias
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Futures.BinanceFuturesCoinAccountBalance.Asset">
+            <summary>
+            The asset this balance is for
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Futures.BinanceFuturesCoinAccountBalance.WalletBalance">
+            <summary>
+            The total balance of this asset
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Futures.BinanceFuturesCoinAccountBalance.CrossWalletBalance">
+            <summary>
+            Crossed wallet balance
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Futures.BinanceFuturesCoinAccountBalance.CrossUnrealizedPnl">
+            <summary>
+            Unrealized profit of crossed positions
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Futures.BinanceFuturesCoinAccountBalance.AvailableBalance">
+            <summary>
+            Available balance
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Futures.BinanceFuturesCoinAccountBalance.MaxWithdrawQuantity">
+            <summary>
+            Maximum quantity for transfer out
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Futures.BinanceFuturesCoinAccountBalance.UpdateTime">
+            <summary>
+            Last update time
+            </summary>
+        </member>
         <member name="T:Binance.Net.Objects.Models.Futures.BinanceFuturesCoinAccountInfo">
             <summary>
             Account info

--- a/Binance.Net/Clients/CoinFuturesApi/BinanceClientCoinFuturesApiAccount.cs
+++ b/Binance.Net/Clients/CoinFuturesApi/BinanceClientCoinFuturesApiAccount.cs
@@ -261,12 +261,12 @@ namespace Binance.Net.Clients.CoinFuturesApi
         #region Future Account Balance
 
         /// <inheritdoc />
-        public async Task<WebCallResult<IEnumerable<BinanceFuturesAccountBalance>>> GetBalancesAsync(long? receiveWindow = null, CancellationToken ct = default)
+        public async Task<WebCallResult<IEnumerable<BinanceFuturesCoinAccountBalance>>> GetBalancesAsync(long? receiveWindow = null, CancellationToken ct = default)
         {
             var parameters = new Dictionary<string, object>();
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.Options.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
-            return await _baseClient.SendRequestInternal<IEnumerable<BinanceFuturesAccountBalance>>(_baseClient.GetUrl(futuresAccountBalanceEndpoint, api, "1"), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
+            return await _baseClient.SendRequestInternal<IEnumerable<BinanceFuturesCoinAccountBalance>>(_baseClient.GetUrl(futuresAccountBalanceEndpoint, api, "1"), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
         }
 
         #endregion

--- a/Binance.Net/Interfaces/Clients/CoinFuturesApi/IBinanceClientCoinFuturesApiAccount.cs
+++ b/Binance.Net/Interfaces/Clients/CoinFuturesApi/IBinanceClientCoinFuturesApiAccount.cs
@@ -42,7 +42,7 @@ namespace Binance.Net.Interfaces.Clients.CoinFuturesApi
         /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns>The account information</returns>
-        Task<WebCallResult<IEnumerable<BinanceFuturesAccountBalance>>> GetBalancesAsync(long? receiveWindow = null, CancellationToken ct = default);
+        Task<WebCallResult<IEnumerable<BinanceFuturesCoinAccountBalance>>> GetBalancesAsync(long? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
         /// Change user's position mode (Hedge Mode or One-way Mode ) on EVERY symbol

--- a/Binance.Net/Objects/Models/Futures/BinanceFuturesCoinAccountBalance.cs
+++ b/Binance.Net/Objects/Models/Futures/BinanceFuturesCoinAccountBalance.cs
@@ -7,7 +7,7 @@ namespace Binance.Net.Objects.Models.Futures
     /// <summary>
     /// Information about an account
     /// </summary>
-    public class BinanceFuturesAccountBalance
+    public class BinanceFuturesCoinAccountBalance
     {
         /// <summary>
         /// Account alias
@@ -44,13 +44,9 @@ namespace Binance.Net.Objects.Models.Futures
         /// <summary>
         /// Maximum quantity for transfer out
         /// </summary>
-        [JsonProperty("maxWithdrawAmount")]
-		public decimal MaxWithdrawQuantity { get; set; }
+        [JsonProperty("withdrawAvailable")]
+        public decimal MaxWithdrawQuantity { get; set; }
 
-        /// <summary>
-        /// Whether the asset can be used as margin in Multi-Assets mode
-        /// </summary>
-        public bool? MarginAvailable { get; set; }
         /// <summary>
         /// Last update time
         /// </summary>


### PR DESCRIPTION
Hi!

I've split `GetBalances` return type for CoinM into its own DTO and fixed `MaxWithdrawQuantity` to look for a JSON field called `withdrawAvailable` as per the docs here: 
https://binance-docs.github.io/apidocs/delivery/en/#futures-account-balance-user_data
For some reason it's different than the usual `maxWithdrawAmount` field that they use in pretty much all other endpoints!