### PR TITLE
Use Static Converters for Requests instead of creating new converters every time

### DIFF
--- a/Binance.Net.UnitTests/BinanceClientTests.cs
+++ b/Binance.Net.UnitTests/BinanceClientTests.cs
@@ -1,6 +1,4 @@
-﻿using Binance.Net.Objects;
-using Binance.Net.UnitTests.TestImplementations;
-using CryptoExchange.Net;
+﻿using Binance.Net.UnitTests.TestImplementations;
 using CryptoExchange.Net.Authentication;
 using CryptoExchange.Net.Requests;
 using Moq;
@@ -12,9 +10,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using CryptoExchange.Net.Objects;
-using Binance.Net.Enums;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using System.Reflection;
 using System.Diagnostics;
 using Binance.Net.Objects.Models.Spot;
@@ -44,7 +40,7 @@ namespace Binance.Net.UnitTests
             Assert.AreEqual(true, result.Success);
             Assert.AreEqual(expected, result.Data);
         }
-       
+
         [TestCase]
         public async Task StartUserStream_Should_RespondWithListenKey()
         {
@@ -166,7 +162,7 @@ namespace Binance.Net.UnitTests
 
             // assert
             Assert.IsTrue(headers.First().Key == "X-MBX-APIKEY" && headers.First().Value == "TestKey");
-        }       
+        }
 
         [TestCase("BTCUSDT", true)]
         [TestCase("NANOUSDT", true)]
@@ -192,8 +188,8 @@ namespace Binance.Net.UnitTests
             var assembly = Assembly.GetAssembly(typeof(BinanceRestClient));
             var ignore = new string[] { "IBinanceClientUsdFuturesApi", "IBinanceClientCoinFuturesApi", "IBinanceClientSpotApi" };
             var clientInterfaces = assembly.GetTypes().Where(t => t.Name.StartsWith("IBinanceClient") && !ignore.Contains(t.Name));
-            
-            foreach(var clientInterface in clientInterfaces)
+
+            foreach (var clientInterface in clientInterfaces)
             {
                 var implementation = assembly.GetTypes().Single(t => t.IsAssignableTo(clientInterface) && t != clientInterface);
                 int methods = 0;

--- a/Binance.Net.UnitTests/BinanceSocketClientTests.cs
+++ b/Binance.Net.UnitTests/BinanceSocketClientTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using Binance.Net.Objects;
 using Binance.Net.UnitTests.TestImplementations;
 using NUnit.Framework;
 using Binance.Net.Enums;
@@ -8,9 +7,7 @@ using Binance.Net.Interfaces;
 using System.Threading.Tasks;
 using Binance.Net.Objects.Models;
 using Binance.Net.Objects.Models.Spot.Socket;
-using Microsoft.Extensions.Logging;
 using Binance.Net.Objects.Models.Futures.Socket;
-using Binance.Net.Objects.Options;
 
 namespace Binance.Net.UnitTests
 {
@@ -129,7 +126,8 @@ namespace Binance.Net.UnitTests
             var data = new BinanceCombinedStream<BinanceStreamTick>()
             {
                 Stream = "ethbtc@ticker",
-                Data = new BinanceStreamTick() { 
+                Data = new BinanceStreamTick()
+                {
                     FirstTradeId = 1,
                     HighPrice = 0.7m,
                     LastTradeId = 2,

--- a/Binance.Net.UnitTests/JsonSocketTests.cs
+++ b/Binance.Net.UnitTests/JsonSocketTests.cs
@@ -2,12 +2,8 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Binance.Net.Interfaces;
 using Binance.Net.Interfaces.Clients;
-using Binance.Net.Objects.Models;
 using Binance.Net.Objects.Models.Spot.Socket;
 using Binance.Net.UnitTests.TestImplementations;
 using Newtonsoft.Json;

--- a/Binance.Net.UnitTests/JsonTests.cs
+++ b/Binance.Net.UnitTests/JsonTests.cs
@@ -1,5 +1,4 @@
-﻿using Binance.Net.Objects;
-using Binance.Net.UnitTests.TestImplementations;
+﻿using Binance.Net.UnitTests.TestImplementations;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -126,7 +125,7 @@ namespace Binance.Net.UnitTests
             await _comparer.ProcessSubject(
                 "Spot/Futures",
                 c => c.GeneralApi.Futures,
-                new [] { "collateralQuantity" });
+                new[] { "collateralQuantity" });
         }
 
         [Test]
@@ -150,7 +149,7 @@ namespace Binance.Net.UnitTests
                 ignoreProperties: new Dictionary<string, List<string>>
                 {
                 },
-                parametersToSetNull: new string[] {  });
+                parametersToSetNull: new string[] { });
         }
 
         [Test]

--- a/Binance.Net.UnitTests/TestImplementations/JsonToObjectComparer.cs
+++ b/Binance.Net.UnitTests/TestImplementations/JsonToObjectComparer.cs
@@ -46,11 +46,11 @@ namespace Binance.Net.UnitTests.TestImplementations
                     FileStream file = null;
                     try
                     {
-                        file = File.OpenRead(Path.Combine(path, $"JsonResponses", folderPrefix, $"{method.Name}{(i == 0 ? "": i.ToString())}.txt"));
+                        file = File.OpenRead(Path.Combine(path, $"JsonResponses", folderPrefix, $"{method.Name}{(i == 0 ? "" : i.ToString())}.txt"));
                     }
                     catch (FileNotFoundException)
                     {
-                        if(i == 0)
+                        if (i == 0)
                             skippedMethods.Add(method.Name);
                         break;
                     }
@@ -85,7 +85,7 @@ namespace Binance.Net.UnitTests.TestImplementations
 
             if (skippedMethods.Any())
                 Debug.WriteLine("Skipped methods:");
-            foreach(var method in skippedMethods)
+            foreach (var method in skippedMethods)
                 Debug.WriteLine(method);
 
             Trace.Listeners.Remove(listener);
@@ -211,7 +211,7 @@ namespace Binance.Net.UnitTests.TestImplementations
             }
 
             var propertyValue = property.GetValue(obj);
-            if(property.GetCustomAttribute<JsonPropertyAttribute>(true)?.ItemConverterType == null)
+            if (property.GetCustomAttribute<JsonPropertyAttribute>(true)?.ItemConverterType == null)
                 CheckPropertyValue(method, prop.Value, propertyValue, property.Name, prop.Name, property, ignoreProperties);
         }
 
@@ -335,12 +335,12 @@ namespace Binance.Net.UnitTests.TestImplementations
         {
             if (jsonValue.Type == JTokenType.String)
             {
-                if(objectValue is decimal dec)
+                if (objectValue is decimal dec)
                 {
-                    if(jsonValue.Value<decimal>() != dec)
+                    if (jsonValue.Value<decimal>() != dec)
                         throw new Exception($"{method}: {property} not equal: {jsonValue.Value<decimal>()} vs {dec}");
                 }
-                else if(objectValue is DateTime time)
+                else if (objectValue is DateTime time)
                 {
                     // timestamp, hard to check..
                 }

--- a/Binance.Net.UnitTests/TestImplementations/TestSocket.cs
+++ b/Binance.Net.UnitTests/TestImplementations/TestSocket.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 
 namespace Binance.Net.UnitTests.TestImplementations
 {
-    public class TestSocket: IWebsocket
+    public class TestSocket : IWebsocket
     {
         public bool CanConnect { get; set; }
         public bool Connected { get; set; }
@@ -53,13 +53,13 @@ namespace Binance.Net.UnitTests.TestImplementations
 
         public void Send(string data)
         {
-            if(!Connected)
+            if (!Connected)
                 throw new Exception("Socket not connected");
         }
 
         public void Reset()
         {
-            
+
         }
 
         public Task CloseAsync()

--- a/Binance.Net/BinanceAuthenticationProvider.cs
+++ b/Binance.Net/BinanceAuthenticationProvider.cs
@@ -4,7 +4,6 @@ using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
-using Binance.Net.Objects;
 using CryptoExchange.Net;
 using CryptoExchange.Net.Authentication;
 using CryptoExchange.Net.Converters;

--- a/Binance.Net/BinanceEnvironment.cs
+++ b/Binance.Net/BinanceEnvironment.cs
@@ -49,12 +49,12 @@ namespace Binance.Net
         public string? CoinFuturesSocketAddress { get; }
 
         internal BinanceEnvironment(
-            string name, 
-            string spotRestAddress, 
-            string spotSocketStreamAddress, 
+            string name,
+            string spotRestAddress,
+            string spotSocketStreamAddress,
             string spotSocketApiAddress,
-            string? blvtSocketAddress, 
-            string? usdFuturesRestAddress, 
+            string? blvtSocketAddress,
+            string? usdFuturesRestAddress,
             string? usdFuturesSocketAddress,
             string? coinFuturesRestAddress,
             string? coinFuturesSocketAddress) :
@@ -73,8 +73,8 @@ namespace Binance.Net
         /// <summary>
         /// Live environment
         /// </summary>
-        public static BinanceEnvironment Live { get; } 
-            = new BinanceEnvironment(TradeEnvironmentNames.Live, 
+        public static BinanceEnvironment Live { get; }
+            = new BinanceEnvironment(TradeEnvironmentNames.Live,
                                      BinanceApiAddresses.Default.RestClientAddress,
                                      BinanceApiAddresses.Default.SocketClientStreamAddress,
                                      BinanceApiAddresses.Default.SocketClientApiAddress,

--- a/Binance.Net/BinanceHelpers.cs
+++ b/Binance.Net/BinanceHelpers.cs
@@ -1,7 +1,6 @@
 ﻿using Binance.Net.Clients;
 using Binance.Net.Enums;
 using Binance.Net.Interfaces.Clients;
-using Binance.Net.Objects;
 using Binance.Net.Objects.Internal;
 using Binance.Net.Objects.Models.Spot;
 using Binance.Net.Objects.Options;
@@ -9,7 +8,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
 using System.Net;
@@ -140,7 +138,8 @@ namespace Binance.Net
             services.AddHttpClient<IBinanceRestClient, BinanceRestClient>(options =>
             {
                 options.Timeout = restOptions.RequestTimeout;
-            }).ConfigurePrimaryHttpMessageHandler(() => {
+            }).ConfigurePrimaryHttpMessageHandler(() =>
+            {
                 var handler = new HttpClientHandler();
                 if (restOptions.Proxy != null)
                 {
@@ -171,7 +170,7 @@ namespace Binance.Net
             if (string.IsNullOrEmpty(symbolString))
                 throw new ArgumentException("Symbol is not provided");
 
-            if(!Regex.IsMatch(symbolString, "^([A-Z|a-z|0-9]{5,})$"))
+            if (!Regex.IsMatch(symbolString, "^([A-Z|a-z|0-9]{5,})$"))
                 throw new ArgumentException($"{symbolString} is not a valid Binance symbol. Should be [BaseAsset][QuoteAsset], e.g. BTCUSDT");
         }
 

--- a/Binance.Net/Clients/BinanceRestClient.cs
+++ b/Binance.Net/Clients/BinanceRestClient.cs
@@ -1,5 +1,4 @@
-﻿using Binance.Net.Objects;
-using CryptoExchange.Net;
+﻿using CryptoExchange.Net;
 using Binance.Net.Interfaces.Clients;
 using Binance.Net.Interfaces.Clients.UsdFuturesApi;
 using Binance.Net.Interfaces.Clients.SpotApi;

--- a/Binance.Net/Clients/BinanceSocketClient.cs
+++ b/Binance.Net/Clients/BinanceSocketClient.cs
@@ -5,7 +5,6 @@ using Binance.Net.Interfaces.Clients;
 using Binance.Net.Interfaces.Clients.CoinFuturesApi;
 using Binance.Net.Interfaces.Clients.SpotApi;
 using Binance.Net.Interfaces.Clients.UsdFuturesApi;
-using Binance.Net.Objects;
 using Binance.Net.Objects.Options;
 using CryptoExchange.Net;
 using CryptoExchange.Net.Authentication;

--- a/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApi.cs
+++ b/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApi.cs
@@ -1,5 +1,4 @@
 ﻿using Binance.Net.Enums;
-using Binance.Net.Objects;
 using CryptoExchange.Net.Authentication;
 using Microsoft.Extensions.Logging;
 using System;
@@ -509,7 +508,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
                 SourceObject = orderbook.Data,
                 Asks = orderbook.Data.Asks.Select(a => new OrderBookEntry { Price = a.Price, Quantity = a.Quantity }),
                 Bids = orderbook.Data.Bids.Select(b => new OrderBookEntry { Price = b.Price, Quantity = b.Quantity })
-            }); 
+            });
         }
 
         async Task<WebCallResult<IEnumerable<Trade>>> IBaseRestClient.GetRecentTradesAsync(string symbol, CancellationToken ct)

--- a/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiAccount.cs
+++ b/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiAccount.cs
@@ -104,7 +104,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "marginType", JsonConvert.SerializeObject(marginType, new FuturesMarginTypeConverter(false)) }
+                { "marginType", JsonConvert.SerializeObject(marginType, StaticConverters.StaticFuturesMarginTypeConverter) }
             };
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
@@ -122,9 +122,9 @@ namespace Binance.Net.Clients.CoinFuturesApi
             {
                 { "symbol", symbol },
                 { "amount", quantity.ToString(CultureInfo.InvariantCulture) },
-                { "type", JsonConvert.SerializeObject(type, new FuturesMarginChangeDirectionTypeConverter(false)) },
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticFuturesMarginChangeDirectionTypeConverter) },
             };
-            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, new PositionSideConverter(false)));
+            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, StaticConverters.StaticPositionSideConverter));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
             return await _baseClient.SendRequestInternal<BinanceFuturesPositionMarginResult>(_baseClient.GetUrl(positionMarginEndpoint, api, signedVersion), HttpMethod.Post, ct, parameters, true).ConfigureAwait(false);
@@ -141,7 +141,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             {
                 { "symbol", symbol }
             };
-            parameters.AddOptionalParameter("type", type.HasValue ? JsonConvert.SerializeObject(type, new FuturesMarginChangeDirectionTypeConverter(false)) : null);
+            parameters.AddOptionalParameter("type", type.HasValue ? JsonConvert.SerializeObject(type, StaticConverters.StaticFuturesMarginChangeDirectionTypeConverter) : null);
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));

--- a/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiExchangeData.cs
+++ b/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiExchangeData.cs
@@ -170,7 +170,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             var url = _baseClient.GetUrl(topLongShortAccountRatioEndpoint, tradingDataapi);
             var parameters = new Dictionary<string, object> {
                 { url.ToString().Contains("dapi") ? "pair": "symbol", symbolPair },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -192,7 +192,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             var url = _baseClient.GetUrl(topLongShortPositionRatioEndpoint, tradingDataapi);
             var parameters = new Dictionary<string, object> {
                 { url.ToString().Contains("dapi") ? "pair": "symbol", symbolPair },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -214,7 +214,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             var url = _baseClient.GetUrl(globalLongShortAccountRatioEndpoint, tradingDataapi);
             var parameters = new Dictionary<string, object> {
                 { url.ToString().Contains("dapi") ? "pair": "symbol", symbolPair },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -235,7 +235,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
 
             var parameters = new Dictionary<string, object> {
                 { "symbol", symbol },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -293,7 +293,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             limit?.ValidateIntBetween(nameof(limit), 1, 1500);
             var parameters = new Dictionary<string, object> {
                 { "symbol", symbol },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
@@ -314,8 +314,8 @@ namespace Binance.Net.Clients.CoinFuturesApi
             limit?.ValidateIntBetween(nameof(limit), 1, 1500);
             var parameters = new Dictionary<string, object> {
                 { "pair", pair },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) },
-                { "contractType", JsonConvert.SerializeObject(contractType, new ContractTypeConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter) },
+                { "contractType", JsonConvert.SerializeObject(contractType, StaticConverters.StaticContractTypeConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
@@ -336,7 +336,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             limit?.ValidateIntBetween(nameof(limit), 1, 1500);
             var parameters = new Dictionary<string, object> {
                 { "pair", pair },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
@@ -404,8 +404,8 @@ namespace Binance.Net.Clients.CoinFuturesApi
 
             var parameters = new Dictionary<string, object> {
                 { "pair", pair },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) },
-                { "contractType", JsonConvert.SerializeObject(contractType, new ContractTypeConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) },
+                { "contractType", JsonConvert.SerializeObject(contractType, StaticConverters.StaticContractTypeConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -426,8 +426,8 @@ namespace Binance.Net.Clients.CoinFuturesApi
 
             var parameters = new Dictionary<string, object> {
                 { "pair", pair },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) },
-                { "contractType", JsonConvert.SerializeObject(contractType, new ContractTypeConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) },
+                { "contractType", JsonConvert.SerializeObject(contractType, StaticConverters.StaticContractTypeConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -448,8 +448,8 @@ namespace Binance.Net.Clients.CoinFuturesApi
 
             var parameters = new Dictionary<string, object> {
                 { "pair", pair },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) },
-                { "contractType", JsonConvert.SerializeObject(contractType, new ContractTypeConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) },
+                { "contractType", JsonConvert.SerializeObject(contractType, StaticConverters.StaticContractTypeConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));

--- a/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiTrading.cs
+++ b/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiTrading.cs
@@ -94,21 +94,21 @@ namespace Binance.Net.Clients.CoinFuturesApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
-                { "type", JsonConvert.SerializeObject(type, new FuturesOrderTypeConverter(false)) }
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticFuturesOrderTypeConverter) }
             };
             parameters.AddOptionalParameter("quantity", quantity?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("newClientOrderId", newClientOrderId);
             parameters.AddOptionalParameter("price", price?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, new TimeInForceConverter(false)));
-            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, new PositionSideConverter(false)));
+            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, StaticConverters.StaticTimeInForceConverter));
+            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, StaticConverters.StaticPositionSideConverter));
             parameters.AddOptionalParameter("stopPrice", stopPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("activationPrice", activationPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("callbackRate", callbackRate?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("workingType", workingType == null ? null : JsonConvert.SerializeObject(workingType, new WorkingTypeConverter(false)));
+            parameters.AddOptionalParameter("workingType", workingType == null ? null : JsonConvert.SerializeObject(workingType, StaticConverters.StaticWorkingTypeConverter));
             parameters.AddOptionalParameter("reduceOnly", reduceOnly?.ToString().ToLower());
             parameters.AddOptionalParameter("closePosition", closePosition?.ToString().ToLower());
-            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, new OrderResponseTypeConverter(false)));
+            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, StaticConverters.StaticOrderResponseTypeConverter));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("priceProtect", priceProtect?.ToString().ToUpper());
 
@@ -158,20 +158,20 @@ namespace Binance.Net.Clients.CoinFuturesApi
                 var orderParameters = new Dictionary<string, object>()
                 {
                     { "symbol", order.Symbol },
-                    { "side", JsonConvert.SerializeObject(order.Side, new OrderSideConverter(false)) },
-                    { "type", JsonConvert.SerializeObject(order.Type, new FuturesOrderTypeConverter(false)) },
+                    { "side", JsonConvert.SerializeObject(order.Side, StaticConverters.StaticOrderSideConverter) },
+                    { "type", JsonConvert.SerializeObject(order.Type, StaticConverters.StaticFuturesOrderTypeConverter) },
                     { "newOrderRespType", "RESULT" }
                 };
 
                 orderParameters.AddOptionalParameter("quantity", order.Quantity?.ToString(CultureInfo.InvariantCulture));
                 orderParameters.AddOptionalParameter("newClientOrderId", order.NewClientOrderId);
                 orderParameters.AddOptionalParameter("price", order.Price?.ToString(CultureInfo.InvariantCulture));
-                orderParameters.AddOptionalParameter("timeInForce", order.TimeInForce == null ? null : JsonConvert.SerializeObject(order.TimeInForce, new TimeInForceConverter(false)));
-                orderParameters.AddOptionalParameter("positionSide", order.PositionSide == null ? null : JsonConvert.SerializeObject(order.PositionSide, new PositionSideConverter(false)));
+                orderParameters.AddOptionalParameter("timeInForce", order.TimeInForce == null ? null : JsonConvert.SerializeObject(order.TimeInForce, StaticConverters.StaticTimeInForceConverter));
+                orderParameters.AddOptionalParameter("positionSide", order.PositionSide == null ? null : JsonConvert.SerializeObject(order.PositionSide, StaticConverters.StaticPositionSideConverter));
                 orderParameters.AddOptionalParameter("stopPrice", order.StopPrice?.ToString(CultureInfo.InvariantCulture));
                 orderParameters.AddOptionalParameter("activationPrice", order.ActivationPrice?.ToString(CultureInfo.InvariantCulture));
                 orderParameters.AddOptionalParameter("callbackRate", order.CallbackRate?.ToString(CultureInfo.InvariantCulture));
-                orderParameters.AddOptionalParameter("workingType", order.WorkingType == null ? null : JsonConvert.SerializeObject(order.WorkingType, new WorkingTypeConverter(false)));
+                orderParameters.AddOptionalParameter("workingType", order.WorkingType == null ? null : JsonConvert.SerializeObject(order.WorkingType, StaticConverters.StaticWorkingTypeConverter));
                 orderParameters.AddOptionalParameter("reduceOnly", order.ReduceOnly?.ToString().ToLower());
                 orderParameters.AddOptionalParameter("priceProtect", order.PriceProtect?.ToString().ToUpper());
                 parameterOrders[i] = orderParameters;

