### PR TITLE
add new fields in get withdraws history endpoint (failure reason, comp…

### DIFF
--- a/Binance.Net/Objects/Models/Spot/BinanceWithdrawalList.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceWithdrawalList.cs
@@ -52,12 +52,27 @@ namespace Binance.Net.Objects.Models.Spot
         /// <summary>
         /// Network that was used
         /// </summary>
-        public string Network { get; set; } = string.Empty;
         /// <summary>
         /// Confirm times for withdraw
         /// </summary>
         [JsonProperty("confirmNo")]
         public int? ConfirmTimes { get; set; }
+        /// <summary>
+        /// Transaction private key 
+        /// </summary>
+        public string txKey { get; set; } = string.Empty;
+        /// <summary>
+        /// reason for withdrawal failure
+        /// </summary>
+        public string Info { get; set; } = string.Empty;
+        /// <summary>
+        /// The wallet type for withdraw
+        /// </summary>
+        public WalletType? WalletType { get; set; }
+        /// <summary>
+        /// Complete UTC time when user's asset is deduct from withdrawing, only if status =  6(success)
+        /// </summary>
+        public DateTime? CompleteTime { get; set; }
         /// <summary>
         /// The status of the withdrawal
         /// </summary>


### PR DESCRIPTION
based binance documents some new fields added to withdraws history endpoint:

```
"info": "The address is not valid. Please confirm with the recipient",  // reason for withdrawal failure
"txKey": "",
"walletType": 1,  //1: Funding Wallet 0:Spot Wallet
```


[link](https://binance-docs.github.io/apidocs/spot/en/#withdraw-history-supporting-network-user_data)