### PR TITLE
GetExchangeInfoAsync based on AccountType

### DIFF
--- a/Binance.Net/Binance.Net.xml
+++ b/Binance.Net/Binance.Net.xml
@@ -1077,7 +1077,16 @@
         <member name="M:Binance.Net.Clients.SpotApi.BinanceClientSpotApiExchangeData.GetExchangeInfoAsync(System.String,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
+        <member name="M:Binance.Net.Clients.SpotApi.BinanceClientSpotApiExchangeData.GetExchangeInfoAsync(Binance.Net.Enums.AccountType,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
         <member name="M:Binance.Net.Clients.SpotApi.BinanceClientSpotApiExchangeData.GetExchangeInfoAsync(System.Collections.Generic.IEnumerable{System.String},System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Binance.Net.Clients.SpotApi.BinanceClientSpotApiExchangeData.GetExchangeInfoAsync(System.Collections.Generic.IEnumerable{System.String},System.Boolean,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Binance.Net.Clients.SpotApi.BinanceClientSpotApiExchangeData.GetExchangeInfoAsync(Binance.Net.Enums.AccountType[],System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="M:Binance.Net.Clients.SpotApi.BinanceClientSpotApiExchangeData.GetSystemStatusAsync(System.Threading.CancellationToken)">
@@ -7188,12 +7197,40 @@
             <param name="ct">Cancellation token</param>
             <returns>Exchange info</returns>
         </member>
+        <member name="M:Binance.Net.Interfaces.Clients.SpotApi.IBinanceClientSpotApiExchangeData.GetExchangeInfoAsync(Binance.Net.Enums.AccountType,System.Threading.CancellationToken)">
+            <summary>
+            Get's information about the exchange including rate limits and information on the provided symbol based on account permissions
+            <para><a href="https://binance-docs.github.io/apidocs/spot/en/#exchange-information" /></para>
+            </summary>
+            <param name="permissions">account type</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Exchange info</returns>
+        </member>
         <member name="M:Binance.Net.Interfaces.Clients.SpotApi.IBinanceClientSpotApiExchangeData.GetExchangeInfoAsync(System.Collections.Generic.IEnumerable{System.String},System.Threading.CancellationToken)">
             <summary>
             Get's information about the exchange including rate limits and information on the provided symbols
             <para><a href="https://binance-docs.github.io/apidocs/spot/en/#exchange-information" /></para>
             </summary>
             <param name="symbols">Symbols to get data for token</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Exchange info</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.Clients.SpotApi.IBinanceClientSpotApiExchangeData.GetExchangeInfoAsync(System.Collections.Generic.IEnumerable{System.String},System.Boolean,System.Threading.CancellationToken)">
+            <summary>
+            Get's information about the exchange including rate limits and information on the provided symbols
+            <para><a href="https://binance-docs.github.io/apidocs/spot/en/#exchange-information" /></para>
+            </summary>
+            <param name="symbols">Symbols to get data for token</param>
+            <param name="permissions">true to use account type permissions instead of symbols</param>
+            <param name="ct">Cancellation token</param>
+            <returns>Exchange info</returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.Clients.SpotApi.IBinanceClientSpotApiExchangeData.GetExchangeInfoAsync(Binance.Net.Enums.AccountType[],System.Threading.CancellationToken)">
+            <summary>
+            Get's information about the exchange including rate limits and information on the provided symbols based on account permissions
+            <para><a href="https://binance-docs.github.io/apidocs/spot/en/#exchange-information" /></para>
+            </summary>
+            <param name="permissions">account type</param>
             <param name="ct">Cancellation token</param>
             <returns>Exchange info</returns>
         </member>

--- a/Binance.Net/Clients/SpotApi/BinanceClientSpotApiExchangeData.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceClientSpotApiExchangeData.cs
@@ -116,6 +116,7 @@ namespace Binance.Net.Clients.SpotApi
         #endregion
 
         #region Exchange Information
+
         /// <inheritdoc />
         public Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(CancellationToken ct = default)
              => GetExchangeInfoAsync(Array.Empty<string>(), ct);
@@ -125,36 +126,12 @@ namespace Binance.Net.Clients.SpotApi
              => GetExchangeInfoAsync(new string[] { symbol }, ct);
 
         /// <inheritdoc />