--- a/Binance.Net/Clients/CoinFuturesApi/BinanceSocketClientCoinFuturesApi.cs
+++ b/Binance.Net/Clients/CoinFuturesApi/BinanceSocketClientCoinFuturesApi.cs
@@ -93,7 +93,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
                 var result = data.Data.Data;
                 onMessage(data.As<IBinanceStreamKlineData>(result, result.Symbol));
             });
-            symbols = symbols.SelectMany(a => intervals.Select(i => a.ToLower(CultureInfo.InvariantCulture) + klineStreamEndpoint + "_" + JsonConvert.SerializeObject(i, new KlineIntervalConverter(false)))).ToArray();
+            symbols = symbols.SelectMany(a => intervals.Select(i => a.ToLower(CultureInfo.InvariantCulture) + klineStreamEndpoint + "_" + JsonConvert.SerializeObject(i,  StaticConverters.StaticKlineIntervalConverter))).ToArray();
             return await SubscribeAsync( BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
 
@@ -146,10 +146,10 @@ namespace Binance.Net.Clients.CoinFuturesApi
             var handler = new Action<DataEvent<BinanceCombinedStream<BinanceStreamKlineData>>>(data => onMessage(data.As(data.Data.Data, data.Data.Data.Symbol)));
             pairs = pairs.Select(a => a.ToLower(CultureInfo.InvariantCulture) +
                                       "_" +
-                                      JsonConvert.SerializeObject(contractType, new ContractTypeConverter(false)).ToLower() +
+                                      JsonConvert.SerializeObject(contractType, StaticConverters.StaticContractTypeConverter).ToLower() +
                                       continuousKlineStreamEndpoint +
                                       "_" +
-                                      JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false))).ToArray();
+                                      JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter)).ToArray();
             return await SubscribeAsync( BaseAddress, pairs, handler, ct).ConfigureAwait(false);
         }
 
@@ -168,7 +168,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             pairs = pairs.Select(a => a.ToLower(CultureInfo.InvariantCulture) +
                                       indexKlineStreamEndpoint +
                                       "_" +
-                                      JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false))).ToArray();
+                                      JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter)).ToArray();
             return await SubscribeAsync( BaseAddress, pairs, handler, ct).ConfigureAwait(false);
         }
 
@@ -187,7 +187,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             symbols = symbols.Select(a => a.ToLower(CultureInfo.InvariantCulture) +
                                           markKlineStreamEndpoint +
                                          "_" +
-                                         JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false))).ToArray();
+                                         JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter)).ToArray();
             return await SubscribeAsync( BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
 

--- a/Binance.Net/Clients/CoinFuturesApi/BinanceSocketClientCoinFuturesApi.cs
+++ b/Binance.Net/Clients/CoinFuturesApi/BinanceSocketClientCoinFuturesApi.cs
@@ -8,7 +8,6 @@ using Binance.Net.Converters;
 using Binance.Net.Enums;
 using Binance.Net.Interfaces;
 using Binance.Net.Interfaces.Clients.CoinFuturesApi;
-using Binance.Net.Objects;
 using Binance.Net.Objects.Internal;
 using Binance.Net.Objects.Models;
 using Binance.Net.Objects.Models.Futures.Socket;
@@ -93,8 +92,8 @@ namespace Binance.Net.Clients.CoinFuturesApi
                 var result = data.Data.Data;
                 onMessage(data.As<IBinanceStreamKlineData>(result, result.Symbol));
             });
-            symbols = symbols.SelectMany(a => intervals.Select(i => a.ToLower(CultureInfo.InvariantCulture) + klineStreamEndpoint + "_" + JsonConvert.SerializeObject(i,  StaticConverters.StaticKlineIntervalConverter))).ToArray();
-            return await SubscribeAsync( BaseAddress, symbols, handler, ct).ConfigureAwait(false);
+            symbols = symbols.SelectMany(a => intervals.Select(i => a.ToLower(CultureInfo.InvariantCulture) + klineStreamEndpoint + "_" + JsonConvert.SerializeObject(i, StaticConverters.StaticKlineIntervalConverter))).ToArray();
+            return await SubscribeAsync(BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -112,7 +111,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
 
             var internalHandler = new Action<DataEvent<JToken>>(data => HandlePossibleSingleData(data, onMessage));
             pairs = pairs.Select(a => a.ToLower(CultureInfo.InvariantCulture) + indexPriceStreamEndpoint + (updateInterval == 1000 ? "@1s" : "")).ToArray();
-            return await SubscribeAsync( BaseAddress, pairs, internalHandler, ct).ConfigureAwait(false);
+            return await SubscribeAsync(BaseAddress, pairs, internalHandler, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -129,7 +128,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
 
             var internalHandler = new Action<DataEvent<JToken>>(data => HandlePossibleSingleData(data, onMessage));
             symbols = symbols.Select(a => a.ToLower(CultureInfo.InvariantCulture) + markPriceStreamEndpoint + (updateInterval == 1000 ? "@1s" : "")).ToArray();
-            return await SubscribeAsync( BaseAddress, symbols, internalHandler, ct).ConfigureAwait(false);
+            return await SubscribeAsync(BaseAddress, symbols, internalHandler, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -149,8 +148,8 @@ namespace Binance.Net.Clients.CoinFuturesApi
                                       JsonConvert.SerializeObject(contractType, StaticConverters.StaticContractTypeConverter).ToLower() +
                                       continuousKlineStreamEndpoint +
                                       "_" +
-                                      JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter)).ToArray();
-            return await SubscribeAsync( BaseAddress, pairs, handler, ct).ConfigureAwait(false);
+                                      JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter)).ToArray();
+            return await SubscribeAsync(BaseAddress, pairs, handler, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -168,8 +167,8 @@ namespace Binance.Net.Clients.CoinFuturesApi
             pairs = pairs.Select(a => a.ToLower(CultureInfo.InvariantCulture) +
                                       indexKlineStreamEndpoint +
                                       "_" +
-                                      JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter)).ToArray();
-            return await SubscribeAsync( BaseAddress, pairs, handler, ct).ConfigureAwait(false);
+                                      JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter)).ToArray();
+            return await SubscribeAsync(BaseAddress, pairs, handler, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -187,8 +186,8 @@ namespace Binance.Net.Clients.CoinFuturesApi
             symbols = symbols.Select(a => a.ToLower(CultureInfo.InvariantCulture) +
                                           markKlineStreamEndpoint +
                                          "_" +
-                                         JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter)).ToArray();
-            return await SubscribeAsync( BaseAddress, symbols, handler, ct).ConfigureAwait(false);
+                                         JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter)).ToArray();
+            return await SubscribeAsync(BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -205,7 +204,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
 
             var handler = new Action<DataEvent<BinanceCombinedStream<BinanceStreamCoinMiniTick>>>(data => onMessage(data.As<IBinanceMiniTick>(data.Data.Data, data.Data.Data.Symbol)));
             symbols = symbols.Select(a => a.ToLower(CultureInfo.InvariantCulture) + symbolMiniTickerStreamEndpoint).ToArray();
-            return await SubscribeAsync( BaseAddress, symbols, handler, ct).ConfigureAwait(false);
+            return await SubscribeAsync(BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -215,7 +214,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
         public async Task<CallResult<UpdateSubscription>> SubscribeToAllMiniTickerUpdatesAsync(Action<DataEvent<IEnumerable<IBinanceMiniTick>>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DataEvent<BinanceCombinedStream<IEnumerable<BinanceStreamCoinMiniTick>>>>(data => onMessage(data.As<IEnumerable<IBinanceMiniTick>>(data.Data.Data, data.Data.Stream)));
-            return await SubscribeAsync( BaseAddress, new[] { allMiniTickerStreamEndpoint }, handler, ct).ConfigureAwait(false);
+            return await SubscribeAsync(BaseAddress, new[] { allMiniTickerStreamEndpoint }, handler, ct).ConfigureAwait(false);
         }
         #endregion
 
@@ -231,7 +230,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
 
             var handler = new Action<DataEvent<BinanceCombinedStream<BinanceStreamCoinTick>>>(data => onMessage(data.As<IBinance24HPrice>(data.Data.Data, data.Data.Data.Symbol)));
             symbols = symbols.Select(a => a.ToLower(CultureInfo.InvariantCulture) + symbolTickerStreamEndpoint).ToArray();
-            return await SubscribeAsync( BaseAddress, symbols, handler, ct).ConfigureAwait(false);
+            return await SubscribeAsync(BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -242,7 +241,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
         public async Task<CallResult<UpdateSubscription>> SubscribeToAllTickerUpdatesAsync(Action<DataEvent<IEnumerable<IBinance24HPrice>>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DataEvent<BinanceCombinedStream<IEnumerable<BinanceStreamCoinTick>>>>(data => onMessage(data.As<IEnumerable<IBinance24HPrice>>(data.Data.Data, data.Data.Stream)));
-            return await SubscribeAsync( BaseAddress, new[] { allTickerStreamEndpoint }, handler, ct).ConfigureAwait(false);
+            return await SubscribeAsync(BaseAddress, new[] { allTickerStreamEndpoint }, handler, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -259,7 +258,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
 
             var handler = new Action<DataEvent<BinanceCombinedStream<BinanceStreamAggregatedTrade>>>(data => onMessage(data.As(data.Data.Data, data.Data.Data.Symbol)));
             symbols = symbols.Select(a => a.ToLower(CultureInfo.InvariantCulture) + aggregatedTradesStreamEndpoint).ToArray();
-            return await SubscribeAsync( BaseAddress, symbols, handler, ct).ConfigureAwait(false);
+            return await SubscribeAsync(BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
         #endregion
 
@@ -308,7 +307,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
 
             var handler = new Action<DataEvent<BinanceCombinedStream<BinanceFuturesStreamBookPrice>>>(data => onMessage(data.As(data.Data.Data, data.Data.Data.Symbol)));
             symbols = symbols.Select(a => a.ToLower(CultureInfo.InvariantCulture) + bookTickerStreamEndpoint).ToArray();
-            return await SubscribeAsync( BaseAddress, symbols, handler, ct).ConfigureAwait(false);
+            return await SubscribeAsync(BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -319,7 +318,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
         public async Task<CallResult<UpdateSubscription>> SubscribeToAllBookTickerUpdatesAsync(Action<DataEvent<BinanceFuturesStreamBookPrice>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DataEvent<BinanceCombinedStream<BinanceFuturesStreamBookPrice>>>(data => onMessage(data.As(data.Data.Data, data.Data.Data.Symbol)));
-            return await SubscribeAsync( BaseAddress, new[] { allBookTickerStreamEndpoint }, handler, ct).ConfigureAwait(false);
+            return await SubscribeAsync(BaseAddress, new[] { allBookTickerStreamEndpoint }, handler, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -336,7 +335,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
 
             var handler = new Action<DataEvent<BinanceCombinedStream<BinanceFuturesStreamLiquidationData>>>(data => onMessage(data.As(data.Data.Data.Data, data.Data.Data.Data.Symbol)));
             symbols = symbols.Select(a => a.ToLower(CultureInfo.InvariantCulture) + liquidationStreamEndpoint).ToArray();
-            return await SubscribeAsync( BaseAddress, symbols, handler, ct).ConfigureAwait(false);
+            return await SubscribeAsync(BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -347,7 +346,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
         public async Task<CallResult<UpdateSubscription>> SubscribeToAllLiquidationUpdatesAsync(Action<DataEvent<BinanceFuturesStreamLiquidation>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DataEvent<BinanceCombinedStream<BinanceFuturesStreamLiquidationData>>>(data => onMessage(data.As(data.Data.Data.Data, data.Data.Data.Data.Symbol)));
-            return await SubscribeAsync( BaseAddress, new[] { allLiquidationStreamEndpoint }, handler, ct).ConfigureAwait(false);
+            return await SubscribeAsync(BaseAddress, new[] { allLiquidationStreamEndpoint }, handler, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -371,7 +370,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             });
 
             symbols = symbols.Select(a => a.ToLower(CultureInfo.InvariantCulture) + partialBookDepthStreamEndpoint + levels + (updateInterval.HasValue ? $"@{updateInterval.Value}ms" : "")).ToArray();
-            return await SubscribeAsync( BaseAddress, symbols, handler, ct).ConfigureAwait(false);
+            return await SubscribeAsync(BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -389,7 +388,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             updateInterval?.ValidateIntValues(nameof(updateInterval), 100, 250, 500);
             var handler = new Action<DataEvent<BinanceCombinedStream<BinanceFuturesStreamOrderBookDepth>>>(data => onMessage(data.As<IBinanceFuturesEventOrderBook>(data.Data.Data, data.Data.Data.Symbol)));
             symbols = symbols.Select(a => a.ToLower(CultureInfo.InvariantCulture) + depthStreamEndpoint + (updateInterval.HasValue ? $"@{updateInterval.Value}ms" : "")).ToArray();
-            return await SubscribeAsync( BaseAddress, symbols, handler, ct).ConfigureAwait(false);
+            return await SubscribeAsync(BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -499,7 +498,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
                 }
             });
 
-            return await SubscribeAsync( BaseAddress, new[] { listenKey }, handler, ct).ConfigureAwait(false);
+            return await SubscribeAsync(BaseAddress, new[] { listenKey }, handler, ct).ConfigureAwait(false);
         }
 
         #endregion

--- a/Binance.Net/Clients/GeneralApi/BinanceRestClientGeneralApi.cs
+++ b/Binance.Net/Clients/GeneralApi/BinanceRestClientGeneralApi.cs
@@ -1,5 +1,4 @@
-﻿using Binance.Net.Objects;
-using CryptoExchange.Net.Authentication;
+﻿using CryptoExchange.Net.Authentication;
 using CryptoExchange.Net.Objects;
 using System;
 using System.Collections.Generic;
@@ -44,7 +43,7 @@ namespace Binance.Net.Clients.GeneralApi
 
         #region constructor/destructor
 
-        internal BinanceRestClientGeneralApi(ILogger logger, HttpClient? httpClient, BinanceRestClient baseClient, BinanceRestOptions options) 
+        internal BinanceRestClientGeneralApi(ILogger logger, HttpClient? httpClient, BinanceRestClient baseClient, BinanceRestOptions options)
             : base(logger, httpClient, options.Environment.SpotRestAddress, options, options.SpotOptions)
         {
             _baseClient = baseClient;

--- a/Binance.Net/Clients/GeneralApi/BinanceRestClientGeneralApiSubAccount.cs
+++ b/Binance.Net/Clients/GeneralApi/BinanceRestClientGeneralApiSubAccount.cs
@@ -558,7 +558,7 @@ namespace Binance.Net.Clients.GeneralApi
                 { "subAccountApiKey", apiKey }
             };
 
-            if(ipAddresses != null)
+            if (ipAddresses != null)
                 parameters.AddOptionalParameter("ipAddress", string.Join(",", ipAddresses));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApi.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApi.cs
@@ -1,6 +1,5 @@
 ﻿using Binance.Net.Converters;
 using Binance.Net.Enums;
-using Binance.Net.Objects;
 using CryptoExchange.Net;
 using CryptoExchange.Net.Authentication;
 using CryptoExchange.Net.Objects;
@@ -134,7 +133,7 @@ namespace Binance.Net.Clients.SpotApi
             parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, StaticConverters.StaticTimeInForceConverter));
             parameters.AddOptionalParameter("stopPrice", stopPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("icebergQty", icebergQty?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("sideEffectType", sideEffectType == null ? null : JsonConvert.SerializeObject(sideEffectType,  StaticConverters.StaticSideEffectTypeConverter));
+            parameters.AddOptionalParameter("sideEffectType", sideEffectType == null ? null : JsonConvert.SerializeObject(sideEffectType, StaticConverters.StaticSideEffectTypeConverter));
             parameters.AddOptionalParameter("isIsolated", isIsolated);
             parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, StaticConverters.StaticOrderResponseTypeConverter));
             parameters.AddOptionalParameter("trailingDelta", trailingDelta);
@@ -180,7 +179,7 @@ namespace Binance.Net.Clients.SpotApi
                 _logger.Log(LogLevel.Debug, "Received Invalid Timestamp error, triggering new time sync");
                 _timeSyncState.LastSyncTime = DateTime.MinValue;
             }
-            return result;                    
+            return result;
         }
 
         internal async Task<WebCallResult> SendRequestInternal(Uri uri, HttpMethod method, CancellationToken cancellationToken,
@@ -232,7 +231,7 @@ namespace Binance.Net.Clients.SpotApi
                 throw new ArgumentException(nameof(symbol) + " required for Binance " + nameof(ISpotClient.PlaceOrderAsync), nameof(symbol));
 
             var order = await Trading.PlaceOrderAsync(symbol, GetOrderSide(side), GetOrderType(type), quantity, price: price, timeInForce: type == CommonOrderType.Limit ? TimeInForce.GoodTillCanceled : (TimeInForce?)null, newClientOrderId: clientOrderId, ct: ct).ConfigureAwait(false);
-            if(!order)
+            if (!order)
                 return order.As<OrderId>(null);
 
             return order.As(new OrderId
@@ -336,7 +335,7 @@ namespace Binance.Net.Clients.SpotApi
                     Price = s.Price,
                     Quantity = s.Quantity,
                     QuantityFilled = s.QuantityFilled,
-                    Side = s.Side == Enums.OrderSide.Buy ? CommonOrderSide.Buy: CommonOrderSide.Sell,
+                    Side = s.Side == Enums.OrderSide.Buy ? CommonOrderSide.Buy : CommonOrderSide.Sell,
                     Type = GetOrderType(s.Type),
                     Status = GetOrderStatus(s.Status),
                     Timestamp = s.CreateTime
@@ -435,8 +434,8 @@ namespace Binance.Net.Clients.SpotApi
                 OpenTime = t.OpenTime,
                 ClosePrice = t.ClosePrice,
                 OpenPrice = t.OpenPrice,
-                Volume  = t.Volume
-            })); 
+                Volume = t.Volume
+            }));
         }
 
         async Task<WebCallResult<OrderBook>> IBaseRestClient.GetOrderBookAsync(string symbol, CancellationToken ct)

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApi.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApi.cs
@@ -124,19 +124,19 @@ namespace Binance.Net.Clients.SpotApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
-                { "type", JsonConvert.SerializeObject(type, new SpotOrderTypeConverter(false)) }
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticSpotOrderTypeConverter) }
             };
             parameters.AddOptionalParameter("quantity", quantity?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("quoteOrderQty", quoteQuantity?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("newClientOrderId", newClientOrderId);
             parameters.AddOptionalParameter("price", price?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, new TimeInForceConverter(false)));
+            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, StaticConverters.StaticTimeInForceConverter));
             parameters.AddOptionalParameter("stopPrice", stopPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("icebergQty", icebergQty?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("sideEffectType", sideEffectType == null ? null : JsonConvert.SerializeObject(sideEffectType, new SideEffectTypeConverter(false)));
+            parameters.AddOptionalParameter("sideEffectType", sideEffectType == null ? null : JsonConvert.SerializeObject(sideEffectType,  StaticConverters.StaticSideEffectTypeConverter));
             parameters.AddOptionalParameter("isIsolated", isIsolated);
-            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, new OrderResponseTypeConverter(false)));
+            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, StaticConverters.StaticOrderResponseTypeConverter));
             parameters.AddOptionalParameter("trailingDelta", trailingDelta);
             parameters.AddOptionalParameter("strategyId", strategyId);
             parameters.AddOptionalParameter("strategyType", strategyType);

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiAccount.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiAccount.cs
@@ -184,7 +184,7 @@ namespace Binance.Net.Clients.SpotApi
             parameters.AddOptionalParameter("network", network);
             parameters.AddOptionalParameter("transactionFeeFlag", transactionFeeFlag);
             parameters.AddOptionalParameter("addressTag", addressTag);
-            parameters.AddOptionalParameter("walletType", walletType != null ? JsonConvert.SerializeObject(walletType, new WalletTypeConverter(false)) : null);
+            parameters.AddOptionalParameter("walletType", walletType != null ? JsonConvert.SerializeObject(walletType, StaticConverters.StaticWalletTypeConverter) : null);
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
             var result = await _baseClient.SendRequestInternal<BinanceWithdrawalPlaced>(_baseClient.GetUrl(withdrawEndpoint, "sapi", "1"), HttpMethod.Post, ct, parameters, true, HttpMethodParameterPosition.InUri).ConfigureAwait(false);
@@ -200,7 +200,7 @@ namespace Binance.Net.Clients.SpotApi
             var parameters = new Dictionary<string, object>();
             parameters.AddOptionalParameter("coin", asset);
             parameters.AddOptionalParameter("withdrawOrderId", withdrawOrderId);
-            parameters.AddOptionalParameter("status", status != null ? JsonConvert.SerializeObject(status, new WithdrawalStatusConverter(false)) : null);
+            parameters.AddOptionalParameter("status", status != null ? JsonConvert.SerializeObject(status, StaticConverters.StaticWithdrawalStatusConverter) : null);
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
@@ -221,7 +221,7 @@ namespace Binance.Net.Clients.SpotApi
             parameters.AddOptionalParameter("coin", asset);
             parameters.AddOptionalParameter("offset", offset?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("status", status != null ? JsonConvert.SerializeObject(status, new DepositStatusConverter(false)) : null);
+            parameters.AddOptionalParameter("status", status != null ? JsonConvert.SerializeObject(status, StaticConverters.StaticDepositStatusConverter) : null);
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
@@ -475,7 +475,7 @@ namespace Binance.Net.Clients.SpotApi
         {
             var parameters = new Dictionary<string, object>
             {
-                { "type", JsonConvert.SerializeObject(type, new UniversalTransferTypeConverter(false)) },
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticUniversalTransferTypeConverter) },
                 { "asset", asset },
                 { "amount", quantity.ToString(CultureInfo.InvariantCulture) }
             };
