### PR TITLE
ServicePointManager.DefaultConnectionLimit = 50;

### DIFF
--- a/Binance.Net/Clients/BinanceClient.cs
+++ b/Binance.Net/Clients/BinanceClient.cs
@@ -16,6 +16,7 @@ using Binance.Net.Clients.GeneralApi;
 using Binance.Net.Clients.SpotApi;
 using Binance.Net.Clients.UsdFuturesApi;
 using Binance.Net.Clients.CoinFuturesApi;
+using System.Net;
 
 namespace Binance.Net.Clients
 {
@@ -53,6 +54,7 @@ namespace Binance.Net.Clients
             SpotApi = AddApiClient(new BinanceClientSpotApi(log, this, options));
             UsdFuturesApi = AddApiClient(new BinanceClientUsdFuturesApi(log, this, options));
             CoinFuturesApi = AddApiClient(new BinanceClientCoinFuturesApi(log, this, options));
+            ServicePointManager.DefaultConnectionLimit = 50;
         }
         #endregion
 


### PR DESCRIPTION
### ServicePointManager.DefaultConnectionLimit Property

>The maximum number of concurrent connections allowed by a [ServicePoint](https://docs.microsoft.com/en-us/dotnet/api/system.net.servicepoint?view=net-6.0) object. The default connection limit is 10 for ASP.NET hosted applications and 2 for all others. When an app is running as an ASP.NET host, it is not possible to alter the value of this property through the config file if the autoConfig property is set to true. However, you can change the value programmatically when the autoConfig property is true. Set your preferred value once, when the AppDomain loads.

https://docs.microsoft.com/en-us/dotnet/api/system.net.servicepointmanager.defaultconnectionlimit?view=net-6.0