-        public Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(AccountType permission, CancellationToken ct = default)
-             => GetExchangeInfoAsync(new AccountType[] { permission }, ct);
-
-        /// <inheritdoc />
         public Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(IEnumerable<string> symbols, CancellationToken ct = default) 
             => GetExchangeInfoAsync(symbols, false, ct);
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(IEnumerable<string> symbols, bool permissions = false, CancellationToken ct = default)
-        {
-            var parameters = new Dictionary<string, object>();
-
-            if (symbols.Count() > 1)
-            {
-                parameters.Add(permissions ? "permissions" : "symbols", JsonConvert.SerializeObject(symbols));
-            }
-            else if (symbols.Any())
-            {
-                parameters.Add(permissions ? "permissions" : "symbol", symbols.First());
-            }
-
-            var exchangeInfoResult = await _baseClient.SendRequestInternal<BinanceExchangeInfo>(_baseClient.GetUrl(exchangeInfoEndpoint, api, publicVersion), HttpMethod.Get, ct, parameters: parameters, arraySerialization: ArrayParametersSerialization.Array, weight: 10).ConfigureAwait(false);
-            if (!exchangeInfoResult)
-                return exchangeInfoResult;
-
-            _baseClient.ExchangeInfo = exchangeInfoResult.Data;
-            _baseClient.LastExchangeInfoUpdate = DateTime.UtcNow;
-            _log.Write(LogLevel.Information, "Trade rules updated");
-            return exchangeInfoResult;
-        }
+        public Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(AccountType permission, CancellationToken ct = default)
+             => GetExchangeInfoAsync(new AccountType[] { permission }, ct);
 
         /// <inheritdoc />
         public async Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(AccountType[] permissions, CancellationToken ct = default)