@@ -494,7 +494,7 @@ namespace Binance.Net.Clients.SpotApi
         {
             var parameters = new Dictionary<string, object>
             {
-                { "type", JsonConvert.SerializeObject(type, new UniversalTransferTypeConverter(false)) }
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticUniversalTransferTypeConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
@@ -578,7 +578,7 @@ namespace Binance.Net.Clients.SpotApi
             {
                 { "asset", asset },
                 { "amount", quantity.ToString(CultureInfo.InvariantCulture) },
-                { "type", JsonConvert.SerializeObject(type, new TransferDirectionTypeConverter(false)) }
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticTransferDirectionTypeConverter) }
             };
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
@@ -653,7 +653,7 @@ namespace Binance.Net.Clients.SpotApi
 
             var parameters = new Dictionary<string, object>
             {
-                { "direction", JsonConvert.SerializeObject(direction, new TransferDirectionConverter(false)) }
+                { "direction", JsonConvert.SerializeObject(direction,  StaticConverters.StaticTransferDirectionConverter) }
             };
             parameters.AddOptionalParameter("size", limit?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("current", page?.ToString(CultureInfo.InvariantCulture));
@@ -907,11 +907,11 @@ namespace Binance.Net.Clients.SpotApi
             parameters.AddOptionalParameter("from",
                 !from.HasValue
                     ? null
-                    : JsonConvert.SerializeObject(from, new IsolatedMarginTransferDirectionConverter(false)));
+                    : JsonConvert.SerializeObject(from, StaticConverters.StaticIsolatedMarginTransferDirectionConverter));
             parameters.AddOptionalParameter("to",
                 !to.HasValue
                     ? null
-                    : JsonConvert.SerializeObject(to, new IsolatedMarginTransferDirectionConverter(false)));
+                    : JsonConvert.SerializeObject(to, StaticConverters.StaticIsolatedMarginTransferDirectionConverter));
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("current", current?.ToString(CultureInfo.InvariantCulture));
@@ -1026,8 +1026,8 @@ namespace Binance.Net.Clients.SpotApi
             {
                 {"asset", asset},
                 {"symbol", symbol},
-                {"transFrom", JsonConvert.SerializeObject(from, new IsolatedMarginTransferDirectionConverter(false))},
-                {"transTo", JsonConvert.SerializeObject(to, new IsolatedMarginTransferDirectionConverter(false))},
+                {"transFrom", JsonConvert.SerializeObject(from, StaticConverters.StaticIsolatedMarginTransferDirectionConverter)},
+                {"transTo", JsonConvert.SerializeObject(to, StaticConverters.StaticIsolatedMarginTransferDirectionConverter)},
                 {"amount", quantity.ToString(CultureInfo.InvariantCulture)}
             };
             parameters.AddOptionalParameter("recvWindow",

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiAccount.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiAccount.cs
@@ -1206,7 +1206,7 @@ namespace Binance.Net.Clients.SpotApi
             parameters.AddOptionalParameter("tokenName", tokenName);
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
-            return await _baseClient.SendRequestInternal<IEnumerable<BinanceBlvtUserLimit>>(_baseClient.GetUrl(blvtUserLimitEndpoint, marginApi, marginVersion), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);           
+            return await _baseClient.SendRequestInternal<IEnumerable<BinanceBlvtUserLimit>>(_baseClient.GetUrl(blvtUserLimitEndpoint, marginApi, marginVersion), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
         }
 
         #endregion
@@ -1244,13 +1244,13 @@ namespace Binance.Net.Clients.SpotApi
         #region Portfolio margin
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BinancePortfolioMarginInfo>> GetPortfolioMarginAccountInfoAsync (long? receiveWindow = null, CancellationToken ct = default)
+        public async Task<WebCallResult<BinancePortfolioMarginInfo>> GetPortfolioMarginAccountInfoAsync(long? receiveWindow = null, CancellationToken ct = default)
         {
             var parameters = new Dictionary<string, object>();
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
             return await _baseClient.SendRequestInternal<BinancePortfolioMarginInfo>(_baseClient.GetUrl(portfolioMarginAccountEndpoint, marginApi, marginVersion), HttpMethod.Get, ct, parameters, true, weight: 1).ConfigureAwait(false);
         }
-        
+
         /// <inheritdoc />
         public async Task<WebCallResult<IEnumerable<BinancePortfolioMarginCollateralRate>>> GetPortfolioMarginCollateralRateAsync(long? receiveWindow = null, CancellationToken ct = default)
         {

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiExchangeData.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiExchangeData.cs
@@ -109,7 +109,7 @@ namespace Binance.Net.Clients.SpotApi
         public async Task<WebCallResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default)
         {
             var result = await _baseClient.SendRequestInternal<BinanceCheckTime>(_baseClient.GetUrl(checkTimeEndpoint, api, publicVersion), HttpMethod.Get, ct, ignoreRateLimit: true).ConfigureAwait(false);
-            return result.As(result.Data?.ServerTime ?? default);            
+            return result.As(result.Data?.ServerTime ?? default);
         }
 
         #endregion
@@ -362,10 +362,10 @@ namespace Binance.Net.Clients.SpotApi
         /// <inheritdoc />
         public async Task<WebCallResult<IEnumerable<IBinanceTick>>> GetTickersAsync(IEnumerable<string> symbols, CancellationToken ct = default)
         {
-            foreach(var symbol in symbols)
+            foreach (var symbol in symbols)
                 symbol.ValidateBinanceSymbol();
 
-            var parameters = new Dictionary<string, object> { { "symbols", $"[{string.Join("," ,symbols.Select(s => $"\"{s}\""))}]" } };
+            var parameters = new Dictionary<string, object> { { "symbols", $"[{string.Join(",", symbols.Select(s => $"\"{s}\""))}]" } };
             var symbolCount = symbols.Count();
             var weight = symbolCount <= 20 ? 1 : symbolCount <= 100 ? 20 : 40;
             var result = await _baseClient.SendRequestInternal<IEnumerable<Binance24HPrice>>(_baseClient.GetUrl(price24HEndpoint, api, publicVersion), HttpMethod.Get, ct, parameters, weight: weight).ConfigureAwait(false);
@@ -435,7 +435,7 @@ namespace Binance.Net.Clients.SpotApi
         /// <inheritdoc />
         public async Task<WebCallResult<IEnumerable<BinancePrice>>> GetPricesAsync(IEnumerable<string> symbols, CancellationToken ct = default)
         {
-            foreach(var symbol in symbols)
+            foreach (var symbol in symbols)
                 symbol.ValidateBinanceSymbol();
 
             var parameters = new Dictionary<string, object> { { "symbols", $"[{string.Join(",", symbols.Select(s => $"\"{s}\""))}]" } };
@@ -464,7 +464,7 @@ namespace Binance.Net.Clients.SpotApi
         /// <inheritdoc />
         public async Task<WebCallResult<IEnumerable<BinanceBookPrice>>> GetBookPricesAsync(IEnumerable<string> symbols, CancellationToken ct = default)
         {
-            foreach(var symbol in symbols)
+            foreach (var symbol in symbols)
                 symbol.ValidateBinanceSymbol();
             var parameters = new Dictionary<string, object> { { "symbols", $"[{string.Join(",", symbols.Select(s => $"\"{s}\""))}]" } };
 

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiExchangeData.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiExchangeData.cs
@@ -301,7 +301,7 @@ namespace Binance.Net.Clients.SpotApi
             limit?.ValidateIntBetween(nameof(limit), 1, 1500);
             var parameters = new Dictionary<string, object> {
                 { "symbol", symbol },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
@@ -322,7 +322,7 @@ namespace Binance.Net.Clients.SpotApi
             limit?.ValidateIntBetween(nameof(limit), 1, 1500);
             var parameters = new Dictionary<string, object> {
                 { "symbol", symbol },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
@@ -625,7 +625,7 @@ namespace Binance.Net.Clients.SpotApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiTrading.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiTrading.cs
@@ -232,7 +232,7 @@ namespace Binance.Net.Clients.SpotApi
 
             var result = await _baseClient.SendRequestInternal<BinanceOrderBase>(_baseClient.GetUrl(cancelOrderEndpoint, api, signedVersion), HttpMethod.Delete, ct, parameters, true).ConfigureAwait(false);
             if (result)
-                    _baseClient.InvokeOrderCanceled(new OrderId() { SourceObject = result.Data, Id = result.Data.Id.ToString(CultureInfo.InvariantCulture) });
+                _baseClient.InvokeOrderCanceled(new OrderId() { SourceObject = result.Data, Id = result.Data.Id.ToString(CultureInfo.InvariantCulture) });
             return result;
         }
 
@@ -273,7 +273,7 @@ namespace Binance.Net.Clients.SpotApi
             decimal? icebergQty = null,
             OrderResponseType? orderResponseType = null,
             int? trailingDelta = null,
-            int? strategyId = null, 
+            int? strategyId = null,
             int? strategyType = null,
             int? receiveWindow = null,
             CancellationToken ct = default)
@@ -346,7 +346,7 @@ namespace Binance.Net.Clients.SpotApi
             return result;
         }
         #endregion
-         
+
         #region Query Order
 
         /// <inheritdoc />
@@ -801,7 +801,7 @@ namespace Binance.Net.Clients.SpotApi
             };
             parameters.AddOptionalParameter("stopLimitPrice", stopLimitPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("isIsolated", isIsolated?.ToString());
-            parameters.AddOptionalParameter("sideEffectType", sideEffectType == null ? null : JsonConvert.SerializeObject(sideEffectType,  StaticConverters.StaticSideEffectTypeConverter));
+            parameters.AddOptionalParameter("sideEffectType", sideEffectType == null ? null : JsonConvert.SerializeObject(sideEffectType, StaticConverters.StaticSideEffectTypeConverter));
             parameters.AddOptionalParameter("listClientOrderId", listClientOrderId);
             parameters.AddOptionalParameter("limitClientOrderId", limitClientOrderId);
             parameters.AddOptionalParameter("stopClientOrderId", stopClientOrderId);
@@ -1330,6 +1330,6 @@ namespace Binance.Net.Clients.SpotApi
 
             return await _baseClient.SendRequestInternal<IEnumerable<BinancePreventedTrade>>(_baseClient.GetUrl("myPreventedMatches", "api", "3"), HttpMethod.Get, ct, parameters, true, weight: 5).ConfigureAwait(false);
         }
-#endregion
+        #endregion
     }
 }

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiTrading.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiTrading.cs
@@ -304,8 +304,8 @@ namespace Binance.Net.Clients.SpotApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
-                { "type", JsonConvert.SerializeObject(type, new SpotOrderTypeConverter(false)) },
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticSpotOrderTypeConverter) },
                 { "cancelReplaceMode", EnumConverter.GetString(cancelReplaceMode) }
             };
             parameters.AddOptionalParameter("cancelNewClientOrderId", newCancelClientOrderId);
@@ -317,10 +317,10 @@ namespace Binance.Net.Clients.SpotApi
             parameters.AddOptionalParameter("quantity", quantity?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("quoteOrderQty", quoteQuantity?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("price", price?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, new TimeInForceConverter(false)));
+            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, StaticConverters.StaticTimeInForceConverter));
             parameters.AddOptionalParameter("stopPrice", stopPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("icebergQty", icebergQty?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, new OrderResponseTypeConverter(false)));
+            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, StaticConverters.StaticOrderResponseTypeConverter));
             parameters.AddOptionalParameter("trailingDelta", trailingDelta);
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
@@ -448,7 +448,7 @@ namespace Binance.Net.Clients.SpotApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
                 { "quantity", quantity.ToString(CultureInfo.InvariantCulture) },
                 { "price", price.ToString(CultureInfo.InvariantCulture) },
                 { "stopPrice", stopPrice.ToString(CultureInfo.InvariantCulture) }
@@ -466,7 +466,7 @@ namespace Binance.Net.Clients.SpotApi
             parameters.AddOptionalParameter("stopClientOrderId", stopClientOrderId);
             parameters.AddOptionalParameter("limitIcebergQty", limitIcebergQuantity);
             parameters.AddOptionalParameter("stopIcebergQty", stopIcebergQuantity);
-            parameters.AddOptionalParameter("stopLimitTimeInForce", stopLimitTimeInForce == null ? null : JsonConvert.SerializeObject(stopLimitTimeInForce, new TimeInForceConverter(false)));
+            parameters.AddOptionalParameter("stopLimitTimeInForce", stopLimitTimeInForce == null ? null : JsonConvert.SerializeObject(stopLimitTimeInForce, StaticConverters.StaticTimeInForceConverter));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
             return await _baseClient.SendRequestInternal<BinanceOrderOcoList>(_baseClient.GetUrl(newOcoOrderEndpoint, api, signedVersion), HttpMethod.Post, ct, parameters, true).ConfigureAwait(false);
@@ -794,21 +794,21 @@ namespace Binance.Net.Clients.SpotApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
                 { "quantity", quantity.ToString(CultureInfo.InvariantCulture) },
                 { "price", price.ToString(CultureInfo.InvariantCulture) },
                 { "stopPrice", stopPrice.ToString(CultureInfo.InvariantCulture) }
             };
             parameters.AddOptionalParameter("stopLimitPrice", stopLimitPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("isIsolated", isIsolated?.ToString());
-            parameters.AddOptionalParameter("sideEffectType", sideEffectType == null ? null : JsonConvert.SerializeObject(sideEffectType, new SideEffectTypeConverter(false)));
+            parameters.AddOptionalParameter("sideEffectType", sideEffectType == null ? null : JsonConvert.SerializeObject(sideEffectType,  StaticConverters.StaticSideEffectTypeConverter));
             parameters.AddOptionalParameter("listClientOrderId", listClientOrderId);
             parameters.AddOptionalParameter("limitClientOrderId", limitClientOrderId);
             parameters.AddOptionalParameter("stopClientOrderId", stopClientOrderId);
             parameters.AddOptionalParameter("limitIcebergQty", limitIcebergQuantity?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, new OrderResponseTypeConverter(false)));
+            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, StaticConverters.StaticOrderResponseTypeConverter));
             parameters.AddOptionalParameter("stopIcebergQty", stopIcebergQuantity?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("stopLimitTimeInForce", stopLimitTimeInForce == null ? null : JsonConvert.SerializeObject(stopLimitTimeInForce, new TimeInForceConverter(false)));
+            parameters.AddOptionalParameter("stopLimitTimeInForce", stopLimitTimeInForce == null ? null : JsonConvert.SerializeObject(stopLimitTimeInForce, StaticConverters.StaticTimeInForceConverter));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
             return await _baseClient.SendRequestInternal<BinanceMarginOrderOcoList>(_baseClient.GetUrl(newMarginOCOOrderEndpoint, marginApi, marginVersion), HttpMethod.Post, ct, parameters, true, weight: 6).ConfigureAwait(false);
@@ -1156,7 +1156,7 @@ namespace Binance.Net.Clients.SpotApi
         public async Task<WebCallResult<IEnumerable<BinanceC2CUserTrade>>> GetC2CTradeHistoryAsync(OrderSide side, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, long? receiveWindow = null, CancellationToken ct = default)
         {
             var parameters = new Dictionary<string, object>();
-            parameters.AddOptionalParameter("tradeType", JsonConvert.SerializeObject(side, new OrderSideConverter(false)));
+            parameters.AddOptionalParameter("tradeType", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter));
             parameters.AddOptionalParameter("startTimestamp", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTimestamp", DateTimeConverter.ConvertToMilliseconds(endTime));
             parameters.AddOptionalParameter("page", page);

--- a/Binance.Net/Clients/SpotApi/BinanceSocketClientSpotApiAccount.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceSocketClientSpotApiAccount.cs
@@ -9,7 +9,6 @@ using CryptoExchange.Net;
 using CryptoExchange.Net.Objects;
 using System.Collections.Generic;
 using Binance.Net.Objects.Models.Spot;
-using CryptoExchange.Net.Converters;
 using Binance.Net.Interfaces.Clients.SpotApi;
 using Binance.Net.Objects;
 

--- a/Binance.Net/Clients/SpotApi/BinanceSocketClientSpotApiExchangeData.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceSocketClientSpotApiExchangeData.cs
@@ -302,7 +302,7 @@ namespace Binance.Net.Clients.SpotApi
             symbols = symbols.SelectMany(a =>
                 intervals.Select(i =>
                     a.ToLower(CultureInfo.InvariantCulture) + "@kline" + "_" +
-                    JsonConvert.SerializeObject(i,  StaticConverters.StaticKlineIntervalConverter))).ToArray();
+                    JsonConvert.SerializeObject(i, StaticConverters.StaticKlineIntervalConverter))).ToArray();
             return await _client.SubscribeAsync(_client.BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
 
@@ -511,7 +511,7 @@ namespace Binance.Net.Clients.SpotApi
             if (address == null)
                 throw new Exception("No url found for Blvt stream, check the `BlvtSocketAddress` in the client environment");
 
-            tokens = tokens.Select(a => a.ToUpper(CultureInfo.InvariantCulture) + "@nav_kline" + "_" + JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter)).ToArray();
+            tokens = tokens.Select(a => a.ToUpper(CultureInfo.InvariantCulture) + "@nav_kline" + "_" + JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter)).ToArray();
             var handler = new Action<DataEvent<BinanceCombinedStream<BinanceStreamKlineData>>>(data => onMessage(data.As(data.Data.Data, data.Data.Data.Symbol)));
             return await _client.SubscribeAsync(address.AppendPath("lvt-p"), tokens, handler, ct).ConfigureAwait(false);
         }

--- a/Binance.Net/Clients/SpotApi/BinanceSocketClientSpotApiExchangeData.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceSocketClientSpotApiExchangeData.cs
@@ -302,7 +302,7 @@ namespace Binance.Net.Clients.SpotApi
             symbols = symbols.SelectMany(a =>
                 intervals.Select(i =>
                     a.ToLower(CultureInfo.InvariantCulture) + "@kline" + "_" +
-                    JsonConvert.SerializeObject(i, new KlineIntervalConverter(false)))).ToArray();
+                    JsonConvert.SerializeObject(i,  StaticConverters.StaticKlineIntervalConverter))).ToArray();
             return await _client.SubscribeAsync(_client.BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
 
@@ -511,7 +511,7 @@ namespace Binance.Net.Clients.SpotApi
             if (address == null)
                 throw new Exception("No url found for Blvt stream, check the `BlvtSocketAddress` in the client environment");
 
-            tokens = tokens.Select(a => a.ToUpper(CultureInfo.InvariantCulture) + "@nav_kline" + "_" + JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false))).ToArray();
+            tokens = tokens.Select(a => a.ToUpper(CultureInfo.InvariantCulture) + "@nav_kline" + "_" + JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter)).ToArray();
             var handler = new Action<DataEvent<BinanceCombinedStream<BinanceStreamKlineData>>>(data => onMessage(data.As(data.Data.Data, data.Data.Data.Symbol)));
             return await _client.SubscribeAsync(address.AppendPath("lvt-p"), tokens, handler, ct).ConfigureAwait(false);
         }

--- a/Binance.Net/Clients/SpotApi/BinanceSocketClientSpotApiTrading.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceSocketClientSpotApiTrading.cs
@@ -172,8 +172,8 @@ namespace Binance.Net.Clients.SpotApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
-                { "type", JsonConvert.SerializeObject(type, new SpotOrderTypeConverter(false)) },
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticSpotOrderTypeConverter) },
                 { "cancelReplaceMode", EnumConverter.GetString(cancelReplaceMode) }
             };
             parameters.AddOptionalParameter("cancelNewClientOrderId", newCancelClientOrderId);
@@ -185,10 +185,10 @@ namespace Binance.Net.Clients.SpotApi
             parameters.AddOptionalParameter("quantity", quantity?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("quoteOrderQty", quoteQuantity?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("price", price?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, new TimeInForceConverter(false)));
+            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, StaticConverters.StaticTimeInForceConverter));
             parameters.AddOptionalParameter("stopPrice", stopPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("icebergQty", icebergQty?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, new OrderResponseTypeConverter(false)));
+            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, StaticConverters.StaticOrderResponseTypeConverter));
             parameters.AddOptionalParameter("trailingDelta", trailingDelta?.ToString(CultureInfo.InvariantCulture));
 
             return await _client.QueryAsync<BinanceReplaceOrderResult>(_client.ClientOptions.Environment.SpotSocketApiAddress.AppendPath("ws-api/v3"), $"order.cancelReplace", parameters, true, true).ConfigureAwait(false);
@@ -249,7 +249,7 @@ namespace Binance.Net.Clients.SpotApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
                 { "quantity", quantity.ToString(CultureInfo.InvariantCulture) },
                 { "price", price.ToString(CultureInfo.InvariantCulture) },
                 { "stopPrice", stopPrice.ToString(CultureInfo.InvariantCulture) }
