### PR TITLE
Add Trailing Delta

### DIFF
--- a/Binance.Net/Converters/SymbolFilterTypeConverter.cs
+++ b/Binance.Net/Converters/SymbolFilterTypeConverter.cs
@@ -21,6 +21,7 @@ namespace Binance.Net.Converters
             new KeyValuePair<SymbolFilterType, string>(SymbolFilterType.MaxNumberAlgorithmicOrders, "MAX_NUM_ALGO_ORDERS"),
             new KeyValuePair<SymbolFilterType, string>(SymbolFilterType.MaxPosition, "MAX_POSITION"),
             new KeyValuePair<SymbolFilterType, string>(SymbolFilterType.PercentagePriceBySide, "PERCENT_PRICE_BY_SIDE"),
+            new KeyValuePair<SymbolFilterType, string>(SymbolFilterType.TrailingDelta, "TRAILING_DELTA"),
         };
     }
 }

--- a/Binance.Net/Enums/SymbolFilterType.cs
+++ b/Binance.Net/Enums/SymbolFilterType.cs
@@ -48,6 +48,10 @@
         /// <summary>
         /// Price filter by side
         /// </summary>
-        PercentagePriceBySide
+        PercentagePriceBySide,
+        /// <summary>
+        /// Trailing delta filter
+        /// </summary>,
+        TrailingDelta,
     }
 }

--- a/Binance.Net/Objects/Models/Spot/BinanceSymbol.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceSymbol.cs
@@ -135,5 +135,10 @@ namespace Binance.Net.Objects.Models.Spot
         /// </summary>
         [JsonIgnore]
         public BinanceSymbolMaxPositionFilter? MaxPositionFilter => Filters.OfType<BinanceSymbolMaxPositionFilter>().FirstOrDefault();
+        /// <summary>
+        /// Filter for the trailing delta values
+        /// </summary>
+        [JsonIgnore]
+        public BinanceSymbolTrailingDeltaFilter? TrailingDeltaFilter => Filters.OfType<BinanceSymbolTrailingDeltaFilter>().FirstOrDefault();
     }
 }

--- a/Binance.Net/Objects/Models/Spot/BinanceSymbolFilter.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceSymbolFilter.cs
@@ -183,4 +183,27 @@ namespace Binance.Net.Objects.Models.Spot
         /// </summary>
         public decimal MaxPosition { get; set; }
     }
+
+    /// <summary>
+    /// Trailing delta filter
+    /// </summary>
+    public class BinanceSymbolTrailingDeltaFilter : BinanceSymbolFilter
+    {
+        /// <summary>
+        /// The MinTrailingAboveDelta filter defines the minimum amount in Basis Point or BIPS above the price to activate the order.
+        /// </summary>
+        public int MinTrailingAboveDelta { get; set; }
+        /// <summary>
+        /// The MaxTrailingAboveDelta filter defines the maximum amount in Basis Point or BIPS above the price to activate the order.
+        /// </summary>
+        public int MaxTrailingAboveDelta { get; set; }
+        /// <summary>
+        /// The MinTrailingBelowDelta filter defines the minimum amount in Basis Point or BIPS below the price to activate the order.
+        /// </summary>
+        public int MinTrailingBelowDelta { get; set; }
+        /// <summary>
+        /// The MaxTrailingBelowDelta filter defines the minimum amount in Basis Point or BIPS below the price to activate the order.
+        /// </summary>
+        public int MaxTrailingBelowDelta { get; set; }
+    }
 }


### PR DESCRIPTION
#1059

Trailing Stops have been enabled.

    This is a type of algo order where the activation is based on a percentage of a price change in the market using the new parameter trailingDelta.
    This can only used with any of the following order types: STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, TAKE_PROFIT_LIMIT.
    The trailingDelta parameter will be done in Basis Points or BIPS.
        For example: a STOP_LOSS SELL order with a trailingDelta of 100 will trigger after a price decrease of 1%. (100 / 10,000 => 0.01 => 1%)
    When used in combination with OCO Orders, the trailingDelta will determine when the contingent leg of the OCO will trigger.
    When trailingDelta is used in combination with stopPrice, once the stopPrice condition is met, the trailing stop starts tracking the price change from the stopPrice based on the trailingDelta provided.
    When no stopPrice is sent, the trailing stop starts tracking the price changes from the last price based on the trailingDelta provided.