@@ -174,6 +151,30 @@ namespace Binance.Net.Clients.SpotApi
             else if (permissions.Any())
             {
                 parameters.Add("permissions", permissions.First().ToString().ToUpper());
+            }
+
+            var exchangeInfoResult = await _baseClient.SendRequestInternal<BinanceExchangeInfo>(_baseClient.GetUrl(exchangeInfoEndpoint, api, publicVersion), HttpMethod.Get, ct, parameters: parameters, arraySerialization: ArrayParametersSerialization.Array, weight: 10).ConfigureAwait(false);
+            if (!exchangeInfoResult)
+                return exchangeInfoResult;
+
+            _baseClient.ExchangeInfo = exchangeInfoResult.Data;
+            _baseClient.LastExchangeInfoUpdate = DateTime.UtcNow;
+            _log.Write(LogLevel.Information, "Trade rules updated");
+            return exchangeInfoResult;
+        }
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(IEnumerable<string> symbols, bool permissions = false, CancellationToken ct = default)
+        {
+            var parameters = new Dictionary<string, object>();
+
+            if (symbols.Count() > 1)
+            {
+                parameters.Add(permissions ? "permissions" : "symbols", JsonConvert.SerializeObject(symbols));
+            }
+            else if (symbols.Any())
+            {
+                parameters.Add(permissions ? "permissions" : "symbol", symbols.First());
             }
 
             var exchangeInfoResult = await _baseClient.SendRequestInternal<BinanceExchangeInfo>(_baseClient.GetUrl(exchangeInfoEndpoint, api, publicVersion), HttpMethod.Get, ct, parameters: parameters, arraySerialization: ArrayParametersSerialization.Array, weight: 10).ConfigureAwait(false);

--- a/Binance.Net/Clients/SpotApi/BinanceClientSpotApiExchangeData.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceClientSpotApiExchangeData.cs
@@ -126,10 +126,6 @@ namespace Binance.Net.Clients.SpotApi
              => GetExchangeInfoAsync(new string[] { symbol }, ct);
 
         /// <inheritdoc />
-        public Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(IEnumerable<string> symbols, CancellationToken ct = default) 
-            => GetExchangeInfoAsync(symbols, false, ct);
-
-        /// <inheritdoc />
         public Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(AccountType permission, CancellationToken ct = default)
              => GetExchangeInfoAsync(new AccountType[] { permission }, ct);
 
@@ -164,17 +160,17 @@ namespace Binance.Net.Clients.SpotApi
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(IEnumerable<string> symbols, bool permissions = false, CancellationToken ct = default)
+        public async Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(IEnumerable<string> symbols, CancellationToken ct = default)
         {
             var parameters = new Dictionary<string, object>();
 
             if (symbols.Count() > 1)
             {
-                parameters.Add(permissions ? "permissions" : "symbols", JsonConvert.SerializeObject(symbols));
+                parameters.Add("symbols", JsonConvert.SerializeObject(symbols));
             }
             else if (symbols.Any())
             {
-                parameters.Add(permissions ? "permissions" : "symbol", symbols.First());
+                parameters.Add("symbol", symbols.First());
             }
 
             var exchangeInfoResult = await _baseClient.SendRequestInternal<BinanceExchangeInfo>(_baseClient.GetUrl(exchangeInfoEndpoint, api, publicVersion), HttpMethod.Get, ct, parameters: parameters, arraySerialization: ArrayParametersSerialization.Array, weight: 10).ConfigureAwait(false);

--- a/Binance.Net/Clients/SpotApi/BinanceClientSpotApiExchangeData.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceClientSpotApiExchangeData.cs
@@ -125,8 +125,8 @@ namespace Binance.Net.Clients.SpotApi
              => GetExchangeInfoAsync(new string[] { symbol }, ct);
 
         /// <inheritdoc />
-        public Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(AccountType permissions, CancellationToken ct = default)
-             => GetExchangeInfoAsync(new AccountType[] { permissions }, ct);
+        public Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(AccountType permission, CancellationToken ct = default)
+             => GetExchangeInfoAsync(new AccountType[] { permission }, ct);
 
         /// <inheritdoc />
         public Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(IEnumerable<string> symbols, CancellationToken ct = default) 

--- a/Binance.Net/Clients/SpotApi/BinanceClientSpotApiExchangeData.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceClientSpotApiExchangeData.cs
@@ -129,23 +129,8 @@ namespace Binance.Net.Clients.SpotApi
              => GetExchangeInfoAsync(new AccountType[] { permissions }, ct);
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(IEnumerable<string> symbols, CancellationToken ct = default)
-        {
-            var parameters = new Dictionary<string, object>();
-            if (symbols.Count() > 1)
-                parameters.Add("symbols", JsonConvert.SerializeObject(symbols));
-            else if (symbols.Any())
-                parameters.Add("symbol", symbols.First());
-
-            var exchangeInfoResult = await _baseClient.SendRequestInternal<BinanceExchangeInfo>(_baseClient.GetUrl(exchangeInfoEndpoint, api, publicVersion), HttpMethod.Get, ct, parameters: parameters, arraySerialization: ArrayParametersSerialization.Array, weight: 10).ConfigureAwait(false);
-            if (!exchangeInfoResult)
-                return exchangeInfoResult;
-
-            _baseClient.ExchangeInfo = exchangeInfoResult.Data;
-            _baseClient.LastExchangeInfoUpdate = DateTime.UtcNow;
-            _log.Write(LogLevel.Information, "Trade rules updated");
-            return exchangeInfoResult;
-        }
+        public Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(IEnumerable<string> symbols, CancellationToken ct = default) 
+            => GetExchangeInfoAsync(symbols, false, ct);
 
         /// <inheritdoc />
         public async Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(IEnumerable<string> symbols, bool permissions = false, CancellationToken ct = default)

--- a/Binance.Net/Interfaces/Clients/SpotApi/IBinanceClientSpotApiExchangeData.cs
+++ b/Binance.Net/Interfaces/Clients/SpotApi/IBinanceClientSpotApiExchangeData.cs
@@ -61,13 +61,13 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(string symbol, CancellationToken ct = default);
 
         /// <summary>
-        /// Get's information about the exchange including rate limits and information on the provided symbol based on account permissions
+        /// Get's information about the exchange including rate limits and information on the provided symbol based on an account permission
         /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#exchange-information" /></para>
         /// </summary>
-        /// <param name="permissions">account type</param>
+        /// <param name="permission">account type</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns>Exchange info</returns>
-        Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(AccountType permissions, CancellationToken ct = default);
+        Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(AccountType permission, CancellationToken ct = default);
 
         /// <summary>
         /// Get's information about the exchange including rate limits and information on the provided symbols

--- a/Binance.Net/Interfaces/Clients/SpotApi/IBinanceClientSpotApiExchangeData.cs
+++ b/Binance.Net/Interfaces/Clients/SpotApi/IBinanceClientSpotApiExchangeData.cs
@@ -61,6 +61,15 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(string symbol, CancellationToken ct = default);
 
         /// <summary>
+        /// Get's information about the exchange including rate limits and information on the provided symbol based on account permissions
+        /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#exchange-information" /></para>
+        /// </summary>
+        /// <param name="permissions">account type</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Exchange info</returns>
+        Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(AccountType permissions, CancellationToken ct = default);
+
+        /// <summary>
         /// Get's information about the exchange including rate limits and information on the provided symbols
         /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#exchange-information" /></para>
         /// </summary>
@@ -68,6 +77,25 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         /// <param name="ct">Cancellation token</param>
         /// <returns>Exchange info</returns>
         Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(IEnumerable<string> symbols, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get's information about the exchange including rate limits and information on the provided symbols
+        /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#exchange-information" /></para>
+        /// </summary>
+        /// <param name="symbols">Symbols to get data for token</param>
+        /// <param name="permissions">true to use account type permissions instead of symbols</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Exchange info</returns>
+        Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(IEnumerable<string> symbols, bool permissions = false, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get's information about the exchange including rate limits and information on the provided symbols based on account permissions
+        /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#exchange-information" /></para>
+        /// </summary>
+        /// <param name="permissions">account type</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Exchange info</returns>
+        Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(AccountType[] permissions, CancellationToken ct = default);
 
         /// <summary>
         /// Get's information about the exchange including rate limits and symbol list

--- a/Binance.Net/Interfaces/Clients/SpotApi/IBinanceClientSpotApiExchangeData.cs
+++ b/Binance.Net/Interfaces/Clients/SpotApi/IBinanceClientSpotApiExchangeData.cs
@@ -52,6 +52,14 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         Task<WebCallResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default);
 
         /// <summary>
+        /// Get's information about the exchange including rate limits and symbol list
+        /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#exchange-information" /></para>
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Exchange info</returns>
+        Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(CancellationToken ct = default);
+
+        /// <summary>
         /// Get's information about the exchange including rate limits and information on the provided symbol
         /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#exchange-information" /></para>
         /// </summary>
@@ -59,15 +67,6 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         /// <param name="ct">Cancellation token</param>
         /// <returns>Exchange info</returns>
         Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(string symbol, CancellationToken ct = default);
-
-        /// <summary>
-        /// Get's information about the exchange including rate limits and information on the provided symbol based on an account permission
-        /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#exchange-information" /></para>
-        /// </summary>
-        /// <param name="permission">account type</param>
-        /// <param name="ct">Cancellation token</param>
-        /// <returns>Exchange info</returns>
-        Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(AccountType permission, CancellationToken ct = default);
 
         /// <summary>
         /// Get's information about the exchange including rate limits and information on the provided symbols
@@ -79,14 +78,13 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(IEnumerable<string> symbols, CancellationToken ct = default);
 
         /// <summary>
-        /// Get's information about the exchange including rate limits and information on the provided symbols
+        /// Get's information about the exchange including rate limits and information on the provided symbol based on an account permission
         /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#exchange-information" /></para>
         /// </summary>
-        /// <param name="symbols">Symbols to get data for token</param>
-        /// <param name="permissions">true to use account type permissions instead of symbols</param>
+        /// <param name="permission">account type</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns>Exchange info</returns>
-        Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(IEnumerable<string> symbols, bool permissions = false, CancellationToken ct = default);
+        Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(AccountType permission, CancellationToken ct = default);
 
         /// <summary>
         /// Get's information about the exchange including rate limits and information on the provided symbols based on account permissions
@@ -98,12 +96,14 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(AccountType[] permissions, CancellationToken ct = default);
 
         /// <summary>
-        /// Get's information about the exchange including rate limits and symbol list
+        /// Get's information about the exchange including rate limits and information on the provided symbols
         /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#exchange-information" /></para>
         /// </summary>
+        /// <param name="symbols">Symbols to get data for token</param>
+        /// <param name="permissions">true to use account type permissions instead of symbols</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns>Exchange info</returns>
-        Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(CancellationToken ct = default);
+        Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(IEnumerable<string> symbols, bool permissions = false, CancellationToken ct = default);
 
         /// <summary>
         /// Gets the status of the Binance platform

--- a/Binance.Net/Interfaces/Clients/SpotApi/IBinanceClientSpotApiExchangeData.cs
+++ b/Binance.Net/Interfaces/Clients/SpotApi/IBinanceClientSpotApiExchangeData.cs
@@ -96,16 +96,6 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(AccountType[] permissions, CancellationToken ct = default);
 
         /// <summary>
-        /// Get's information about the exchange including rate limits and information on the provided symbols
-        /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#exchange-information" /></para>
-        /// </summary>
-        /// <param name="symbols">Symbols to get data for token</param>
-        /// <param name="permissions">true to use account type permissions instead of symbols</param>
-        /// <param name="ct">Cancellation token</param>
-        /// <returns>Exchange info</returns>
-        Task<WebCallResult<BinanceExchangeInfo>> GetExchangeInfoAsync(IEnumerable<string> symbols, bool permissions = false, CancellationToken ct = default);
-
-        /// <summary>
         /// Gets the status of the Binance platform
         /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#system-status-system" /></para>
         /// </summary>


### PR DESCRIPTION
```
Changes to GET /api/v3/exchangeInfo
New optional parameter permissions added to display all symbols with the permissions matching the parameter provided. (eg.SPOT, MARGIN, LEVERAGED)
If not provided, the default value will be ["SPOT","MARGIN", "LEVERAGED"].
This means the request GET /api/v3/exchangeInfo without any parameters will show all symbols that can be used for SPOT,MARGIN and/or LEVERAGED trading.
To search for symbols that can be traded on other permissions (e.g. TRD_GRP_004, etc), then this needs to be searched for explicitly. (e.g.permissions=TRD_GRP_004)
Cannot be combined with symbol or symbols
```

https://github.com/JKorf/Binance.Net/issues/1154