@@ -271,7 +271,7 @@ namespace Binance.Net.Clients.SpotApi
             parameters.AddOptionalParameter("stopIcebergQty", stopIcebergQty?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("stopIcebergQty", stopIcebergQuantity?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("stopClientOrderId", stopClientOrderId);
-            parameters.AddOptionalParameter("stopLimitTimeInForce", stopLimitTimeInForce == null ? null : JsonConvert.SerializeObject(stopLimitTimeInForce, new TimeInForceConverter(false)));
+            parameters.AddOptionalParameter("stopLimitTimeInForce", stopLimitTimeInForce == null ? null : JsonConvert.SerializeObject(stopLimitTimeInForce, StaticConverters.StaticTimeInForceConverter));
 
             return await _client.QueryAsync<BinanceOrderOcoList>(_client.ClientOptions.Environment.SpotSocketApiAddress.AppendPath("ws-api/v3"), $"orderList.place", parameters, true, true).ConfigureAwait(false);
         }

--- a/Binance.Net/Clients/SpotApi/BinanceSocketClientSpotApiTrading.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceSocketClientSpotApiTrading.cs
@@ -8,7 +8,6 @@ using Binance.Net.Enums;
 using Binance.Net.Converters;
 using Newtonsoft.Json;
 using System.Globalization;
-using System.Net.Http;
 using System;
 using Binance.Net.Interfaces.Clients.SpotApi;
 using Binance.Net.Objects;

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApi.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApi.cs
@@ -1,5 +1,4 @@
 ﻿using Binance.Net.Enums;
-using Binance.Net.Objects;
 using CryptoExchange.Net.Authentication;
 using CryptoExchange.Net.Objects;
 using Microsoft.Extensions.Logging;
@@ -99,7 +98,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
         /// <inheritdoc />
         protected override AuthenticationProvider CreateAuthenticationProvider(ApiCredentials credentials)
             => new BinanceAuthenticationProvider(credentials);
-       
+
         internal Uri GetUrl(string endpoint, string api, string? version = null)
         {
             var result = BaseAddress.AppendPath(api);
@@ -317,7 +316,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
                     MarkPrice = p.MarkPrice,
                     Quantity = p.Quantity,
                     UnrealizedPnl = p.UnrealizedPnl,
-                    Side = p.PositionSide == PositionSide.Long ? CommonPositionSide.Long : p.PositionSide == PositionSide.Short ? CommonPositionSide.Short: CommonPositionSide.Both                    
+                    Side = p.PositionSide == PositionSide.Long ? CommonPositionSide.Long : p.PositionSide == PositionSide.Short ? CommonPositionSide.Short : CommonPositionSide.Both
                 }
             ));
         }

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiAccount.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiAccount.cs
@@ -200,7 +200,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
             parameters.AddOptionalParameter("symbol", symbol);
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
-            if(symbol == null)            
+            if (symbol == null)
                 return await _baseClient.SendRequestInternal<IEnumerable<BinanceFuturesQuantileEstimation>>(_baseClient.GetUrl(adlQuantileEndpoint, api, signedVersion), HttpMethod.Get, ct, parameters, true, weight: 5).ConfigureAwait(false);
 
             var result = await _baseClient.SendRequestInternal<BinanceFuturesQuantileEstimation>(_baseClient.GetUrl(adlQuantileEndpoint, api, signedVersion), HttpMethod.Get, ct, parameters, true, weight: 5).ConfigureAwait(false);

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiAccount.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiAccount.cs
@@ -108,7 +108,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "marginType", JsonConvert.SerializeObject(marginType, new FuturesMarginTypeConverter(false)) }
+                { "marginType", JsonConvert.SerializeObject(marginType, StaticConverters.StaticFuturesMarginTypeConverter) }
             };
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
@@ -126,9 +126,9 @@ namespace Binance.Net.Clients.UsdFuturesApi
             {
                 { "symbol", symbol },
                 { "amount", quantity.ToString(CultureInfo.InvariantCulture) },
-                { "type", JsonConvert.SerializeObject(type, new FuturesMarginChangeDirectionTypeConverter(false)) }
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticFuturesMarginChangeDirectionTypeConverter) }
             };
-            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, new PositionSideConverter(false)));
+            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, StaticConverters.StaticPositionSideConverter));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
             return await _baseClient.SendRequestInternal<BinanceFuturesPositionMarginResult>(_baseClient.GetUrl(positionMarginEndpoint, api, signedVersion), HttpMethod.Post, ct, parameters, true).ConfigureAwait(false);
@@ -145,7 +145,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
             {
                 { "symbol", symbol }
             };
-            parameters.AddOptionalParameter("type", type.HasValue ? JsonConvert.SerializeObject(type, new FuturesMarginChangeDirectionTypeConverter(false)) : null);
+            parameters.AddOptionalParameter("type", type.HasValue ? JsonConvert.SerializeObject(type, StaticConverters.StaticFuturesMarginChangeDirectionTypeConverter) : null);
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiExchangeData.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiExchangeData.cs
@@ -171,7 +171,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
             var url = _baseClient.GetUrl(topLongShortAccountRatioEndpoint, tradingDataapi);
             var parameters = new Dictionary<string, object> {
                 { url.ToString().Contains("dapi") ? "pair": "symbol", symbolPair },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -193,7 +193,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
             var url = _baseClient.GetUrl(topLongShortPositionRatioEndpoint, tradingDataapi);
             var parameters = new Dictionary<string, object> {
                 { url.ToString().Contains("dapi") ? "pair": "symbol", symbolPair },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -215,7 +215,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
             var url = _baseClient.GetUrl(globalLongShortAccountRatioEndpoint, tradingDataapi);
             var parameters = new Dictionary<string, object> {
                 { url.ToString().Contains("dapi") ? "pair": "symbol", symbolPair },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -236,7 +236,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
 
             var parameters = new Dictionary<string, object> {
                 { "symbol", symbol },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -329,7 +329,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
             limit?.ValidateIntBetween(nameof(limit), 1, 1500);
             var parameters = new Dictionary<string, object> {
                 { "symbol", symbol },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
@@ -388,7 +388,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
 
             var parameters = new Dictionary<string, object> {
                 { "symbol", symbol },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -409,7 +409,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
 
             var parameters = new Dictionary<string, object> {
                 { "symbol", symbol },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -461,8 +461,8 @@ namespace Binance.Net.Clients.UsdFuturesApi
             limit?.ValidateIntBetween(nameof(limit), 1, 1500);
             var parameters = new Dictionary<string, object> {
                 { "pair", pair },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) },
-                { "contractType", JsonConvert.SerializeObject(contractType, new ContractTypeConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter) },
+                { "contractType", JsonConvert.SerializeObject(contractType, StaticConverters.StaticContractTypeConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
@@ -483,7 +483,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
             limit?.ValidateIntBetween(nameof(limit), 1, 1500);
             var parameters = new Dictionary<string, object> {
                 { "pair", pair },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiTrading.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiTrading.cs
@@ -105,21 +105,21 @@ namespace Binance.Net.Clients.UsdFuturesApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
-                { "type", JsonConvert.SerializeObject(type, new FuturesOrderTypeConverter(false)) }
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticFuturesOrderTypeConverter) }
             };
             parameters.AddOptionalParameter("quantity", quantity?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("newClientOrderId", newClientOrderId);
             parameters.AddOptionalParameter("price", price?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, new TimeInForceConverter(false)));
-            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, new PositionSideConverter(false)));
+            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, StaticConverters.StaticTimeInForceConverter));
+            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, StaticConverters.StaticPositionSideConverter));
             parameters.AddOptionalParameter("stopPrice", stopPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("activationPrice", activationPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("callbackRate", callbackRate?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("workingType", workingType == null ? null : JsonConvert.SerializeObject(workingType, new WorkingTypeConverter(false)));
+            parameters.AddOptionalParameter("workingType", workingType == null ? null : JsonConvert.SerializeObject(workingType, StaticConverters.StaticWorkingTypeConverter));
             parameters.AddOptionalParameter("reduceOnly", reduceOnly?.ToString().ToLower());
             parameters.AddOptionalParameter("closePosition", closePosition?.ToString().ToLower());
-            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, new OrderResponseTypeConverter(false)));
+            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, StaticConverters.StaticOrderResponseTypeConverter));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("priceProtect", priceProtect?.ToString().ToUpper());
 
@@ -172,20 +172,20 @@ namespace Binance.Net.Clients.UsdFuturesApi
                 var orderParameters = new Dictionary<string, object>()
                 {
                     { "symbol", order.Symbol },
-                    { "side", JsonConvert.SerializeObject(order.Side, new OrderSideConverter(false)) },
-                    { "type", JsonConvert.SerializeObject(order.Type, new FuturesOrderTypeConverter(false)) },
+                    { "side", JsonConvert.SerializeObject(order.Side, StaticConverters.StaticOrderSideConverter) },
+                    { "type", JsonConvert.SerializeObject(order.Type, StaticConverters.StaticFuturesOrderTypeConverter) },
                     { "newOrderRespType", "RESULT" }
                 };
 
                 orderParameters.AddOptionalParameter("quantity", order.Quantity?.ToString(CultureInfo.InvariantCulture));
                 orderParameters.AddOptionalParameter("newClientOrderId", order.NewClientOrderId);
                 orderParameters.AddOptionalParameter("price", order.Price?.ToString(CultureInfo.InvariantCulture));
-                orderParameters.AddOptionalParameter("timeInForce", order.TimeInForce == null ? null : JsonConvert.SerializeObject(order.TimeInForce, new TimeInForceConverter(false)));
-                orderParameters.AddOptionalParameter("positionSide", order.PositionSide == null ? null : JsonConvert.SerializeObject(order.PositionSide, new PositionSideConverter(false)));
+                orderParameters.AddOptionalParameter("timeInForce", order.TimeInForce == null ? null : JsonConvert.SerializeObject(order.TimeInForce, StaticConverters.StaticTimeInForceConverter));
+                orderParameters.AddOptionalParameter("positionSide", order.PositionSide == null ? null : JsonConvert.SerializeObject(order.PositionSide, StaticConverters.StaticPositionSideConverter));
                 orderParameters.AddOptionalParameter("stopPrice", order.StopPrice?.ToString(CultureInfo.InvariantCulture));
                 orderParameters.AddOptionalParameter("activationPrice", order.ActivationPrice?.ToString(CultureInfo.InvariantCulture));
                 orderParameters.AddOptionalParameter("callbackRate", order.CallbackRate?.ToString(CultureInfo.InvariantCulture));
-                orderParameters.AddOptionalParameter("workingType", order.WorkingType == null ? null : JsonConvert.SerializeObject(order.WorkingType, new WorkingTypeConverter(false)));
+                orderParameters.AddOptionalParameter("workingType", order.WorkingType == null ? null : JsonConvert.SerializeObject(order.WorkingType, StaticConverters.StaticWorkingTypeConverter));
                 orderParameters.AddOptionalParameter("reduceOnly", order.ReduceOnly?.ToString().ToLower());
                 orderParameters.AddOptionalParameter("priceProtect", order.PriceProtect?.ToString().ToUpper());
                 parameterOrders[i] = orderParameters;
@@ -458,11 +458,11 @@ namespace Binance.Net.Clients.UsdFuturesApi
             var parameters = new Dictionary<string, object>()
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
                 { "quantity", quantity.ToString(CultureInfo.InvariantCulture) },
                 { "urgency", EnumConverter.GetString(urgency) },
             };
-            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, new PositionSideConverter(false)));
+            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, StaticConverters.StaticPositionSideConverter));
             parameters.AddOptionalParameter("clientAlgoId", clientOrderId);
             parameters.AddOptionalParameter("reduceOnly", reduceOnly);
             parameters.AddOptionalParameter("limitPrice", limitPrice);
@@ -490,11 +490,11 @@ namespace Binance.Net.Clients.UsdFuturesApi
             var parameters = new Dictionary<string, object>()
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
                 { "quantity", quantity.ToString(CultureInfo.InvariantCulture) },
                 { "duration", duration },
             };
-            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, new PositionSideConverter(false)));
+            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, StaticConverters.StaticPositionSideConverter));
             parameters.AddOptionalParameter("clientAlgoId", clientOrderId);
             parameters.AddOptionalParameter("reduceOnly", reduceOnly);
             parameters.AddOptionalParameter("limitPrice", limitPrice);
@@ -538,7 +538,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
         {
             var parameters = new Dictionary<string, object>();
             parameters.AddOptionalParameter("symbol", symbol);
-            parameters.AddOptionalParameter("side", side == null? null: JsonConvert.SerializeObject(side, new OrderSideConverter(false)));
+            parameters.AddOptionalParameter("side", side == null? null: JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter));
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
             parameters.AddOptionalParameter("page", page);

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiTrading.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiTrading.cs
@@ -48,7 +48,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
         private readonly ILogger _logger;
 
         private readonly BinanceRestClientUsdFuturesApi _baseClient;
-        private readonly string _spotBaseAddress; 
+        private readonly string _spotBaseAddress;
 
         internal BinanceRestClientUsdFuturesApiTrading(ILogger logger, BinanceRestClientUsdFuturesApi baseClient)
         {
@@ -534,11 +534,11 @@ namespace Binance.Net.Clients.UsdFuturesApi
 
         #region Get historical Algo Orders
         /// <inheritdoc />
-        public async Task<WebCallResult<BinanceAlgoOrders>> GetClosedAlgoOrdersAsync(string? symbol = null, OrderSide? side = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? limit = null,long? receiveWindow = null, CancellationToken ct = default)
+        public async Task<WebCallResult<BinanceAlgoOrders>> GetClosedAlgoOrdersAsync(string? symbol = null, OrderSide? side = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? limit = null, long? receiveWindow = null, CancellationToken ct = default)
         {
             var parameters = new Dictionary<string, object>();
             parameters.AddOptionalParameter("symbol", symbol);
-            parameters.AddOptionalParameter("side", side == null? null: JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter));
+            parameters.AddOptionalParameter("side", side == null ? null : JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter));
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
             parameters.AddOptionalParameter("page", page);

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceSocketClientUsdFuturesApi.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceSocketClientUsdFuturesApi.cs
@@ -127,7 +127,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
         {
             symbols.ValidateNotNull(nameof(symbols));
             var handler = new Action<DataEvent<BinanceCombinedStream<BinanceStreamKlineData>>>(data => onMessage(data.As<IBinanceStreamKlineData>(data.Data.Data, data.Data.Data.Symbol)));
-            symbols = symbols.SelectMany(a => intervals.Select(i => a.ToLower(CultureInfo.InvariantCulture) + klineStreamEndpoint + "_" + JsonConvert.SerializeObject(i, new KlineIntervalConverter(false)))).ToArray();
+            symbols = symbols.SelectMany(a => intervals.Select(i => a.ToLower(CultureInfo.InvariantCulture) + klineStreamEndpoint + "_" + JsonConvert.SerializeObject(i,  StaticConverters.StaticKlineIntervalConverter))).ToArray();
             return await SubscribeAsync(BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
 
@@ -145,10 +145,10 @@ namespace Binance.Net.Clients.UsdFuturesApi
             var handler = new Action<DataEvent<BinanceCombinedStream<BinanceStreamContinuousKlineData>>>(data => onMessage(data.As(data.Data.Data, data.Data.Data.Symbol)));
             pairs = pairs.Select(a => a.ToLower(CultureInfo.InvariantCulture) +
                                       "_" +
-                                      JsonConvert.SerializeObject(contractType, new ContractTypeConverter(false)).ToLower() +
+                                      JsonConvert.SerializeObject(contractType, StaticConverters.StaticContractTypeConverter).ToLower() +
                                       continuousContractKlineStreamEndpoint +
                                       "_" +
-                                      JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false))).ToArray();
+                                      JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter)).ToArray();
             return await SubscribeAsync(BaseAddress, pairs, handler, ct).ConfigureAwait(false);
         }
 

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceSocketClientUsdFuturesApi.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceSocketClientUsdFuturesApi.cs
@@ -8,11 +8,9 @@ using Binance.Net.Converters;
 using Binance.Net.Enums;
 using Binance.Net.Interfaces;
 using Binance.Net.Interfaces.Clients.UsdFuturesApi;
-using Binance.Net.Objects;
 using Binance.Net.Objects.Internal;
 using Binance.Net.Objects.Models;
 using Binance.Net.Objects.Models.Futures.Socket;
-using Binance.Net.Objects.Models.Spot.Blvt;
 using Binance.Net.Objects.Models.Spot.Socket;
 using Binance.Net.Objects.Options;
 using CryptoExchange.Net;
@@ -35,7 +33,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
         private const string continuousContractKlineStreamEndpoint = "@continuousKline";
         private const string markPriceStreamEndpoint = "@markPrice";
         private const string allMarkPriceStreamEndpoint = "!markPrice@arr";
-        private const string symbolMiniTickerStreamEndpoint = "@miniTicker";    
+        private const string symbolMiniTickerStreamEndpoint = "@miniTicker";
         private const string allMiniTickerStreamEndpoint = "!miniTicker@arr";
         private const string symbolTickerStreamEndpoint = "@ticker";
         private const string allTickerStreamEndpoint = "!ticker@arr";
@@ -127,7 +125,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
         {
             symbols.ValidateNotNull(nameof(symbols));
             var handler = new Action<DataEvent<BinanceCombinedStream<BinanceStreamKlineData>>>(data => onMessage(data.As<IBinanceStreamKlineData>(data.Data.Data, data.Data.Data.Symbol)));
-            symbols = symbols.SelectMany(a => intervals.Select(i => a.ToLower(CultureInfo.InvariantCulture) + klineStreamEndpoint + "_" + JsonConvert.SerializeObject(i,  StaticConverters.StaticKlineIntervalConverter))).ToArray();
+            symbols = symbols.SelectMany(a => intervals.Select(i => a.ToLower(CultureInfo.InvariantCulture) + klineStreamEndpoint + "_" + JsonConvert.SerializeObject(i, StaticConverters.StaticKlineIntervalConverter))).ToArray();
             return await SubscribeAsync(BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
 
@@ -148,7 +146,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
                                       JsonConvert.SerializeObject(contractType, StaticConverters.StaticContractTypeConverter).ToLower() +
                                       continuousContractKlineStreamEndpoint +
                                       "_" +
-                                      JsonConvert.SerializeObject(interval,  StaticConverters.StaticKlineIntervalConverter)).ToArray();
+                                      JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter)).ToArray();
             return await SubscribeAsync(BaseAddress, pairs, handler, ct).ConfigureAwait(false);
         }
 
@@ -452,7 +450,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
                         {
                             var result = Deserialize<BinanceStreamEvent>(token);
                             if (result)
-                                onListenKeyExpired?.Invoke(data.As(result.Data, combinedToken["stream"]!.Value<string>()));                            
+                                onListenKeyExpired?.Invoke(data.As(result.Data, combinedToken["stream"]!.Value<string>()));
                             else
                                 _logger.Log(LogLevel.Warning, "Couldn't deserialize data received from the expired listen key event: " + result.Error);
                             break;

--- a/Binance.Net/Converters/DepositStatusConverter.cs
+++ b/Binance.Net/Converters/DepositStatusConverter.cs
@@ -4,9 +4,9 @@ using Binance.Net.Enums;
 
 namespace Binance.Net.Converters
 {
-    internal class DepositStatusConverter: BaseConverter<DepositStatus>
+    internal class DepositStatusConverter : BaseConverter<DepositStatus>
     {
-        public DepositStatusConverter(): this(true) { }
+        public DepositStatusConverter() : this(true) { }
         public DepositStatusConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<DepositStatus, string>> Mapping => new List<KeyValuePair<DepositStatus, string>>

--- a/Binance.Net/Converters/ExecutionTypeConverter.cs
+++ b/Binance.Net/Converters/ExecutionTypeConverter.cs
@@ -4,9 +4,9 @@ using CryptoExchange.Net.Converters;
 
 namespace Binance.Net.Converters
 {
-    internal class ExecutionTypeConverter: BaseConverter<ExecutionType>
+    internal class ExecutionTypeConverter : BaseConverter<ExecutionType>
     {
-        public ExecutionTypeConverter(): this(true) { }
+        public ExecutionTypeConverter() : this(true) { }
         public ExecutionTypeConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<ExecutionType, string>> Mapping => new List<KeyValuePair<ExecutionType, string>>

--- a/Binance.Net/Converters/FuturesMarginChangeDirectionTypeConverter.cs
+++ b/Binance.Net/Converters/FuturesMarginChangeDirectionTypeConverter.cs
@@ -6,7 +6,7 @@ namespace Binance.Net.Converters
 {
     internal class FuturesMarginChangeDirectionTypeConverter : BaseConverter<FuturesMarginChangeDirectionType>
     {
-        public FuturesMarginChangeDirectionTypeConverter(): this(false) { }
+        public FuturesMarginChangeDirectionTypeConverter() : this(false) { }
         public FuturesMarginChangeDirectionTypeConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<FuturesMarginChangeDirectionType, string>> Mapping => new List<KeyValuePair<FuturesMarginChangeDirectionType, string>>

--- a/Binance.Net/Converters/FuturesMarginTypeConverter.cs
+++ b/Binance.Net/Converters/FuturesMarginTypeConverter.cs
@@ -6,7 +6,7 @@ namespace Binance.Net.Converters
 {
     internal class FuturesMarginTypeConverter : BaseConverter<FuturesMarginType>
     {
-        public FuturesMarginTypeConverter(): this(false) { }
+        public FuturesMarginTypeConverter() : this(false) { }
         public FuturesMarginTypeConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<FuturesMarginType, string>> Mapping => new List<KeyValuePair<FuturesMarginType, string>>

--- a/Binance.Net/Converters/FuturesTransferTypeConverter.cs
+++ b/Binance.Net/Converters/FuturesTransferTypeConverter.cs
@@ -4,7 +4,7 @@ using CryptoExchange.Net.Converters;
 
 namespace Binance.Net.Converters
 {
-    internal class FuturesTransferTypeConverter: BaseConverter<FuturesTransferType>
+    internal class FuturesTransferTypeConverter : BaseConverter<FuturesTransferType>
     {
         public FuturesTransferTypeConverter() : this(true) { }
         public FuturesTransferTypeConverter(bool quotes) : base(quotes) { }

--- a/Binance.Net/Converters/IncomeTypeConverter.cs
+++ b/Binance.Net/Converters/IncomeTypeConverter.cs
@@ -4,9 +4,9 @@ using Binance.Net.Enums;
 
 namespace Binance.Net.Converters
 {
-    internal class IncomeTypeConverter: BaseConverter<IncomeType>
+    internal class IncomeTypeConverter : BaseConverter<IncomeType>
     {
-        public IncomeTypeConverter(): this(true) { }
+        public IncomeTypeConverter() : this(true) { }
         public IncomeTypeConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<IncomeType, string>> Mapping => new List<KeyValuePair<IncomeType, string>>

--- a/Binance.Net/Converters/InterfaceConverter.cs
+++ b/Binance.Net/Converters/InterfaceConverter.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Binance.Net.Converters
 {
-    internal class InterfaceConverter<TImp>: JsonConverter
+    internal class InterfaceConverter<TImp> : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {

--- a/Binance.Net/Converters/KlineIntervalConverter.cs
+++ b/Binance.Net/Converters/KlineIntervalConverter.cs
@@ -4,9 +4,9 @@ using CryptoExchange.Net.Converters;
 
 namespace Binance.Net.Converters
 {
-    internal class KlineIntervalConverter: BaseConverter<KlineInterval>
+    internal class KlineIntervalConverter : BaseConverter<KlineInterval>
     {
-        public KlineIntervalConverter(): this(true) { }
+        public KlineIntervalConverter() : this(true) { }
         public KlineIntervalConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<KlineInterval, string>> Mapping => new List<KeyValuePair<KlineInterval, string>>

--- a/Binance.Net/Converters/ListOrderStatusConverter.cs
+++ b/Binance.Net/Converters/ListOrderStatusConverter.cs
@@ -6,7 +6,7 @@ namespace Binance.Net.Converters
 {
     internal class ListOrderStatusConverter : BaseConverter<ListOrderStatus>
     {
-        public ListOrderStatusConverter(): this(true) { }
+        public ListOrderStatusConverter() : this(true) { }
         public ListOrderStatusConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<ListOrderStatus, string>> Mapping => new List<KeyValuePair<ListOrderStatus, string>>

--- a/Binance.Net/Converters/ListStatusTypeConverter.cs
+++ b/Binance.Net/Converters/ListStatusTypeConverter.cs
@@ -6,7 +6,7 @@ namespace Binance.Net.Converters
 {
     internal class ListStatusTypeConverter : BaseConverter<ListStatusType>
     {
-        public ListStatusTypeConverter(): this(true) { }
+        public ListStatusTypeConverter() : this(true) { }
         public ListStatusTypeConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<ListStatusType, string>> Mapping => new List<KeyValuePair<ListStatusType, string>>

--- a/Binance.Net/Converters/LoanIncomeTypeConverter.cs
+++ b/Binance.Net/Converters/LoanIncomeTypeConverter.cs
@@ -6,7 +6,7 @@ namespace Binance.Net.Converters
 {
     internal class LoanIncomeTypeConverter : BaseConverter<LoanIncomeType>
     {
-        public LoanIncomeTypeConverter(): this(true) { }
+        public LoanIncomeTypeConverter() : this(true) { }
         public LoanIncomeTypeConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<LoanIncomeType, string>> Mapping => new List<KeyValuePair<LoanIncomeType, string>>

--- a/Binance.Net/Converters/MarginStatusConverter.cs
+++ b/Binance.Net/Converters/MarginStatusConverter.cs
@@ -6,7 +6,7 @@ namespace Binance.Net.Converters
 {
     internal class MarginStatusConverter : BaseConverter<MarginStatus>
     {
-        public MarginStatusConverter(): this(false) { }
+        public MarginStatusConverter() : this(false) { }
         public MarginStatusConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<MarginStatus, string>> Mapping => new List<KeyValuePair<MarginStatus, string>>

--- a/Binance.Net/Converters/MinerStatusConverter.cs
+++ b/Binance.Net/Converters/MinerStatusConverter.cs
@@ -6,7 +6,7 @@ namespace Binance.Net.Converters
 {
     internal class MinerStatusConverter : BaseConverter<MinerStatus>
     {
-        public MinerStatusConverter(): this(true) { }
+        public MinerStatusConverter() : this(true) { }
         public MinerStatusConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<MinerStatus, string>> Mapping => new List<KeyValuePair<MinerStatus, string>>

--- a/Binance.Net/Converters/OrderRejectReasonConverter.cs
+++ b/Binance.Net/Converters/OrderRejectReasonConverter.cs
@@ -4,9 +4,9 @@ using CryptoExchange.Net.Converters;
 
 namespace Binance.Net.Converters
 {
-    internal class OrderRejectReasonConverter: BaseConverter<OrderRejectReason>
+    internal class OrderRejectReasonConverter : BaseConverter<OrderRejectReason>
     {
-        public OrderRejectReasonConverter(): this(true) { }
+        public OrderRejectReasonConverter() : this(true) { }
         public OrderRejectReasonConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<OrderRejectReason, string>> Mapping => new List<KeyValuePair<OrderRejectReason, string>>

--- a/Binance.Net/Converters/OrderResponseTypeConverter.cs
+++ b/Binance.Net/Converters/OrderResponseTypeConverter.cs
@@ -4,9 +4,9 @@ using Binance.Net.Enums;
 
 namespace Binance.Net.Converters
 {
-    internal class OrderResponseTypeConverter: BaseConverter<OrderResponseType>
+    internal class OrderResponseTypeConverter : BaseConverter<OrderResponseType>
     {
-        public OrderResponseTypeConverter(): this(true) { }
+        public OrderResponseTypeConverter() : this(true) { }
         public OrderResponseTypeConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<OrderResponseType, string>> Mapping => new List<KeyValuePair<OrderResponseType, string>>

--- a/Binance.Net/Converters/OrderSideConverter.cs
+++ b/Binance.Net/Converters/OrderSideConverter.cs
@@ -6,7 +6,7 @@ namespace Binance.Net.Converters
 {
     internal class OrderSideConverter : BaseConverter<OrderSide>
     {
-        public OrderSideConverter(): this(true) { }
+        public OrderSideConverter() : this(true) { }
         public OrderSideConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<OrderSide, string>> Mapping => new List<KeyValuePair<OrderSide, string>>

--- a/Binance.Net/Converters/OrderStatusConverter.cs
+++ b/Binance.Net/Converters/OrderStatusConverter.cs
@@ -6,7 +6,7 @@ namespace Binance.Net.Converters
 {
     internal class OrderStatusConverter : BaseConverter<OrderStatus>
     {
-        public OrderStatusConverter(): this(true) { }
+        public OrderStatusConverter() : this(true) { }
         public OrderStatusConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<OrderStatus, string>> Mapping => new List<KeyValuePair<OrderStatus, string>>

--- a/Binance.Net/Converters/RateLimitConverter.cs
+++ b/Binance.Net/Converters/RateLimitConverter.cs
@@ -4,7 +4,7 @@ using CryptoExchange.Net.Converters;
 
 namespace Binance.Net.Converters
 {
-    internal class RateLimitConverter: BaseConverter<RateLimitType>
+    internal class RateLimitConverter : BaseConverter<RateLimitType>
     {
         public RateLimitConverter() : this(true) { }
         public RateLimitConverter(bool quotes) : base(quotes) { }

--- a/Binance.Net/Converters/SideEffectTypeConverter.cs
+++ b/Binance.Net/Converters/SideEffectTypeConverter.cs
@@ -4,9 +4,9 @@ using Binance.Net.Enums;
 
 namespace Binance.Net.Converters
 {
-    internal class SideEffectTypeConverter: BaseConverter<SideEffectType>
+    internal class SideEffectTypeConverter : BaseConverter<SideEffectType>
     {
-        public SideEffectTypeConverter(): this(true) { }
+        public SideEffectTypeConverter() : this(true) { }
         public SideEffectTypeConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<SideEffectType, string>> Mapping => new List<KeyValuePair<SideEffectType, string>>

--- a/Binance.Net/Converters/StaticConverters.cs
+++ b/Binance.Net/Converters/StaticConverters.cs
@@ -9,11 +9,11 @@
         internal readonly static SideEffectTypeConverter StaticSideEffectTypeConverter = new SideEffectTypeConverter(false);
 
         internal readonly static PositionSideConverter StaticPositionSideConverter = new PositionSideConverter(false);
-        
+
         internal readonly static WorkingTypeConverter StaticWorkingTypeConverter = new WorkingTypeConverter(false);
 
         internal readonly static OrderResponseTypeConverter StaticOrderResponseTypeConverter = new OrderResponseTypeConverter(false);
-        
+
         internal readonly static FuturesOrderTypeConverter StaticFuturesOrderTypeConverter = new FuturesOrderTypeConverter(false);
 
         internal readonly static WalletTypeConverter StaticWalletTypeConverter = new WalletTypeConverter(false);

--- a/Binance.Net/Converters/StaticConverters.cs
+++ b/Binance.Net/Converters/StaticConverters.cs
@@ -1,0 +1,45 @@
+﻿namespace Binance.Net.Converters
+{
+    internal class StaticConverters
+    {
+        internal readonly static OrderSideConverter StaticOrderSideConverter = new OrderSideConverter(false);
+
+        internal readonly static TimeInForceConverter StaticTimeInForceConverter = new TimeInForceConverter(false);
+
+        internal readonly static SideEffectTypeConverter StaticSideEffectTypeConverter = new SideEffectTypeConverter(false);
+
+        internal readonly static PositionSideConverter StaticPositionSideConverter = new PositionSideConverter(false);
+        
+        internal readonly static WorkingTypeConverter StaticWorkingTypeConverter = new WorkingTypeConverter(false);
+
+        internal readonly static OrderResponseTypeConverter StaticOrderResponseTypeConverter = new OrderResponseTypeConverter(false);
+        
+        internal readonly static FuturesOrderTypeConverter StaticFuturesOrderTypeConverter = new FuturesOrderTypeConverter(false);
+
+        internal readonly static WalletTypeConverter StaticWalletTypeConverter = new WalletTypeConverter(false);
+
+        internal readonly static WithdrawalStatusConverter StaticWithdrawalStatusConverter = new WithdrawalStatusConverter(false);
+
+        internal readonly static DepositStatusConverter StaticDepositStatusConverter = new DepositStatusConverter(false);
+
+        internal readonly static UniversalTransferTypeConverter StaticUniversalTransferTypeConverter = new UniversalTransferTypeConverter(false);
+
+        internal readonly static TransferDirectionTypeConverter StaticTransferDirectionTypeConverter = new TransferDirectionTypeConverter(false);
+
+        internal readonly static TransferDirectionConverter StaticTransferDirectionConverter = new TransferDirectionConverter(false);
+
+        internal readonly static IsolatedMarginTransferDirectionConverter StaticIsolatedMarginTransferDirectionConverter = new IsolatedMarginTransferDirectionConverter(false);
+
+        internal readonly static KlineIntervalConverter StaticKlineIntervalConverter = new KlineIntervalConverter(false);
+
+        internal readonly static ContractTypeConverter StaticContractTypeConverter = new ContractTypeConverter(false);
+
+        internal readonly static SpotOrderTypeConverter StaticSpotOrderTypeConverter = new SpotOrderTypeConverter(false);
+
+        internal readonly static FuturesMarginTypeConverter StaticFuturesMarginTypeConverter = new FuturesMarginTypeConverter(false);
+
+        internal readonly static FuturesMarginChangeDirectionTypeConverter StaticFuturesMarginChangeDirectionTypeConverter = new FuturesMarginChangeDirectionTypeConverter(false);
+
+        internal readonly static PeriodIntervalConverter StaticPeriodIntervalConverter = new PeriodIntervalConverter(false);
+    }
+}

--- a/Binance.Net/Converters/SymbolFilterConverter.cs
+++ b/Binance.Net/Converters/SymbolFilterConverter.cs
@@ -221,7 +221,7 @@ namespace Binance.Net.Converters
                 case SymbolFilterType.IcebergOrders:
                     var MaxNumIcebergOrders = (BinanceMaxNumberOfIcebergOrdersFilter)filter;
                     writer.WritePropertyName("maxNumIcebergOrders");
-                    writer.WriteValue(MaxNumIcebergOrders.MaxNumIcebergOrders);                   
+                    writer.WriteValue(MaxNumIcebergOrders.MaxNumIcebergOrders);
                     break;
                 case SymbolFilterType.PercentagePriceBySide:
                     var pricePercentSideBySideFilter = (BinanceSymbolPercentPriceBySideFilter)filter;

--- a/Binance.Net/Converters/SymbolFilterTypeConverter.cs
+++ b/Binance.Net/Converters/SymbolFilterTypeConverter.cs
@@ -6,7 +6,7 @@ namespace Binance.Net.Converters
 {
     internal class SymbolFilterTypeConverter : BaseConverter<SymbolFilterType>
     {
-        public SymbolFilterTypeConverter(): this(true) { }
+        public SymbolFilterTypeConverter() : this(true) { }
         public SymbolFilterTypeConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<SymbolFilterType, string>> Mapping => new List<KeyValuePair<SymbolFilterType, string>>

--- a/Binance.Net/Converters/SymbolStatusConverter.cs
+++ b/Binance.Net/Converters/SymbolStatusConverter.cs
@@ -6,7 +6,7 @@ namespace Binance.Net.Converters
 {
     internal class SymbolStatusConverter : BaseConverter<SymbolStatus>
     {
-        public SymbolStatusConverter(): this(true) { }
+        public SymbolStatusConverter() : this(true) { }
         public SymbolStatusConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<SymbolStatus, string>> Mapping => new List<KeyValuePair<SymbolStatus, string>>

--- a/Binance.Net/Converters/TimeInForceConverter.cs
+++ b/Binance.Net/Converters/TimeInForceConverter.cs
@@ -6,7 +6,7 @@ namespace Binance.Net.Converters
 {
     internal class TimeInForceConverter : BaseConverter<TimeInForce>
     {
-        public TimeInForceConverter(): this(true) { }
+        public TimeInForceConverter() : this(true) { }
         public TimeInForceConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<TimeInForce, string>> Mapping => new List<KeyValuePair<TimeInForce, string>>

--- a/Binance.Net/Converters/TransferDirectionConverter.cs
+++ b/Binance.Net/Converters/TransferDirectionConverter.cs
@@ -4,9 +4,9 @@ using Binance.Net.Enums;
 
 namespace Binance.Net.Converters
 {
-    internal class TransferDirectionConverter: BaseConverter<TransferDirection>
+    internal class TransferDirectionConverter : BaseConverter<TransferDirection>
     {
-        public TransferDirectionConverter(): this(true) { }
+        public TransferDirectionConverter() : this(true) { }
         public TransferDirectionConverter(bool quotes) : base(quotes) { }
 
         protected override List<KeyValuePair<TransferDirection, string>> Mapping => new List<KeyValuePair<TransferDirection, string>>

--- a/Binance.Net/Enums/DownloadStatus.cs
+++ b/Binance.Net/Enums/DownloadStatus.cs
@@ -1,7 +1,4 @@
 ﻿using CryptoExchange.Net.Attributes;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Binance.Net.Enums
 {

--- a/Binance.Net/Enums/PayOrderType.cs
+++ b/Binance.Net/Enums/PayOrderType.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using CryptoExchange.Net.Attributes;
+﻿using CryptoExchange.Net.Attributes;
 
 namespace Binance.Net.Enums
 {

--- a/Binance.Net/Interfaces/Clients/GeneralApi/IBinanceRestClientGeneralApiSubAccount.cs
+++ b/Binance.Net/Interfaces/Clients/GeneralApi/IBinanceRestClientGeneralApiSubAccount.cs
@@ -174,7 +174,7 @@ namespace Binance.Net.Interfaces.Clients.GeneralApi
         /// <param name="ct">Cancellation token</param>
         /// <returns>Futures summary</returns>
         Task<WebCallResult<BinanceSubAccountsFuturesSummary>> GetSubAccountsFuturesSummaryAsync(int? receiveWindow = null, CancellationToken ct = default);
-        
+
         /// <summary>
         /// Gets futures position risk for a sub account
         /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#get-futures-position-risk-of-sub-account-for-master-account" /></para>

--- a/Binance.Net/Interfaces/Clients/IBinanceRestClient.cs
+++ b/Binance.Net/Interfaces/Clients/IBinanceRestClient.cs
@@ -2,7 +2,6 @@
 using Binance.Net.Interfaces.Clients.GeneralApi;
 using Binance.Net.Interfaces.Clients.SpotApi;
 using Binance.Net.Interfaces.Clients.UsdFuturesApi;
-using Binance.Net.Objects;
 using CryptoExchange.Net.Authentication;
 using CryptoExchange.Net.Interfaces;
 
@@ -11,7 +10,7 @@ namespace Binance.Net.Interfaces.Clients
     /// <summary>
     /// Client for accessing the Binance Rest API. 
     /// </summary>
-    public interface IBinanceRestClient: IRestClient
+    public interface IBinanceRestClient : IRestClient
     {
         /// <summary>
         /// General API endpoints

--- a/Binance.Net/Interfaces/Clients/IBinanceSocketClient.cs
+++ b/Binance.Net/Interfaces/Clients/IBinanceSocketClient.cs
@@ -1,8 +1,6 @@
-﻿using Binance.Net.Clients.SpotApi;
-using Binance.Net.Interfaces.Clients.CoinFuturesApi;
+﻿using Binance.Net.Interfaces.Clients.CoinFuturesApi;
 using Binance.Net.Interfaces.Clients.SpotApi;
 using Binance.Net.Interfaces.Clients.UsdFuturesApi;
-using Binance.Net.Objects;
 using CryptoExchange.Net.Authentication;
 using CryptoExchange.Net.Interfaces;
 
@@ -11,7 +9,7 @@ namespace Binance.Net.Interfaces.Clients
     /// <summary>
     /// Client for accessing the Binance websocket API
     /// </summary>
-    public interface IBinanceSocketClient: ISocketClient
+    public interface IBinanceSocketClient : ISocketClient
     {
         /// <summary>
         /// Coin futures streams

--- a/Binance.Net/Interfaces/Clients/SpotApi/IBinanceRestClientSpotApiAccount.cs
+++ b/Binance.Net/Interfaces/Clients/SpotApi/IBinanceRestClientSpotApiAccount.cs
@@ -118,7 +118,7 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
         Task<WebCallResult<IEnumerable<BinanceUserBalance>>> GetBalancesAsync(string? asset = null, bool? needBtcValuation = null, int? receiveWindow = null, CancellationToken ct = default);
-        
+
         /// <summary>
         /// Get asset dividend records
         /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#asset-dividend-record-user_data" /></para>

--- a/Binance.Net/Interfaces/Clients/SpotApi/IBinanceSocketClientSpotApiExchangeData.cs
+++ b/Binance.Net/Interfaces/Clients/SpotApi/IBinanceSocketClientSpotApiExchangeData.cs
@@ -1,5 +1,4 @@
 ﻿using Binance.Net.Enums;
-using Binance.Net.Interfaces;
 using Binance.Net.Objects;
 using Binance.Net.Objects.Models.Spot;
 using Binance.Net.Objects.Models.Spot.Blvt;
@@ -153,8 +152,19 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+
+        /* Unmerged change from project 'Binance.Net (netstandard2.0)'
+        Before:
+                Task<CallResult<UpdateSubscription>> SubscribeToAllMiniTickerUpdatesAsync(Action<DataEvent<IEnumerable<IBinanceMiniTick>>> onMessage, CancellationToken ct = default);
+
+                /// <summary>
+        After:
+                Task<CallResult<UpdateSubscription>> SubscribeToAllMiniTickerUpdatesAsync(Action<DataEvent<IEnumerable<IBinanceMiniTick>>> onMessage, CancellationToken ct = default);
+
+                /// <summary>
+        */
         Task<CallResult<UpdateSubscription>> SubscribeToAllMiniTickerUpdatesAsync(Action<DataEvent<IEnumerable<IBinanceMiniTick>>> onMessage, CancellationToken ct = default);
-        
+
         /// <summary>
         /// Subscribe to rolling window ticker updates stream for all symbols
         /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#all-market-rolling-window-statistics-streams" /></para>
@@ -164,7 +174,7 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         Task<CallResult<UpdateSubscription>> SubscribeToAllRollingWindowTickerUpdatesAsync(TimeSpan windowSize, Action<DataEvent<IEnumerable<BinanceStreamRollingWindowTick>>> onMessage, CancellationToken ct = default);
-        
+
         /// <summary>
         /// Subscribes to ticker updates stream for all symbols
         /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#all-market-tickers-stream" /></para>

--- a/Binance.Net/Interfaces/Clients/UsdFuturesApi/IBinanceSocketClientUsdFuturesApi.cs
+++ b/Binance.Net/Interfaces/Clients/UsdFuturesApi/IBinanceSocketClientUsdFuturesApi.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Binance.Net.Objects.Models;
 using Binance.Net.Objects.Models.Futures.Socket;
-using Binance.Net.Objects.Models.Spot.Blvt;
 using Binance.Net.Objects.Models.Spot.Socket;
 using CryptoExchange.Net.Interfaces;
 
@@ -343,7 +342,7 @@ namespace Binance.Net.Interfaces.Clients.UsdFuturesApi
             Action<DataEvent<BinanceGridUpdate>>? onGridUpdate,
             CancellationToken ct = default);
 
-        
+
         /// <summary>
         /// Subscribes to the Mark price update stream for a all symbols
         /// <para><a href="https://binance-docs.github.io/apidocs/futures/en/#mark-price-stream-for-all-market" /></para>

--- a/Binance.Net/Interfaces/IBinance24HPriceBase.cs
+++ b/Binance.Net/Interfaces/IBinance24HPriceBase.cs
@@ -5,7 +5,7 @@ namespace Binance.Net.Interfaces
     /// <summary>
     /// 24 hour price stats
     /// </summary>
-    public interface IBinance24HPrice: IBinanceMiniTick
+    public interface IBinance24HPrice : IBinanceMiniTick
     {
         /// <summary>
         /// The actual price change in the last 24 hours
@@ -21,12 +21,12 @@ namespace Binance.Net.Interfaces
         /// The weighted average price in the last 24 hours
         /// </summary>
         decimal WeightedAveragePrice { get; set; }
-        
+
         /// <summary>
         /// The most recent trade quantity
         /// </summary>
         decimal LastQuantity { get; set; }
-        
+
         /// <summary>
         /// Time at which this 24 hours opened
         /// </summary>

--- a/Binance.Net/Interfaces/IBinanceAggregatedTrade.cs
+++ b/Binance.Net/Interfaces/IBinanceAggregatedTrade.cs
@@ -26,7 +26,7 @@ namespace Binance.Net.Interfaces
         /// <summary>
         /// The last trade id in this aggregation
         /// </summary>
-         long LastTradeId { get; set; }
+        long LastTradeId { get; set; }
         /// <summary>
         /// The timestamp of the trades
         /// </summary>

--- a/Binance.Net/Interfaces/IBinanceBalance.cs
+++ b/Binance.Net/Interfaces/IBinanceBalance.cs
@@ -4,7 +4,7 @@
     /// Balance data
     /// </summary>
     public interface IBinanceBalance
-	{
+    {
         /// <summary>
         /// The asset this balance is for
         /// </summary>
@@ -21,5 +21,5 @@
         /// The total balance of this asset (Free + Locked)
         /// </summary>
         decimal Total { get; }
-	}
+    }
 }

--- a/Binance.Net/Interfaces/IBinanceKline.cs
+++ b/Binance.Net/Interfaces/IBinanceKline.cs
@@ -11,7 +11,7 @@ namespace Binance.Net.Interfaces
         /// The time this candlestick opened
         /// </summary>
         DateTime OpenTime { get; set; }
-        
+
         /// <summary>
         /// The price at which this candlestick opened
         /// </summary>

--- a/Binance.Net/Interfaces/IBinanceStreamKlineData.cs
+++ b/Binance.Net/Interfaces/IBinanceStreamKlineData.cs
@@ -21,7 +21,7 @@ namespace Binance.Net.Interfaces
     /// <summary>
     /// Stream kline data
     /// </summary>
-    public interface IBinanceStreamKline: IBinanceKline
+    public interface IBinanceStreamKline : IBinanceKline
     {
         /// <summary>
         /// Interval

--- a/Binance.Net/Objects/Internal/BinanceSnapshotWrapper.cs
+++ b/Binance.Net/Objects/Internal/BinanceSnapshotWrapper.cs
@@ -5,7 +5,7 @@ namespace Binance.Net.Objects.Internal
     internal class BinanceSnapshotWrapper<T>
     {
         public int Code { get; set; }
-        [JsonProperty("msg")] 
+        [JsonProperty("msg")]
         public string Message { get; set; } = string.Empty;
         [JsonProperty("snapshotVos")]
         public T SnapshotData { get; set; } = default!;

--- a/Binance.Net/Objects/Models/BinanceOrderBase.cs
+++ b/Binance.Net/Objects/Models/BinanceOrderBase.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using Binance.Net.Converters;
 using Binance.Net.Enums;
 using CryptoExchange.Net.Converters;

--- a/Binance.Net/Objects/Models/BinanceResult.cs
+++ b/Binance.Net/Objects/Models/BinanceResult.cs
@@ -22,7 +22,7 @@ namespace Binance.Net.Objects.Models
     /// Query result
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    internal class BinanceResult<T>: BinanceResult
+    internal class BinanceResult<T> : BinanceResult
     {
         /// <summary>
         /// The data

--- a/Binance.Net/Objects/Models/Futures/AlgoOrders/BinanceAlgoOrderResult.cs
+++ b/Binance.Net/Objects/Models/Futures/AlgoOrders/BinanceAlgoOrderResult.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Algo order result
     /// </summary>
-    public class BinanceAlgoOrderResult: BinanceResult
+    public class BinanceAlgoOrderResult : BinanceResult
     {
         /// <summary>
         /// Order id

--- a/Binance.Net/Objects/Models/Futures/AlgoOrders/BinanceAlgoResult.cs
+++ b/Binance.Net/Objects/Models/Futures/AlgoOrders/BinanceAlgoResult.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Algo order result
     /// </summary>
-    public class BinanceAlgoResult: BinanceResult
+    public class BinanceAlgoResult : BinanceResult
     {
         /// <summary>
         /// Algo order id

--- a/Binance.Net/Objects/Models/Futures/AlgoOrders/BinanceAlgoSubOrder.cs
+++ b/Binance.Net/Objects/Models/Futures/AlgoOrders/BinanceAlgoSubOrder.cs
@@ -4,7 +4,6 @@ using CryptoExchange.Net.Converters;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Binance.Net.Objects.Models.Futures.AlgoOrders
 {

--- a/Binance.Net/Objects/Models/Futures/BinanceFuturesBookPrice.cs
+++ b/Binance.Net/Objects/Models/Futures/BinanceFuturesBookPrice.cs
@@ -5,7 +5,7 @@ namespace Binance.Net.Objects.Models.Futures
     /// <summary>
     /// Book price
     /// </summary>
-    public class BinanceFuturesBookPrice: BinanceBookPrice
+    public class BinanceFuturesBookPrice : BinanceBookPrice
     {
         /// <summary>
         /// Pair

--- a/Binance.Net/Objects/Models/Futures/BinanceFuturesCancelOrder.cs
+++ b/Binance.Net/Objects/Models/Futures/BinanceFuturesCancelOrder.cs
@@ -141,7 +141,7 @@ namespace Binance.Net.Objects.Models.Futures
         /// </summary>
         [JsonProperty("positionSide"), JsonConverter(typeof(PositionSideConverter))]
         public PositionSide PositionSide { get; set; }
-        
+
         /// <summary>
         /// Price protect
         /// </summary>

--- a/Binance.Net/Objects/Models/Futures/BinanceFuturesCoinKline.cs
+++ b/Binance.Net/Objects/Models/Futures/BinanceFuturesCoinKline.cs
@@ -7,7 +7,7 @@ namespace Binance.Net.Objects.Models.Futures
     /// Candlestick information for symbol
     /// </summary>
     [JsonConverter(typeof(ArrayConverter))]
-    public class BinanceFuturesCoinKline: BinanceKlineBase
+    public class BinanceFuturesCoinKline : BinanceKlineBase
     {
         /// <inheritdoc/>
         [ArrayProperty(7)]

--- a/Binance.Net/Objects/Models/Futures/BinanceFuturesExchangeInfo.cs
+++ b/Binance.Net/Objects/Models/Futures/BinanceFuturesExchangeInfo.cs
@@ -32,7 +32,7 @@ namespace Binance.Net.Objects.Models.Futures
     /// <summary>
     /// Exchange info
     /// </summary>
-    public class BinanceFuturesUsdtExchangeInfo: BinanceFuturesExchangeInfo
+    public class BinanceFuturesUsdtExchangeInfo : BinanceFuturesExchangeInfo
     {
         /// <summary>
         /// All symbols supported

--- a/Binance.Net/Objects/Models/Futures/BinanceFuturesIncomeHistory.cs
+++ b/Binance.Net/Objects/Models/Futures/BinanceFuturesIncomeHistory.cs
@@ -25,7 +25,7 @@ namespace Binance.Net.Objects.Models.Futures
         /// <summary>
         /// Type of income
         /// </summary>
-        public IncomeType? IncomeType => IncomeTypeString != null ? new IncomeTypeConverter().ReadString(IncomeTypeString): (IncomeType?)null;
+        public IncomeType? IncomeType => IncomeTypeString != null ? new IncomeTypeConverter().ReadString(IncomeTypeString) : (IncomeType?)null;
 
         /// <summary>
         /// Quantity of income

--- a/Binance.Net/Objects/Models/Futures/BinanceFuturesInitialLeverageChangeResult.cs
+++ b/Binance.Net/Objects/Models/Futures/BinanceFuturesInitialLeverageChangeResult.cs
@@ -17,7 +17,7 @@ namespace Binance.Net.Objects.Models.Futures
         /// NOTE: string type, because the value van be 'inf' (infinite)
         /// </summary>
         public string? MaxNotionalValue { get; set; }
-        
+
         /// <summary>
         /// Max quantity
         /// </summary>

--- a/Binance.Net/Objects/Models/Futures/BinanceFuturesMarkPrice.cs
+++ b/Binance.Net/Objects/Models/Futures/BinanceFuturesMarkPrice.cs
@@ -52,7 +52,7 @@ namespace Binance.Net.Objects.Models.Futures
     /// <summary>
     /// Mark price for Coin-M future
     /// </summary>
-    public class BinanceFuturesCoinMarkPrice: BinanceFuturesMarkPrice
+    public class BinanceFuturesCoinMarkPrice : BinanceFuturesMarkPrice
     {
         /// <summary>
         /// The pair

--- a/Binance.Net/Objects/Models/Futures/BinanceFuturesMultipleOrderPlaceResult.cs
+++ b/Binance.Net/Objects/Models/Futures/BinanceFuturesMultipleOrderPlaceResult.cs
@@ -5,7 +5,7 @@ namespace Binance.Net.Objects.Models.Futures
     /// <summary>
     /// Extension to be able to deserialize an error response as well
     /// </summary>
-    internal class BinanceFuturesMultipleOrderPlaceResult: BinanceFuturesPlacedOrder
+    internal class BinanceFuturesMultipleOrderPlaceResult : BinanceFuturesPlacedOrder
     {
         public int Code { get; set; }
         [JsonProperty("msg")]

--- a/Binance.Net/Objects/Models/Futures/BinanceFuturesOpenInterest.cs
+++ b/Binance.Net/Objects/Models/Futures/BinanceFuturesOpenInterest.cs
@@ -31,7 +31,7 @@ namespace Binance.Net.Objects.Models.Futures
     /// <summary>
     /// Open interest
     /// </summary>
-    public class BinanceFuturesCoinOpenInterest: BinanceFuturesOpenInterest
+    public class BinanceFuturesCoinOpenInterest : BinanceFuturesOpenInterest
     {
         /// <summary>
         /// The pair

--- a/Binance.Net/Objects/Models/Futures/BinanceFuturesOrder.cs
+++ b/Binance.Net/Objects/Models/Futures/BinanceFuturesOrder.cs
@@ -151,7 +151,7 @@ namespace Binance.Net.Objects.Models.Futures
         /// </summary>
         [JsonProperty("positionSide"), JsonConverter(typeof(PositionSideConverter))]
         public PositionSide PositionSide { get; set; }
-        
+
         /// <summary>
         /// Price protect
         /// </summary>

--- a/Binance.Net/Objects/Models/Futures/BinanceFuturesQuantileEstimation.cs
+++ b/Binance.Net/Objects/Models/Futures/BinanceFuturesQuantileEstimation.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// Quantile
         /// </summary>
-        public BinanceFuturesAdlQuantile? AdlQuantile{ get; set; }
+        public BinanceFuturesAdlQuantile? AdlQuantile { get; set; }
     }
 
     /// <summary>

--- a/Binance.Net/Objects/Models/Futures/BinanceFuturesSymbol.cs
+++ b/Binance.Net/Objects/Models/Futures/BinanceFuturesSymbol.cs
@@ -163,7 +163,7 @@ namespace Binance.Net.Objects.Models.Futures
     /// <summary>
     /// Information about a futures symbol
     /// </summary>
-    public class BinanceFuturesUsdtSymbol: BinanceFuturesSymbol
+    public class BinanceFuturesUsdtSymbol : BinanceFuturesSymbol
     {
         /// <summary>
         /// The status of the symbol
@@ -181,7 +181,7 @@ namespace Binance.Net.Objects.Models.Futures
     /// <summary>
     /// Information about a futures symbol
     /// </summary>
-    public class BinanceFuturesCoinSymbol: BinanceFuturesSymbol
+    public class BinanceFuturesCoinSymbol : BinanceFuturesSymbol
     {
 
         /// <summary>
@@ -201,6 +201,6 @@ namespace Binance.Net.Objects.Models.Futures
         /// </summary>
         [JsonProperty("equalQtyPrecision")]
         public int EqualQuantityPrecision { get; set; }
-       
+
     }
 }

--- a/Binance.Net/Objects/Models/Futures/BinanceFuturesTrade.cs
+++ b/Binance.Net/Objects/Models/Futures/BinanceFuturesTrade.cs
@@ -76,7 +76,7 @@ namespace Binance.Net.Objects.Models.Futures
     /// <summary>
     /// Trade details
     /// </summary>
-    public class BinanceFuturesUsdtTrade: BinanceFuturesTrade
+    public class BinanceFuturesUsdtTrade : BinanceFuturesTrade
     {
         /// <summary>
         /// Quote quantity

--- a/Binance.Net/Objects/Models/Futures/BinancePosition.cs
+++ b/Binance.Net/Objects/Models/Futures/BinancePosition.cs
@@ -40,7 +40,7 @@ namespace Binance.Net.Objects.Models.Futures
     /// <summary>
     /// Position info
     /// </summary>
-    public class BinancePositionInfoBase: BinancePositionBase
+    public class BinancePositionInfoBase : BinancePositionBase
     {
         /// <summary>
         /// Initial margin
@@ -56,7 +56,7 @@ namespace Binance.Net.Objects.Models.Futures
         /// Position initial margin
         /// </summary>
         public decimal PositionInitialMargin { get; set; }
-        
+
         /// <summary>
         /// Open order initial margin
         /// </summary>
@@ -106,7 +106,7 @@ namespace Binance.Net.Objects.Models.Futures
     /// <summary>
     /// Base position details
     /// </summary>
-    public class BinancePositionDetailsBase: BinancePositionBase
+    public class BinancePositionDetailsBase : BinancePositionBase
     {
         /// <summary>
         /// Margin type

--- a/Binance.Net/Objects/Models/Futures/Socket/BinanceFuturesStreamAccountInfo.cs
+++ b/Binance.Net/Objects/Models/Futures/Socket/BinanceFuturesStreamAccountInfo.cs
@@ -10,7 +10,7 @@ namespace Binance.Net.Objects.Models.Futures.Socket
     /// <summary>
     /// Account update
     /// </summary>
-    public class BinanceFuturesStreamAccountUpdate: BinanceStreamEvent
+    public class BinanceFuturesStreamAccountUpdate : BinanceStreamEvent
     {
         /// <summary>
         /// The update data

--- a/Binance.Net/Objects/Models/Futures/Socket/BinanceFuturesStreamConfigUpdate.cs
+++ b/Binance.Net/Objects/Models/Futures/Socket/BinanceFuturesStreamConfigUpdate.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using Binance.Net.Converters;
-using Binance.Net.Enums;
 using CryptoExchange.Net.Converters;
 using Newtonsoft.Json;
 

--- a/Binance.Net/Objects/Models/Futures/Socket/BinanceFuturesStreamContinuousKline.cs
+++ b/Binance.Net/Objects/Models/Futures/Socket/BinanceFuturesStreamContinuousKline.cs
@@ -9,7 +9,7 @@ namespace Binance.Net.Objects.Models.Futures.Socket
     /// <summary>
     /// Wrapper for continuous kline information for a symbol
     /// </summary>
-    public class BinanceStreamContinuousKlineData: BinanceStreamEvent, IBinanceStreamKlineData
+    public class BinanceStreamContinuousKlineData : BinanceStreamEvent, IBinanceStreamKlineData
     {
         /// <summary>
         /// The symbol the data is for

--- a/Binance.Net/Objects/Models/Futures/Socket/BinanceFuturesStreamIndexKline.cs
+++ b/Binance.Net/Objects/Models/Futures/Socket/BinanceFuturesStreamIndexKline.cs
@@ -91,7 +91,7 @@ namespace Binance.Net.Objects.Models.Futures.Socket
         /// </summary>
         [JsonProperty("v")]
         public string Ignore4 { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Number of basic data
         /// </summary>

--- a/Binance.Net/Objects/Models/Futures/Socket/BinanceFuturesStreamIndexPrice.cs
+++ b/Binance.Net/Objects/Models/Futures/Socket/BinanceFuturesStreamIndexPrice.cs
@@ -5,7 +5,7 @@ namespace Binance.Net.Objects.Models.Futures.Socket
     /// <summary>
     /// Index price update
     /// </summary>
-    public class BinanceFuturesStreamIndexPrice: BinanceStreamEvent
+    public class BinanceFuturesStreamIndexPrice : BinanceStreamEvent
     {
         /// <summary>
         /// The pair

--- a/Binance.Net/Objects/Models/Futures/Socket/BinanceFuturesStreamLiquidation.cs
+++ b/Binance.Net/Objects/Models/Futures/Socket/BinanceFuturesStreamLiquidation.cs
@@ -35,55 +35,55 @@ namespace Binance.Net.Objects.Models.Futures.Socket
         /// </summary>
         [JsonProperty("S"), JsonConverter(typeof(OrderSideConverter))]
         public OrderSide Side { get; set; }
-        
+
         /// <summary>
         /// Liquidation order type
         /// </summary>
         [JsonProperty("o"), JsonConverter(typeof(FuturesOrderTypeConverter))]
         public FuturesOrderType Type { get; set; }
-        
+
         /// <summary>
         /// Liquidation Time in Force
         /// </summary>
         [JsonProperty("f"), JsonConverter(typeof(TimeInForceConverter))]
         public TimeInForce TimeInForce { get; set; }
-        
+
         /// <summary>
         /// Liquidation Original Quantity
         /// </summary>
         [JsonProperty("q")]
         public decimal Quantity { get; set; }
-        
+
         /// <summary>
         /// Liquidation order price
         /// </summary>
         [JsonProperty("p")]
         public decimal Price { get; set; }
-        
+
         /// <summary>
         /// Liquidation Average Price
         /// </summary>
         [JsonProperty("ap")]
         public decimal AveragePrice { get; set; }
-        
+
         /// <summary>
         /// Liquidation Order Status
         /// </summary>
         [JsonProperty("X"), JsonConverter(typeof(OrderStatusConverter))]
         public OrderStatus Status { get; set; }
-        
+
         /// <summary>
         /// Liquidation Last Filled Quantity
         /// </summary>
         [JsonProperty("l")]
         public decimal LastQuantityFilled { get; set; }
-        
+
         /// <summary>
         /// Liquidation Accumulated fill quantity
         /// </summary>
         [JsonProperty("z")]
         public decimal QuantityFilled { get; set; }
-        
+
         /// <summary>
         /// Liquidation Trade Time
         /// </summary>

--- a/Binance.Net/Objects/Models/Futures/Socket/BinanceFuturesStreamMarkPrice.cs
+++ b/Binance.Net/Objects/Models/Futures/Socket/BinanceFuturesStreamMarkPrice.cs
@@ -8,7 +8,7 @@ namespace Binance.Net.Objects.Models.Futures.Socket
     /// <summary>
     /// Mark price update
     /// </summary>
-    public class BinanceFuturesStreamMarkPrice: BinanceStreamEvent, IBinanceFuturesMarkPrice
+    public class BinanceFuturesStreamMarkPrice : BinanceStreamEvent, IBinanceFuturesMarkPrice
     {
         /// <summary>
         /// Symbol
@@ -33,7 +33,7 @@ namespace Binance.Net.Objects.Models.Futures.Socket
         /// </summary>
         [JsonProperty("r")]
         public decimal? FundingRate { get; set; }
-        
+
         /// <summary>
         /// Next Funding Time
         /// </summary>

--- a/Binance.Net/Objects/Models/Futures/Socket/BinanceFuturesStreamOrderUpdate.cs
+++ b/Binance.Net/Objects/Models/Futures/Socket/BinanceFuturesStreamOrderUpdate.cs
@@ -9,7 +9,7 @@ namespace Binance.Net.Objects.Models.Futures.Socket
     /// <summary>
     /// Order update
     /// </summary>
-    public class BinanceFuturesStreamOrderUpdate: BinanceStreamEvent
+    public class BinanceFuturesStreamOrderUpdate : BinanceStreamEvent
     {
         /// <summary>
         /// Update data

--- a/Binance.Net/Objects/Models/Futures/Socket/BinanceFuturesStreamSymbolUpdate.cs
+++ b/Binance.Net/Objects/Models/Futures/Socket/BinanceFuturesStreamSymbolUpdate.cs
@@ -3,7 +3,6 @@ using CryptoExchange.Net.Converters;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Binance.Net.Objects.Models.Futures.Socket
 {

--- a/Binance.Net/Objects/Models/Futures/Socket/BinanceStrategyUpdate.cs
+++ b/Binance.Net/Objects/Models/Futures/Socket/BinanceStrategyUpdate.cs
@@ -7,7 +7,7 @@ namespace Binance.Net.Objects.Models.Futures.Socket
     /// <summary>
     /// Strategy update
     /// </summary>
-    public class BinanceStrategyUpdate: BinanceStreamEvent
+    public class BinanceStrategyUpdate : BinanceStreamEvent
     {
         /// <summary>
         /// Update info

--- a/Binance.Net/Objects/Models/Spot/Binance24hPrice.cs
+++ b/Binance.Net/Objects/Models/Spot/Binance24hPrice.cs
@@ -33,7 +33,7 @@ namespace Binance.Net.Objects.Models.Spot
         /// </summary>
         [JsonProperty("AskQty")]
         public decimal BestAskQuantity { get; set; }
-        
+
         /// <inheritdoc />
         public override decimal Volume { get; set; }
         /// <inheritdoc />

--- a/Binance.Net/Objects/Models/Spot/BinanceAccountInfo.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceAccountInfo.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Binance.Net.Converters;
 using Binance.Net.Enums;
 using Binance.Net.Interfaces;
 using CryptoExchange.Net.Converters;

--- a/Binance.Net/Objects/Models/Spot/BinanceEventOrderBook.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceEventOrderBook.cs
@@ -9,7 +9,7 @@ namespace Binance.Net.Objects.Models.Spot
     /// <summary>
     /// Stream order book
     /// </summary>
-    public class BinanceEventOrderBook: BinanceOrderBook, IBinanceEventOrderBook
+    public class BinanceEventOrderBook : BinanceOrderBook, IBinanceEventOrderBook
     {
         /// <summary>
         /// The id of this update, can be synced with BinanceClient.Spot.GetOrderBook to update the order book
@@ -34,7 +34,7 @@ namespace Binance.Net.Objects.Models.Spot
         /// </summary>
         [JsonProperty("E"), JsonConverter(typeof(DateTimeConverter))]
         public DateTime EventTime { get; set; }
-        
+
         /// <summary>
         /// Setter for bids (needed forJson.Net)
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/BinanceFuturesAccountSnapshot.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceFuturesAccountSnapshot.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Binance.Net.Converters;
 using Binance.Net.Enums;
 using CryptoExchange.Net.Converters;
 using Newtonsoft.Json;

--- a/Binance.Net/Objects/Models/Spot/BinanceListResult.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceListResult.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using CryptoExchange.Net.Converters;
 using Newtonsoft.Json;
 

--- a/Binance.Net/Objects/Models/Spot/BinanceOrder.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceOrder.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Information regarding a specific order
     /// </summary>
-    public class BinanceOrder: BinanceOrderBase
+    public class BinanceOrder : BinanceOrderBase
     {
     }
 }

--- a/Binance.Net/Objects/Models/Spot/BinanceOrderBook.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceOrderBook.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Binance.Net.Interfaces;
-using CryptoExchange.Net.Interfaces;
 using Newtonsoft.Json;
 
 namespace Binance.Net.Objects.Models.Spot
@@ -22,7 +21,7 @@ namespace Binance.Net.Objects.Models.Spot
         /// </summary>
         [JsonProperty("lastUpdateId")]
         public long LastUpdateId { get; set; }
-        
+
         /// <summary>
         /// The list of bids
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/BinanceOrderOcoList.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceOrderOcoList.cs
@@ -76,7 +76,7 @@ namespace Binance.Net.Objects.Models.Spot
     /// <summary>
     /// The result of placing a new order
     /// </summary>
-    public class BinancePlacedOcoOrder: BinanceOrderBase
+    public class BinancePlacedOcoOrder : BinanceOrderBase
     {
         /// <summary>
         /// The time the order was placed

--- a/Binance.Net/Objects/Models/Spot/BinanceOrderRateLimit.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceOrderRateLimit.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Rate limit info
     /// </summary>
-    public class BinanceCurrentRateLimit: BinanceRateLimit
+    public class BinanceCurrentRateLimit : BinanceRateLimit
     {
         /// <summary>
         /// The current used amount

--- a/Binance.Net/Objects/Models/Spot/BinancePlacedOrder.cs
+++ b/Binance.Net/Objects/Models/Spot/BinancePlacedOrder.cs
@@ -9,14 +9,14 @@ namespace Binance.Net.Objects.Models.Spot
     /// <summary>
     /// The result of placing a new order
     /// </summary>
-    public class BinancePlacedOrder: BinanceOrderBase
+    public class BinancePlacedOrder : BinanceOrderBase
     {
         /// <summary>
         /// The time the order was placed
         /// </summary>
         [JsonProperty("transactTime"), JsonConverter(typeof(DateTimeConverter))]
         public new DateTime CreateTime { get; set; }
-        
+
         /// <summary>
         /// Trades for the order
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/BinancePrice.cs
+++ b/Binance.Net/Objects/Models/Spot/BinancePrice.cs
@@ -27,7 +27,7 @@ namespace Binance.Net.Objects.Models.Spot
     /// <summary>
     /// Futures-Coin price
     /// </summary>
-    public class BinanceFuturesCoinPrice: BinancePrice
+    public class BinanceFuturesCoinPrice : BinancePrice
     {
         /// <summary>
         /// Name of the pair

--- a/Binance.Net/Objects/Models/Spot/BinanceRecentTrade.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceRecentTrade.cs
@@ -8,7 +8,7 @@ namespace Binance.Net.Objects.Models.Spot
     /// <summary>
     /// Recent trade info
     /// </summary>
-    public abstract class BinanceRecentTrade: IBinanceRecentTrade
+    public abstract class BinanceRecentTrade : IBinanceRecentTrade
     {
         /// <summary>
         /// The id of the trade

--- a/Binance.Net/Objects/Models/Spot/BinanceReplaceOrderResult.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceReplaceOrderResult.cs
@@ -7,7 +7,7 @@ namespace Binance.Net.Objects.Models.Spot
     /// <summary>
     /// The result of replacing an order
     /// </summary>
-    public class BinanceReplaceOrderResult: BinanceReplaceResult
+    public class BinanceReplaceOrderResult : BinanceReplaceResult
     {
         /// <summary>
         /// Cancel result
@@ -32,7 +32,7 @@ namespace Binance.Net.Objects.Models.Spot
     /// <summary>
     /// Replace order
     /// </summary>
-    public class BinanceReplaceOrder: BinancePlacedOrder
+    public class BinanceReplaceOrder : BinancePlacedOrder
     {
         /// <summary>
         /// Failure message
@@ -48,7 +48,7 @@ namespace Binance.Net.Objects.Models.Spot
     /// <summary>
     /// Replace cancel order info
     /// </summary>
-    public class BinanceReplaceCancelOrder: BinanceOrderBase
+    public class BinanceReplaceCancelOrder : BinanceOrderBase
     {
         /// <summary>
         /// Failure message

--- a/Binance.Net/Objects/Models/Spot/BinanceSpotAccountSnapshot.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceSpotAccountSnapshot.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Binance.Net.Converters;
 using Binance.Net.Enums;
 using CryptoExchange.Net.Converters;
 using Newtonsoft.Json;

--- a/Binance.Net/Objects/Models/Spot/BinanceSpotFuturesTransfer.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceSpotFuturesTransfer.cs
@@ -35,7 +35,7 @@ namespace Binance.Net.Objects.Models.Spot
         /// </summary>
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Timestamp { get; set; }
-        
+
         /// <summary>
         /// The status of the transfer
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/BinanceSpotKline.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceSpotKline.cs
@@ -7,7 +7,7 @@ namespace Binance.Net.Objects.Models.Spot
     /// Candlestick information for symbol
     /// </summary>
     [JsonConverter(typeof(ArrayConverter))]
-    public class BinanceSpotKline: BinanceKlineBase
+    public class BinanceSpotKline : BinanceKlineBase
     {
         /// <summary>
         /// The volume traded during this candlestick

--- a/Binance.Net/Objects/Models/Spot/BinanceSymbol.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceSymbol.cs
@@ -108,7 +108,7 @@ namespace Binance.Net.Objects.Models.Spot
         /// <summary>
         /// Filter for max amount of iceberg parts for this symbol
         /// </summary>
-        [JsonIgnore]        
+        [JsonIgnore]
         public BinanceSymbolIcebergPartsFilter? IceBergPartsFilter => Filters.OfType<BinanceSymbolIcebergPartsFilter>().FirstOrDefault();
         /// <summary>
         /// Filter for max accuracy of the quantity for this symbol

--- a/Binance.Net/Objects/Models/Spot/BinanceSymbolFilter.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceSymbolFilter.cs
@@ -19,7 +19,7 @@ namespace Binance.Net.Objects.Models.Spot
     /// <summary>
     /// Price filter
     /// </summary>
-    public class BinanceSymbolPriceFilter: BinanceSymbolFilter
+    public class BinanceSymbolPriceFilter : BinanceSymbolFilter
     {
         /// <summary>
         /// The minimal price the order can be for
@@ -237,7 +237,7 @@ namespace Binance.Net.Objects.Models.Spot
         /// </summary>
         public int MaxTrailingBelowDelta { get; set; }
     }
-    
+
     /// <summary>
     /// Max Iceberg Orders Filter
     /// </summary>

--- a/Binance.Net/Objects/Models/Spot/BinanceTrade.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceTrade.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using CryptoExchange.Net.Converters;
 using Newtonsoft.Json;
 
@@ -27,7 +26,7 @@ namespace Binance.Net.Objects.Models.Spot
         /// Id of the order list this order belongs to
         /// </summary>
         public long? OrderListId { get; set; }
-        
+
         /// <summary>
         /// The price of the trade
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Blvt/BinanceBlvtInfoUpdate.cs
+++ b/Binance.Net/Objects/Models/Spot/Blvt/BinanceBlvtInfoUpdate.cs
@@ -7,7 +7,7 @@ namespace Binance.Net.Objects.Models.Spot.Blvt
     /// <summary>
     /// Blvt info update
     /// </summary>
-    public class BinanceBlvtInfoUpdate: BinanceStreamEvent
+    public class BinanceBlvtInfoUpdate : BinanceStreamEvent
     {
         /// <summary>
         /// Token name

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageAccountInfo.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageAccountInfo.cs
@@ -11,28 +11,28 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// Max Maker Commission
         /// </summary>
         public decimal MaxMakerCommission { get; set; }
-        
+
         /// <summary>
         /// Min Maker Commission
         /// </summary>
         public decimal MinMakerCommission { get; set; }
-        
+
         /// <summary>
         /// Max Taker Commission
         /// </summary>
         public decimal MaxTakerCommission { get; set; }
-        
+
         /// <summary>
         /// Min Taker Commission
         /// </summary>
         public decimal MinTakerCommission { get; set; }
-        
+
         /// <summary>
         /// Sub Account Quantity
         /// </summary>
         [JsonProperty("subAccountQty")]
         public int SubAccountQuantity { get; set; }
-        
+
         /// <summary>
         /// Max Sub Account Quantity
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageApiKeyCreateResult.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageApiKeyCreateResult.cs
@@ -11,30 +11,30 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// Sub Account Id
         /// </summary>
         public string SubAccountId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Api Key
         /// </summary>
         public string ApiKey { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Api Secret
         /// </summary>
         [JsonProperty("secretKey")]
         public string ApiSecret { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Is Spot Trading Enabled
         /// </summary>
         [JsonProperty("canTrade")]
         public bool IsSpotTradingEnabled { get; set; }
-        
+
         /// <summary>
         /// Is Margin Trading Enabled
         /// </summary>
         [JsonProperty("marginTrade")]
         public bool IsMarginTradingEnabled { get; set; }
-        
+
         /// <summary>
         /// Is Futures Trading Enabled
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageBnbBurnStatus.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageBnbBurnStatus.cs
@@ -11,13 +11,13 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// Sub Account Id
         /// </summary>
         public string SubAccountId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Is Spot BNB Burn
         /// </summary>
         [JsonProperty("spotBNBBurn")]
         public bool IsSpotBnbBurn { get; set; }
-        
+
         /// <summary>
         /// Is Interest BNB Burn
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageChangeBnbBurnMarginInterestResult.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageChangeBnbBurnMarginInterestResult.cs
@@ -11,7 +11,7 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// Sub Account Id
         /// </summary>
         public string SubAccountId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Is Interest BNB Burn
         /// </summary> 

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageChangeBnbBurnSpotAndMarginResult.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageChangeBnbBurnSpotAndMarginResult.cs
@@ -11,7 +11,7 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// Sub Account Id
         /// </summary>
         public string SubAccountId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Is Spot BNB Burn
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageEnableFuturesResult.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageEnableFuturesResult.cs
@@ -13,13 +13,13 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// Sub Account Id
         /// </summary>
         public string SubAccountId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Is Futures Enabled
         /// </summary>
         [JsonProperty("enableFutures")]
         public bool IsFuturesEnabled { get; set; }
-        
+
         /// <summary>
         /// Update Date
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageEnableLeverageTokenResult.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageEnableLeverageTokenResult.cs
@@ -11,7 +11,7 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// Sub Account Id
         /// </summary>
         public string SubAccountId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Is Leverage Token Enabled
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageEnableMarginResult.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageEnableMarginResult.cs
@@ -13,13 +13,13 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// Sub Account Id
         /// </summary>
         public string SubAccountId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Is Margin Enabled
         /// </summary>
         [JsonProperty("enableMargin")]
         public bool IsMarginEnabled { get; set; }
-        
+
         /// <summary>
         /// Update Date
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageFuturesAssetInfo.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageFuturesAssetInfo.cs
@@ -31,43 +31,43 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// Sub Account Id
         /// </summary>
         public string SubAccountId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Futures enable
         /// </summary>
         [JsonProperty("futuresEnable")]
         public bool IsFuturesEnable { get; set; }
-        
+
         /// <summary>
         /// Total Initial Margin Of Usdt
         /// </summary>
         public decimal TotalInitialMarginOfUsdt { get; set; }
-        
+
         /// <summary>
         /// Total Maintenance Margin Of Usdt
         /// </summary>
         public decimal TotalMaintenanceMarginOfUsdt { get; set; }
-        
+
         /// <summary>
         /// Total Wallet Balance Of Usdt
         /// </summary>
         public decimal TotalWalletBalanceOfUsdt { get; set; }
-        
+
         /// <summary>
         /// Total Unrealized Profit Of Usdt
         /// </summary>
         public decimal TotalUnrealizedProfitOfUsdt { get; set; }
-        
+
         /// <summary>
         /// Total Margin Balance Of Usdt
         /// </summary>
         public decimal TotalMarginBalanceOfUsdt { get; set; }
-        
+
         /// <summary>
         /// Total Position Initial Margin Of Usdt
         /// </summary>
         public decimal TotalPositionInitialMarginOfUsdt { get; set; }
-        
+
         /// <summary>
         /// Total Open Order Initial Margin Of Usdt
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageFuturesRebate.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageFuturesRebate.cs
@@ -18,22 +18,22 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// Income
         /// </summary>
         public decimal Income { get; set; }
-        
+
         /// <summary>
         /// Asset
         /// </summary>
         public string Asset { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Symbol
         /// </summary>
         public string Symbol { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// TradeId
         /// </summary>
         public long TradeId { get; set; }
-        
+
         /// <summary>
         /// Date
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageFuturesType.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageFuturesType.cs
@@ -9,7 +9,7 @@
         /// USDT-Ⓜ Futures
         /// </summary>
         USDT = 1,
-        
+
         /// <summary>
         /// COIN-Ⓜ Futures
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageIpRestriction.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageIpRestriction.cs
@@ -31,7 +31,7 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         [JsonProperty("updateTime"), JsonConverter(typeof(DateTimeConverter))]
         public DateTime UpdateDate { get; set; }
     }
-    
+
     /// <summary>
     /// IP Restriction
     /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageMarginAssetInfo.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageMarginAssetInfo.cs
@@ -31,28 +31,28 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// Sub Account Id
         /// </summary>
         public string SubAccountId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Margin enable
         /// </summary>
         [JsonProperty("marginEnable")]
         public bool IsMarginEnable { get; set; }
-        
+
         /// <summary>
         /// Total Asset Of Btc
         /// </summary>
         public decimal TotalAssetOfBtc { get; set; }
-        
+
         /// <summary>
         /// Total Liability Of Btc
         /// </summary>
         public decimal TotalLiabilityOfBtc { get; set; }
-        
+
         /// <summary>
         /// Total Net Asset Of Btc
         /// </summary>
         public decimal TotalNetAssetOfBtc { get; set; }
-        
+
         /// <summary>
         /// Margin level
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageRebate.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageRebate.cs
@@ -18,17 +18,17 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// Income
         /// </summary>
         public decimal Income { get; set; }
-        
+
         /// <summary>
         /// Asset
         /// </summary>
         public string Asset { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Symbol
         /// </summary>
         public string Symbol { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Trade Id
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageSpotAssetInfo.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageSpotAssetInfo.cs
@@ -31,7 +31,7 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// Sub Account Id
         /// </summary>
         public string SubAccountId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Total Balance Of Btc
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageSubAccountApiKey.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageSubAccountApiKey.cs
@@ -11,24 +11,24 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// Sub Account Id
         /// </summary>
         public string SubAccountId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Api Key
         /// </summary>
         public string ApiKey { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Is Spot Trading Enabled
         /// </summary>
         [JsonProperty("canTrade")]
         public bool IsSpotTradingEnabled { get; set; }
-        
+
         /// <summary>
         /// Is Margin Trading Enabled
         /// </summary>
         [JsonProperty("marginTrade")]
         public bool IsMarginTradingEnabled { get; set; }
-        
+
         /// <summary>
         /// Is Futures Trading Enabled
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageSubAccountCoinFuturesCommission.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageSubAccountCoinFuturesCommission.cs
@@ -9,27 +9,27 @@
         /// Sub Account Id
         /// </summary>
         public string SubAccountId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Pair
         /// </summary>
         public string Pair { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// COIN-Ⓜ futures commission adjustment for maker
         /// </summary>
         public int MakerAdjustment { get; set; }
-        
+
         /// <summary>
         /// COIN-Ⓜ futures commission adjustment for taker
         /// </summary>
         public int TakerAdjustment { get; set; }
-        
+
         /// <summary>
         /// COIN-Ⓜ futures commission (after adjusted) for maker
         /// </summary>
         public decimal MakerCommission { get; set; }
-        
+
         /// <summary>
         /// COIN-Ⓜ futures commission (after adjusted) for taker
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageSubAccountCommission.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageSubAccountCommission.cs
@@ -9,23 +9,23 @@
         /// Sub Account Id
         /// </summary>
         public string SubAccountId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Maker Commission
         /// </summary>
         public decimal MakerCommission { get; set; }
-        
+
         /// <summary>
         /// Taker Commission
         /// </summary>
         public decimal TakerCommission { get; set; }
-        
+
         /// <summary>
         /// Margin Maker Commission
         /// <para>If margin disabled, return -1</para>
         /// </summary>
         public decimal MarginMakerCommission { get; set; }
-        
+
         /// <summary>
         /// Margin Taker Commission
         /// <para>If margin disabled, return -1</para>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageSubAccountDepositStatus.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageSubAccountDepositStatus.cs
@@ -9,12 +9,12 @@
         /// Pending
         /// </summary>
         Pending = 0,
-        
+
         /// <summary>
         /// Success
         /// </summary>
         Success = 1,
-        
+
         /// <summary>
         /// Credited but cannot withdraw
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageSubAccountDepositTransaction.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageSubAccountDepositTransaction.cs
@@ -13,56 +13,56 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// Sub Account Id
         /// </summary>
         public string SubAccountId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Address
         /// </summary>
         public string Address { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Address Tag
         /// </summary>
         public string AddressTag { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Quantity
         /// </summary>
         [JsonProperty("amount")]
         public decimal Quantity { get; set; }
-        
+
         /// <summary>
         /// Asset
         /// </summary>
         [JsonProperty("coin")]
         public string Asset { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Date
         /// </summary>
         [JsonProperty("insertTime"), JsonConverter(typeof(DateTimeConverter))]
         public DateTime Timestamp { get; set; }
-        
+
         /// <summary>
         /// Network
         /// </summary>
         public string Network { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Status
         /// </summary>
         public BinanceBrokerageSubAccountDepositStatus Status { get; set; }
-        
+
         /// <summary>
         /// Transaction Id
         /// </summary>
         [JsonProperty("txId")]
         public string TransactionId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Source Address
         /// </summary>
         public string SourceAddress { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Confirm Times
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageSubAccountFuturesCommission.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageSubAccountFuturesCommission.cs
@@ -9,7 +9,7 @@
         /// Sub Account Id
         /// </summary>
         public string SubAccountId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Symbol
         /// </summary>
@@ -24,17 +24,17 @@
         /// USDT-Ⓜ futures commission adjustment for maker
         /// </summary>
         public int MakerAdjustment { get; set; }
-        
+
         /// <summary>
         /// USDT-Ⓜ futures commission adjustment for taker
         /// </summary>
         public int TakerAdjustment { get; set; }
-        
+
         /// <summary>
         /// USDT-Ⓜ futures commission (after adjusted) for maker
         /// </summary>
         public decimal MakerCommission { get; set; }
-        
+
         /// <summary>
         /// USDT-Ⓜ futures commission (after adjusted) for taker
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageTransferFuturesResult.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageTransferFuturesResult.cs
@@ -12,12 +12,12 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// </summary>
         [JsonProperty("txnId")]
         public string Id { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Success
         /// </summary>
         public bool Success { get; set; }
-        
+
         /// <summary>
         /// Client Transfer Id
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageTransferFuturesTransaction.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageTransferFuturesTransaction.cs
@@ -14,19 +14,19 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// Success
         /// </summary>
         public bool Success { get; set; }
-        
+
         /// <summary>
         /// Futures type
         /// </summary>
         public BinanceBrokerageFuturesType FuturesType { get; set; }
-        
+
         /// <summary>
         /// Transfer
         /// </summary>
         [JsonProperty("transfer")]
         public IEnumerable<BinanceBrokerageTransferFuturesTransaction> Transactions { get; set; } = Array.Empty<BinanceBrokerageTransferFuturesTransaction>();
     }
-    
+
     /// <summary>
     /// Transfer Futures Transaction
     /// </summary>
@@ -36,35 +36,35 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// From Id
         /// </summary>
         public string FromId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// To Id
         /// </summary>
         public string ToId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Asset
         /// </summary>
         public string Asset { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Quantity
         /// </summary>
         [JsonProperty("qty")]
         public decimal Quantity { get; set; }
-        
+
         /// <summary>
         /// Transaction Id
         /// </summary>
         [JsonProperty("tranId")]
         public string Id { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Client Transfer Id
         /// </summary>
         [JsonProperty("clientTranId")]
         public string ClientTransferId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Date
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageTransferResult.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageTransferResult.cs
@@ -12,7 +12,7 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// </summary>
         [JsonProperty("txnId")]
         public string Id { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Client Transfer Id
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageTransferTransaction.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageTransferTransaction.cs
@@ -16,40 +16,40 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// </summary>
         [JsonProperty("txnId")]
         public string Id { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Client Transfer Id
         /// </summary>
         [JsonProperty("clientTranId")]
         public string ClientTransferId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// From Id
         /// </summary>
         public string FromId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// To Id
         /// </summary>
         public string ToId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Asset
         /// </summary>
         public string Asset { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Quantity
         /// </summary>
         [JsonProperty("qty")]
         public decimal Quantity { get; set; }
-        
+
         /// <summary>
         /// Date
         /// </summary>
         [JsonProperty("time"), JsonConverter(typeof(DateTimeConverter))]
         public DateTime Date { get; set; }
-        
+
         /// <summary>
         /// Status
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageTransferTransactionUniversal.cs
+++ b/Binance.Net/Objects/Models/Spot/Brokerage/SubAccountData/BinanceBrokerageTransferTransactionUniversal.cs
@@ -16,47 +16,47 @@ namespace Binance.Net.Objects.Models.Spot.Brokerage.SubAccountData
         /// </summary>
         [JsonProperty("txnId")]
         public string Id { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Client Transfer Id
         /// </summary>
         [JsonProperty("clientTranId")]
         public string ClientTransferId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// To id
         /// </summary>
         public string ToId { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// From account type
         /// </summary>
         [JsonConverter(typeof(BrokerageAccountTypeConverter))]
         public BrokerageAccountType FromAccountType { get; set; }
-        
+
         /// <summary>
         /// To account type
         /// </summary>
         [JsonConverter(typeof(BrokerageAccountTypeConverter))]
         public BrokerageAccountType ToAccountType { get; set; }
-        
+
         /// <summary>
         /// Asset
         /// </summary>
         public string Asset { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Quantity
         /// </summary>
         [JsonProperty("qty")]
         public decimal Quantity { get; set; }
-        
+
         /// <summary>
         /// Date
         /// </summary>
         [JsonProperty("time"), JsonConverter(typeof(DateTimeConverter))]
         public DateTime Date { get; set; }
-        
+
         /// <summary>
         /// Status
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Loans/BinanceCryptoLoanBorrow.cs
+++ b/Binance.Net/Objects/Models/Spot/Loans/BinanceCryptoLoanBorrow.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Binance.Net.Objects.Models.Spot.Loans
 {

--- a/Binance.Net/Objects/Models/Spot/Loans/BinanceCryptoLoanBorrowRecord.cs
+++ b/Binance.Net/Objects/Models/Spot/Loans/BinanceCryptoLoanBorrowRecord.cs
@@ -2,8 +2,6 @@
 using CryptoExchange.Net.Converters;
 using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Binance.Net.Objects.Models.Spot.Loans
 {

--- a/Binance.Net/Objects/Models/Spot/Loans/BinanceCryptoLoanLtvAdjust.cs
+++ b/Binance.Net/Objects/Models/Spot/Loans/BinanceCryptoLoanLtvAdjust.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Binance.Net.Objects.Models.Spot.Loans
 {

--- a/Binance.Net/Objects/Models/Spot/Loans/BinanceCryptoLoanLtvAdjustRecord.cs
+++ b/Binance.Net/Objects/Models/Spot/Loans/BinanceCryptoLoanLtvAdjustRecord.cs
@@ -1,8 +1,6 @@
 ﻿using CryptoExchange.Net.Converters;
 using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Binance.Net.Objects.Models.Spot.Loans
 {

--- a/Binance.Net/Objects/Models/Spot/Loans/BinanceCryptoLoanRepayRecord.cs
+++ b/Binance.Net/Objects/Models/Spot/Loans/BinanceCryptoLoanRepayRecord.cs
@@ -2,8 +2,6 @@
 using CryptoExchange.Net.Converters;
 using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Binance.Net.Objects.Models.Spot.Loans
 {

--- a/Binance.Net/Objects/Models/Spot/Margin/BinanceMarginAccountSnapshot.cs
+++ b/Binance.Net/Objects/Models/Spot/Margin/BinanceMarginAccountSnapshot.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Binance.Net.Converters;
 using Binance.Net.Enums;
 using CryptoExchange.Net.Converters;
 using Newtonsoft.Json;

--- a/Binance.Net/Objects/Models/Spot/Margin/BinanceMarginOrderOcoList.cs
+++ b/Binance.Net/Objects/Models/Spot/Margin/BinanceMarginOrderOcoList.cs
@@ -5,7 +5,7 @@ namespace Binance.Net.Objects.Models.Spot.Margin
     /// <summary>
     /// Oco info
     /// </summary>
-    public class BinanceMarginOrderOcoList: BinanceOrderOcoList
+    public class BinanceMarginOrderOcoList : BinanceOrderOcoList
     {
         /// <summary>
         /// Margin buy borrow quantity

--- a/Binance.Net/Objects/Models/Spot/PortfolioMargin/BinancePortfolioMarginCollateralRate.cs
+++ b/Binance.Net/Objects/Models/Spot/PortfolioMargin/BinancePortfolioMarginCollateralRate.cs
@@ -1,6 +1,4 @@
-﻿using Binance.Net.Enums;
-using CryptoExchange.Net.Converters;
-namespace Binance.Net.Objects.Models.Spot.PortfolioMargin
+﻿namespace Binance.Net.Objects.Models.Spot.PortfolioMargin
 {
     /// <summary>
     /// Portfolio margin collateral rate info

--- a/Binance.Net/Objects/Models/Spot/PortfolioMargin/BinancePortfolioMarginInfo.cs
+++ b/Binance.Net/Objects/Models/Spot/PortfolioMargin/BinancePortfolioMarginInfo.cs
@@ -1,9 +1,6 @@
 ﻿using Binance.Net.Enums;
 using CryptoExchange.Net.Converters;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Binance.Net.Objects.Models.Spot.PortfolioMargin
 {

--- a/Binance.Net/Objects/Models/Spot/PortfolioMargin/BinancePortfolioMarginLoan.cs
+++ b/Binance.Net/Objects/Models/Spot/PortfolioMargin/BinancePortfolioMarginLoan.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
 
 namespace Binance.Net.Objects.Models.Spot.PortfolioMargin
 {

--- a/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamAggregatedTrade.cs
+++ b/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamAggregatedTrade.cs
@@ -8,7 +8,7 @@ namespace Binance.Net.Objects.Models.Spot.Socket
     /// <summary>
     /// Aggregated information about trades for a symbol
     /// </summary>
-    public class BinanceStreamAggregatedTrade: BinanceStreamEvent, IBinanceAggregatedTrade
+    public class BinanceStreamAggregatedTrade : BinanceStreamEvent, IBinanceAggregatedTrade
     {
         /// <summary>
         /// The symbol the trade was for
@@ -50,7 +50,7 @@ namespace Binance.Net.Objects.Models.Spot.Socket
         /// </summary>
         [JsonProperty("m")]
         public bool BuyerIsMaker { get; set; }
-        
+
         /// <summary>
         /// Unused
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamBalanceUpdate.cs
+++ b/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamBalanceUpdate.cs
@@ -7,7 +7,7 @@ namespace Binance.Net.Objects.Models.Spot.Socket
     /// <summary>
     /// Update when asset is withdrawn/deposited 
     /// </summary>
-    public class BinanceStreamBalanceUpdate: BinanceStreamEvent
+    public class BinanceStreamBalanceUpdate : BinanceStreamEvent
     {
         /// <summary>
         /// The asset which changed

--- a/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamBookPrice.cs
+++ b/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamBookPrice.cs
@@ -6,7 +6,7 @@ namespace Binance.Net.Objects.Models.Spot.Socket
     /// <summary>
     /// Book tick
     /// </summary>
-    public class BinanceStreamBookPrice: IBinanceBookPrice
+    public class BinanceStreamBookPrice : IBinanceBookPrice
     {
         /// <summary>
         /// Update id

--- a/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamKline.cs
+++ b/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamKline.cs
@@ -10,7 +10,7 @@ namespace Binance.Net.Objects.Models.Spot.Socket
     /// <summary>
     /// Wrapper for kline information for a symbol
     /// </summary>
-    public class BinanceStreamKlineData: BinanceStreamEvent, IBinanceStreamKlineData
+    public class BinanceStreamKlineData : BinanceStreamEvent, IBinanceStreamKlineData
     {
         /// <summary>
         /// The symbol the data is for
@@ -29,7 +29,7 @@ namespace Binance.Net.Objects.Models.Spot.Socket
     /// <summary>
     /// The kline data
     /// </summary>
-    public class BinanceStreamKline: BinanceKlineBase, IBinanceStreamKline
+    public class BinanceStreamKline : BinanceKlineBase, IBinanceStreamKline
     {
         /// <summary>
         /// The open time of this candlestick

--- a/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamMiniTick.cs
+++ b/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamMiniTick.cs
@@ -37,7 +37,7 @@ namespace Binance.Net.Objects.Models.Spot.Socket
         /// </summary>
         [JsonProperty("l")]
         public decimal LowPrice { get; set; }
-        
+
         /// <summary>
         /// Total traded volume
         /// </summary>
@@ -52,7 +52,7 @@ namespace Binance.Net.Objects.Models.Spot.Socket
     /// <summary>
     /// Stream mini tick
     /// </summary>
-    public class BinanceStreamMiniTick: BinanceStreamMiniTickBase
+    public class BinanceStreamMiniTick : BinanceStreamMiniTickBase
     {
         /// <inheritdoc/>
         [JsonProperty("v")]

--- a/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamOrderList.cs
+++ b/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamOrderList.cs
@@ -6,11 +6,11 @@ using CryptoExchange.Net.Converters;
 using Newtonsoft.Json;
 
 namespace Binance.Net.Objects.Models.Spot.Socket
-{   
+{
     /// <summary>
     /// Order list info
     /// </summary>
-    public class BinanceStreamOrderList: BinanceStreamEvent
+    public class BinanceStreamOrderList : BinanceStreamEvent
     {
         /// <summary>
         /// The id of the order list

--- a/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamOrderUpdate.cs
+++ b/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamOrderUpdate.cs
@@ -9,7 +9,7 @@ namespace Binance.Net.Objects.Models.Spot.Socket
     /// <summary>
     /// Update data about an order
     /// </summary>
-    public class BinanceStreamOrderUpdate: BinanceStreamEvent
+    public class BinanceStreamOrderUpdate : BinanceStreamEvent
     {
         /// <summary>
         /// The id of the order as assigned by Binance

--- a/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamPositionsUpdate.cs
+++ b/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamPositionsUpdate.cs
@@ -30,7 +30,7 @@ namespace Binance.Net.Objects.Models.Spot.Socket
     /// <summary>
     /// Information about an asset balance
     /// </summary>
-    public class BinanceStreamBalance: IBinanceBalance
+    public class BinanceStreamBalance : IBinanceBalance
     {
         /// <summary>
         /// The asset this balance is for

--- a/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamRollingWindowTick.cs
+++ b/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamRollingWindowTick.cs
@@ -7,7 +7,7 @@ namespace Binance.Net.Objects.Models.Spot.Socket
     /// <summary>
     /// Rolling window tick info
     /// </summary>
-    public class BinanceStreamRollingWindowTick: BinanceStreamEvent
+    public class BinanceStreamRollingWindowTick : BinanceStreamEvent
     {
         /// <summary>
         /// The symbol this data is for

--- a/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamTick.cs
+++ b/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamTick.cs
@@ -8,8 +8,8 @@ namespace Binance.Net.Objects.Models.Spot.Socket
     /// <summary>
     /// Tick info
     /// </summary>
-    public abstract class BinanceStreamTickBase: BinanceStreamEvent, IBinanceTick
-    {        
+    public abstract class BinanceStreamTickBase : BinanceStreamEvent, IBinanceTick
+    {
         /// <summary>
         /// The symbol this data is for
         /// </summary>
@@ -118,7 +118,7 @@ namespace Binance.Net.Objects.Models.Spot.Socket
     /// <summary>
     /// Stream tick
     /// </summary>
-    public class BinanceStreamTick: BinanceStreamTickBase
+    public class BinanceStreamTick : BinanceStreamTickBase
     {
         /// <summary>
         /// Total traded volume in the base asset

--- a/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamTrade.cs
+++ b/Binance.Net/Objects/Models/Spot/Socket/BinanceStreamTrade.cs
@@ -8,7 +8,7 @@ namespace Binance.Net.Objects.Models.Spot.Socket
     /// <summary>
     /// Aggregated information about trades for a symbol
     /// </summary>
-    public class BinanceStreamTrade: BinanceStreamEvent, IBinanceTrade
+    public class BinanceStreamTrade : BinanceStreamEvent, IBinanceTrade
     {
         /// <summary>
         /// The symbol the trade was for

--- a/Binance.Net/Objects/Models/Spot/Staking/BinanceStakingResult.cs
+++ b/Binance.Net/Objects/Models/Spot/Staking/BinanceStakingResult.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Staking result
     /// </summary>
-    public class BinanceStakingResult 
+    public class BinanceStakingResult
     {
         /// <summary>
         /// Successful
@@ -14,7 +14,7 @@
     /// <summary>
     /// Staking result
     /// </summary>
-    public class BinanceStakingPositionResult: BinanceStakingResult
+    public class BinanceStakingPositionResult : BinanceStakingResult
     {
         /// <summary>
         /// Id of the position

--- a/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountBlvt.cs
+++ b/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountBlvt.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// The email associated with the sub account
         /// </summary>
-        public string Email { get; set; } = string.Empty;      
+        public string Email { get; set; } = string.Empty;
         /// <summary>
         /// Blvt enabled
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountEmail.cs
+++ b/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountEmail.cs
@@ -8,6 +8,6 @@
         /// <summary>
         /// The email associated with the sub account
         /// </summary>
-        public string Email { get; set; } = string.Empty;        
+        public string Email { get; set; } = string.Empty;
     }
 }

--- a/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountFuturesDetails.cs
+++ b/Binance.Net/Objects/Models/Spot/SubAccountData/BinanceSubAccountFuturesDetails.cs
@@ -42,7 +42,7 @@ namespace Binance.Net.Objects.Models.Spot.SubAccountData
         /// Max quantity which can be withdrawn
         /// </summary>
         [JsonProperty("maxWithdrawAmount")]
-        public decimal MaxWithdrawQuantity{ get; set; }
+        public decimal MaxWithdrawQuantity { get; set; }
         /// <summary>
         /// Total initial margin
         /// </summary>
@@ -77,7 +77,7 @@ namespace Binance.Net.Objects.Models.Spot.SubAccountData
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime UpdateTime { get; set; }
     }
-    
+
     /// <summary>
     /// Sub account future asset details
     /// </summary>

--- a/Binance.Net/Objects/Options/BinanceSocketOptions.cs
+++ b/Binance.Net/Objects/Options/BinanceSocketOptions.cs
@@ -29,7 +29,7 @@ namespace Binance.Net.Objects.Options
         /// <summary>
         /// Options for the Coin Futures API
         /// </summary>
-        public BinanceSocketApiOptions CoinFuturesOptions { get; private set; } = new BinanceSocketApiOptions(); 
+        public BinanceSocketApiOptions CoinFuturesOptions { get; private set; } = new BinanceSocketApiOptions();
 
         internal BinanceSocketOptions Copy()
         {

--- a/Binance.Net/SymbolOrderBooks/BinanceFuturesUsdtSymbolOrderBook.cs
+++ b/Binance.Net/SymbolOrderBooks/BinanceFuturesUsdtSymbolOrderBook.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Binance.Net.Clients;
 using Binance.Net.Interfaces;
 using Binance.Net.Interfaces.Clients;
-using Binance.Net.Objects;
 using Binance.Net.Objects.Options;
 using CryptoExchange.Net.Objects;
 using CryptoExchange.Net.OrderBook;

--- a/Binance.Net/SymbolOrderBooks/BinanceOrderBookFactory.cs
+++ b/Binance.Net/SymbolOrderBooks/BinanceOrderBookFactory.cs
@@ -32,7 +32,7 @@ namespace Binance.Net.SymbolOrderBooks
                                              _serviceProvider.GetRequiredService<IBinanceRestClient>(),
                                              _serviceProvider.GetRequiredService<IBinanceSocketClient>());
 
-        
+
         /// <inheritdoc />
         public ISymbolOrderBook CreateUsdtFutures(string symbol, Action<BinanceOrderBookOptions>? options = null)
             => new BinanceFuturesUsdtSymbolOrderBook(symbol,
@@ -41,7 +41,7 @@ namespace Binance.Net.SymbolOrderBooks
                                              _serviceProvider.GetRequiredService<IBinanceRestClient>(),
                                              _serviceProvider.GetRequiredService<IBinanceSocketClient>());
 
-        
+
         /// <inheritdoc />
         public ISymbolOrderBook CreateCoinFutures(string symbol, Action<BinanceOrderBookOptions>? options = null)
             => new BinanceFuturesCoinSymbolOrderBook(symbol,

--- a/Binance.Net/SymbolOrderBooks/BinanceSpotSymbolOrderBook.cs
+++ b/Binance.Net/SymbolOrderBooks/BinanceSpotSymbolOrderBook.cs
@@ -4,12 +4,10 @@ using System.Threading.Tasks;
 using Binance.Net.Clients;
 using Binance.Net.Interfaces;
 using Binance.Net.Interfaces.Clients;
-using Binance.Net.Objects;
 using Binance.Net.Objects.Options;
 using CryptoExchange.Net.Objects;
 using CryptoExchange.Net.OrderBook;
 using CryptoExchange.Net.Sockets;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Binance.Net.SymbolOrderBooks
@@ -112,7 +110,7 @@ namespace Binance.Net.SymbolOrderBooks
 
         private void HandleUpdate(DataEvent<IBinanceEventOrderBook> data)
         {
-            if(data.Data.FirstUpdateId != null)
+            if (data.Data.FirstUpdateId != null)
                 UpdateOrderBook(data.Data.FirstUpdateId.Value, data.Data.LastUpdateId, data.Data.Bids, data.Data.Asks);
             else
                 UpdateOrderBook(data.Data.LastUpdateId, data.Data.Bids, data.Data.Asks);
@@ -121,10 +119,10 @@ namespace Binance.Net.SymbolOrderBooks
 
         private void HandleUpdate(DataEvent<IBinanceOrderBook> data)
         {
-            if (Levels == null)            
-                UpdateOrderBook(data.Data.LastUpdateId, data.Data.Bids, data.Data.Asks);            
-            else            
-                SetInitialOrderBook(data.Data.LastUpdateId, data.Data.Bids, data.Data.Asks);            
+            if (Levels == null)
+                UpdateOrderBook(data.Data.LastUpdateId, data.Data.Bids, data.Data.Asks);
+            else
+                SetInitialOrderBook(data.Data.LastUpdateId, data.Data.Bids, data.Data.Asks);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Closes https://github.com/JKorf/Binance.Net/issues/1275

```cs
new TimeInForceConverter(false)
```

There are lots of requests that are calling `new` when they don't need to, which slows down the request.

https://github.com/JKorf/Binance.Net/blob/e3c98cbc7d03b663a5a3bd43b19ae16cc00291f1/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApi.cs#L134

This is one example from `PlaceOrderInternal` but this is true for anywhere you see the converters **outside of an attribute** like below

```cs
new OrderSideConverter(false);
new SpotOrderTypeConverter(false);
new TimeInForceConverter(false);
new SideEffectTypeConverter(false);
new OrderResponseTypeConverter(false);
etc....
```

I solved this by creating a [static version of all these converters](https://github.com/NoParamedic/BinanceAPI.NET/blob/master/Binance-API/Binance-API/Converters/StaticConverters.cs)

I could do something similar and open a pull request if you want, let me know.