### PR TITLE
Use Static Converters for Requests instead of creating new converters every time 

### DIFF
--- a/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiAccount.cs
+++ b/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiAccount.cs
@@ -104,7 +104,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "marginType", JsonConvert.SerializeObject(marginType, new FuturesMarginTypeConverter(false)) }
+                { "marginType", JsonConvert.SerializeObject(marginType, StaticConverters.StaticFuturesMarginTypeConverter) }
             };
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
@@ -122,9 +122,9 @@ namespace Binance.Net.Clients.CoinFuturesApi
             {
                 { "symbol", symbol },
                 { "amount", quantity.ToString(CultureInfo.InvariantCulture) },
-                { "type", JsonConvert.SerializeObject(type, new FuturesMarginChangeDirectionTypeConverter(false)) },
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticFuturesMarginChangeDirectionTypeConverter) },
             };
-            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, new PositionSideConverter(false)));
+            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, StaticConverters.StaticPositionSideConverter));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
             return await _baseClient.SendRequestInternal<BinanceFuturesPositionMarginResult>(_baseClient.GetUrl(positionMarginEndpoint, api, signedVersion), HttpMethod.Post, ct, parameters, true).ConfigureAwait(false);
@@ -141,7 +141,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             {
                 { "symbol", symbol }
             };
-            parameters.AddOptionalParameter("type", type.HasValue ? JsonConvert.SerializeObject(type, new FuturesMarginChangeDirectionTypeConverter(false)) : null);
+            parameters.AddOptionalParameter("type", type.HasValue ? JsonConvert.SerializeObject(type, StaticConverters.StaticFuturesMarginChangeDirectionTypeConverter) : null);
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));

--- a/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiExchangeData.cs
+++ b/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiExchangeData.cs
@@ -170,7 +170,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             var url = _baseClient.GetUrl(topLongShortAccountRatioEndpoint, tradingDataapi);
             var parameters = new Dictionary<string, object> {
                 { url.ToString().Contains("dapi") ? "pair": "symbol", symbolPair },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -192,7 +192,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             var url = _baseClient.GetUrl(topLongShortPositionRatioEndpoint, tradingDataapi);
             var parameters = new Dictionary<string, object> {
                 { url.ToString().Contains("dapi") ? "pair": "symbol", symbolPair },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -214,7 +214,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             var url = _baseClient.GetUrl(globalLongShortAccountRatioEndpoint, tradingDataapi);
             var parameters = new Dictionary<string, object> {
                 { url.ToString().Contains("dapi") ? "pair": "symbol", symbolPair },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -235,7 +235,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
 
             var parameters = new Dictionary<string, object> {
                 { "symbol", symbol },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -293,7 +293,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             limit?.ValidateIntBetween(nameof(limit), 1, 1500);
             var parameters = new Dictionary<string, object> {
                 { "symbol", symbol },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
@@ -314,8 +314,8 @@ namespace Binance.Net.Clients.CoinFuturesApi
             limit?.ValidateIntBetween(nameof(limit), 1, 1500);
             var parameters = new Dictionary<string, object> {
                 { "pair", pair },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) },
-                { "contractType", JsonConvert.SerializeObject(contractType, new ContractTypeConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter) },
+                { "contractType", JsonConvert.SerializeObject(contractType, StaticConverters.StaticContractTypeConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
@@ -336,7 +336,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             limit?.ValidateIntBetween(nameof(limit), 1, 1500);
             var parameters = new Dictionary<string, object> {
                 { "pair", pair },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
@@ -404,8 +404,8 @@ namespace Binance.Net.Clients.CoinFuturesApi
 
             var parameters = new Dictionary<string, object> {
                 { "pair", pair },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) },
-                { "contractType", JsonConvert.SerializeObject(contractType, new ContractTypeConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) },
+                { "contractType", JsonConvert.SerializeObject(contractType, StaticConverters.StaticContractTypeConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -426,8 +426,8 @@ namespace Binance.Net.Clients.CoinFuturesApi
 
             var parameters = new Dictionary<string, object> {
                 { "pair", pair },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) },
-                { "contractType", JsonConvert.SerializeObject(contractType, new ContractTypeConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) },
+                { "contractType", JsonConvert.SerializeObject(contractType, StaticConverters.StaticContractTypeConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -448,8 +448,8 @@ namespace Binance.Net.Clients.CoinFuturesApi
 
             var parameters = new Dictionary<string, object> {
                 { "pair", pair },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) },
-                { "contractType", JsonConvert.SerializeObject(contractType, new ContractTypeConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) },
+                { "contractType", JsonConvert.SerializeObject(contractType, StaticConverters.StaticContractTypeConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));

--- a/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiTrading.cs
+++ b/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiTrading.cs
@@ -94,21 +94,21 @@ namespace Binance.Net.Clients.CoinFuturesApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
-                { "type", JsonConvert.SerializeObject(type, new FuturesOrderTypeConverter(false)) }
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticFuturesOrderTypeConverter) }
             };
             parameters.AddOptionalParameter("quantity", quantity?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("newClientOrderId", newClientOrderId);
             parameters.AddOptionalParameter("price", price?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, new TimeInForceConverter(false)));
-            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, new PositionSideConverter(false)));
+            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, StaticConverters.StaticTimeInForceConverter));
+            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, StaticConverters.StaticPositionSideConverter));
             parameters.AddOptionalParameter("stopPrice", stopPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("activationPrice", activationPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("callbackRate", callbackRate?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("workingType", workingType == null ? null : JsonConvert.SerializeObject(workingType, new WorkingTypeConverter(false)));
+            parameters.AddOptionalParameter("workingType", workingType == null ? null : JsonConvert.SerializeObject(workingType, StaticConverters.StaticWorkingTypeConverter));
             parameters.AddOptionalParameter("reduceOnly", reduceOnly?.ToString().ToLower());
             parameters.AddOptionalParameter("closePosition", closePosition?.ToString().ToLower());
-            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, new OrderResponseTypeConverter(false)));
+            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, StaticConverters.StaticOrderResponseTypeConverter));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("priceProtect", priceProtect?.ToString().ToUpper());
 
@@ -158,20 +158,20 @@ namespace Binance.Net.Clients.CoinFuturesApi
                 var orderParameters = new Dictionary<string, object>()
                 {
                     { "symbol", order.Symbol },
-                    { "side", JsonConvert.SerializeObject(order.Side, new OrderSideConverter(false)) },
-                    { "type", JsonConvert.SerializeObject(order.Type, new FuturesOrderTypeConverter(false)) },
+                    { "side", JsonConvert.SerializeObject(order.Side, StaticConverters.StaticOrderSideConverter) },
+                    { "type", JsonConvert.SerializeObject(order.Type, StaticConverters.StaticFuturesOrderTypeConverter) },
                     { "newOrderRespType", "RESULT" }
                 };
 
                 orderParameters.AddOptionalParameter("quantity", order.Quantity?.ToString(CultureInfo.InvariantCulture));
                 orderParameters.AddOptionalParameter("newClientOrderId", order.NewClientOrderId);
                 orderParameters.AddOptionalParameter("price", order.Price?.ToString(CultureInfo.InvariantCulture));
-                orderParameters.AddOptionalParameter("timeInForce", order.TimeInForce == null ? null : JsonConvert.SerializeObject(order.TimeInForce, new TimeInForceConverter(false)));
-                orderParameters.AddOptionalParameter("positionSide", order.PositionSide == null ? null : JsonConvert.SerializeObject(order.PositionSide, new PositionSideConverter(false)));
+                orderParameters.AddOptionalParameter("timeInForce", order.TimeInForce == null ? null : JsonConvert.SerializeObject(order.TimeInForce, StaticConverters.StaticTimeInForceConverter));
+                orderParameters.AddOptionalParameter("positionSide", order.PositionSide == null ? null : JsonConvert.SerializeObject(order.PositionSide, StaticConverters.StaticPositionSideConverter));
                 orderParameters.AddOptionalParameter("stopPrice", order.StopPrice?.ToString(CultureInfo.InvariantCulture));
                 orderParameters.AddOptionalParameter("activationPrice", order.ActivationPrice?.ToString(CultureInfo.InvariantCulture));
                 orderParameters.AddOptionalParameter("callbackRate", order.CallbackRate?.ToString(CultureInfo.InvariantCulture));
-                orderParameters.AddOptionalParameter("workingType", order.WorkingType == null ? null : JsonConvert.SerializeObject(order.WorkingType, new WorkingTypeConverter(false)));
+                orderParameters.AddOptionalParameter("workingType", order.WorkingType == null ? null : JsonConvert.SerializeObject(order.WorkingType, StaticConverters.StaticWorkingTypeConverter));
                 orderParameters.AddOptionalParameter("reduceOnly", order.ReduceOnly?.ToString().ToLower());
                 orderParameters.AddOptionalParameter("priceProtect", order.PriceProtect?.ToString().ToUpper());
                 parameterOrders[i] = orderParameters;

--- a/Binance.Net/Clients/CoinFuturesApi/BinanceSocketClientCoinFuturesApi.cs
+++ b/Binance.Net/Clients/CoinFuturesApi/BinanceSocketClientCoinFuturesApi.cs
@@ -93,7 +93,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
                 var result = data.Data.Data;
                 onMessage(data.As<IBinanceStreamKlineData>(result, result.Symbol));
             });
-            symbols = symbols.SelectMany(a => intervals.Select(i => a.ToLower(CultureInfo.InvariantCulture) + klineStreamEndpoint + "_" + JsonConvert.SerializeObject(i, new KlineIntervalConverter(false)))).ToArray();
+            symbols = symbols.SelectMany(a => intervals.Select(i => a.ToLower(CultureInfo.InvariantCulture) + klineStreamEndpoint + "_" + JsonConvert.SerializeObject(i, StaticConverters.StaticKlineIntervalConverter))).ToArray();
             return await SubscribeAsync( BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
 
@@ -146,10 +146,10 @@ namespace Binance.Net.Clients.CoinFuturesApi
             var handler = new Action<DataEvent<BinanceCombinedStream<BinanceStreamKlineData>>>(data => onMessage(data.As(data.Data.Data, data.Data.Data.Symbol)));
             pairs = pairs.Select(a => a.ToLower(CultureInfo.InvariantCulture) +
                                       "_" +
-                                      JsonConvert.SerializeObject(contractType, new ContractTypeConverter(false)).ToLower() +
+                                      JsonConvert.SerializeObject(contractType, StaticConverters.StaticContractTypeConverter).ToLower() +
                                       continuousKlineStreamEndpoint +
                                       "_" +
-                                      JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false))).ToArray();
+                                      JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter)).ToArray();
             return await SubscribeAsync( BaseAddress, pairs, handler, ct).ConfigureAwait(false);
         }
 
@@ -168,7 +168,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             pairs = pairs.Select(a => a.ToLower(CultureInfo.InvariantCulture) +
                                       indexKlineStreamEndpoint +
                                       "_" +
-                                      JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false))).ToArray();
+                                      JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter)).ToArray();
             return await SubscribeAsync( BaseAddress, pairs, handler, ct).ConfigureAwait(false);
         }
 
@@ -187,7 +187,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             symbols = symbols.Select(a => a.ToLower(CultureInfo.InvariantCulture) +
                                           markKlineStreamEndpoint +
                                          "_" +
-                                         JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false))).ToArray();
+                                         JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter)).ToArray();
             return await SubscribeAsync( BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
 

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApi.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApi.cs
@@ -124,19 +124,19 @@ namespace Binance.Net.Clients.SpotApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
-                { "type", JsonConvert.SerializeObject(type, new SpotOrderTypeConverter(false)) }
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticSpotOrderTypeConverter) }
             };
             parameters.AddOptionalParameter("quantity", quantity?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("quoteOrderQty", quoteQuantity?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("newClientOrderId", newClientOrderId);
             parameters.AddOptionalParameter("price", price?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, new TimeInForceConverter(false)));
+            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, StaticConverters.StaticTimeInForceConverter));
             parameters.AddOptionalParameter("stopPrice", stopPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("icebergQty", icebergQty?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("sideEffectType", sideEffectType == null ? null : JsonConvert.SerializeObject(sideEffectType, new SideEffectTypeConverter(false)));
+            parameters.AddOptionalParameter("sideEffectType", sideEffectType == null ? null : JsonConvert.SerializeObject(sideEffectType, StaticConverters.StaticSideEffectTypeConverter));
             parameters.AddOptionalParameter("isIsolated", isIsolated);
-            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, new OrderResponseTypeConverter(false)));
+            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, StaticConverters.StaticOrderResponseTypeConverter));
             parameters.AddOptionalParameter("trailingDelta", trailingDelta);
             parameters.AddOptionalParameter("strategyId", strategyId);
             parameters.AddOptionalParameter("strategyType", strategyType);

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiAccount.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiAccount.cs
@@ -184,7 +184,7 @@ namespace Binance.Net.Clients.SpotApi
             parameters.AddOptionalParameter("network", network);
             parameters.AddOptionalParameter("transactionFeeFlag", transactionFeeFlag);
             parameters.AddOptionalParameter("addressTag", addressTag);
-            parameters.AddOptionalParameter("walletType", walletType != null ? JsonConvert.SerializeObject(walletType, new WalletTypeConverter(false)) : null);
+            parameters.AddOptionalParameter("walletType", walletType != null ? JsonConvert.SerializeObject(walletType, StaticConverters.StaticWalletTypeConverter) : null);
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
             var result = await _baseClient.SendRequestInternal<BinanceWithdrawalPlaced>(_baseClient.GetUrl(withdrawEndpoint, "sapi", "1"), HttpMethod.Post, ct, parameters, true, HttpMethodParameterPosition.InUri).ConfigureAwait(false);
@@ -200,7 +200,7 @@ namespace Binance.Net.Clients.SpotApi
             var parameters = new Dictionary<string, object>();
             parameters.AddOptionalParameter("coin", asset);
             parameters.AddOptionalParameter("withdrawOrderId", withdrawOrderId);
-            parameters.AddOptionalParameter("status", status != null ? JsonConvert.SerializeObject(status, new WithdrawalStatusConverter(false)) : null);
+            parameters.AddOptionalParameter("status", status != null ? JsonConvert.SerializeObject(status, StaticConverters.StaticWithdrawalStatusConverter) : null);
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
@@ -221,7 +221,7 @@ namespace Binance.Net.Clients.SpotApi
             parameters.AddOptionalParameter("coin", asset);
             parameters.AddOptionalParameter("offset", offset?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("status", status != null ? JsonConvert.SerializeObject(status, new DepositStatusConverter(false)) : null);
+            parameters.AddOptionalParameter("status", status != null ? JsonConvert.SerializeObject(status, StaticConverters.StaticDepositStatusConverter) : null);
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
@@ -475,7 +475,7 @@ namespace Binance.Net.Clients.SpotApi
         {
             var parameters = new Dictionary<string, object>
             {
-                { "type", JsonConvert.SerializeObject(type, new UniversalTransferTypeConverter(false)) },
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticUniversalTransferTypeConverter) },
                 { "asset", asset },
                 { "amount", quantity.ToString(CultureInfo.InvariantCulture) }
             };
@@ -494,7 +494,7 @@ namespace Binance.Net.Clients.SpotApi
         {
             var parameters = new Dictionary<string, object>
             {
-                { "type", JsonConvert.SerializeObject(type, new UniversalTransferTypeConverter(false)) }
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticUniversalTransferTypeConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
@@ -578,7 +578,7 @@ namespace Binance.Net.Clients.SpotApi
             {
                 { "asset", asset },
                 { "amount", quantity.ToString(CultureInfo.InvariantCulture) },
-                { "type", JsonConvert.SerializeObject(type, new TransferDirectionTypeConverter(false)) }
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticTransferDirectionTypeConverter) }
             };
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
@@ -653,7 +653,7 @@ namespace Binance.Net.Clients.SpotApi
 
             var parameters = new Dictionary<string, object>
             {
-                { "direction", JsonConvert.SerializeObject(direction, new TransferDirectionConverter(false)) }
+                { "direction", JsonConvert.SerializeObject(direction, StaticConverters.StaticTransferDirectionConverter) }
             };
             parameters.AddOptionalParameter("size", limit?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("current", page?.ToString(CultureInfo.InvariantCulture));
@@ -907,11 +907,11 @@ namespace Binance.Net.Clients.SpotApi
             parameters.AddOptionalParameter("from",
                 !from.HasValue
                     ? null
-                    : JsonConvert.SerializeObject(from, new IsolatedMarginTransferDirectionConverter(false)));
+                    : JsonConvert.SerializeObject(from, StaticConverters.StaticIsolatedMarginTransferDirectionConverter));
             parameters.AddOptionalParameter("to",
                 !to.HasValue
                     ? null
-                    : JsonConvert.SerializeObject(to, new IsolatedMarginTransferDirectionConverter(false)));
+                    : JsonConvert.SerializeObject(to, StaticConverters.StaticIsolatedMarginTransferDirectionConverter));
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("current", current?.ToString(CultureInfo.InvariantCulture));
@@ -1026,8 +1026,8 @@ namespace Binance.Net.Clients.SpotApi
             {
                 {"asset", asset},
                 {"symbol", symbol},
-                {"transFrom", JsonConvert.SerializeObject(from, new IsolatedMarginTransferDirectionConverter(false))},
-                {"transTo", JsonConvert.SerializeObject(to, new IsolatedMarginTransferDirectionConverter(false))},
+                {"transFrom", JsonConvert.SerializeObject(from, StaticConverters.StaticIsolatedMarginTransferDirectionConverter)},
+                {"transTo", JsonConvert.SerializeObject(to, StaticConverters.StaticIsolatedMarginTransferDirectionConverter)},
                 {"amount", quantity.ToString(CultureInfo.InvariantCulture)}
             };
             parameters.AddOptionalParameter("recvWindow",

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiExchangeData.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiExchangeData.cs
@@ -301,7 +301,7 @@ namespace Binance.Net.Clients.SpotApi
             limit?.ValidateIntBetween(nameof(limit), 1, 1500);
             var parameters = new Dictionary<string, object> {
                 { "symbol", symbol },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
@@ -322,7 +322,7 @@ namespace Binance.Net.Clients.SpotApi
             limit?.ValidateIntBetween(nameof(limit), 1, 1500);
             var parameters = new Dictionary<string, object> {
                 { "symbol", symbol },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
@@ -625,7 +625,7 @@ namespace Binance.Net.Clients.SpotApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiTrading.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiTrading.cs
@@ -304,8 +304,8 @@ namespace Binance.Net.Clients.SpotApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
-                { "type", JsonConvert.SerializeObject(type, new SpotOrderTypeConverter(false)) },
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticSpotOrderTypeConverter) },
                 { "cancelReplaceMode", EnumConverter.GetString(cancelReplaceMode) }
             };
             parameters.AddOptionalParameter("cancelNewClientOrderId", newCancelClientOrderId);
@@ -317,10 +317,10 @@ namespace Binance.Net.Clients.SpotApi
             parameters.AddOptionalParameter("quantity", quantity?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("quoteOrderQty", quoteQuantity?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("price", price?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, new TimeInForceConverter(false)));
+            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, StaticConverters.StaticTimeInForceConverter));
             parameters.AddOptionalParameter("stopPrice", stopPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("icebergQty", icebergQty?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, new OrderResponseTypeConverter(false)));
+            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, StaticConverters.StaticOrderResponseTypeConverter));
             parameters.AddOptionalParameter("trailingDelta", trailingDelta);
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
@@ -448,7 +448,7 @@ namespace Binance.Net.Clients.SpotApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
                 { "quantity", quantity.ToString(CultureInfo.InvariantCulture) },
                 { "price", price.ToString(CultureInfo.InvariantCulture) },
                 { "stopPrice", stopPrice.ToString(CultureInfo.InvariantCulture) }
@@ -466,7 +466,7 @@ namespace Binance.Net.Clients.SpotApi
             parameters.AddOptionalParameter("stopClientOrderId", stopClientOrderId);
             parameters.AddOptionalParameter("limitIcebergQty", limitIcebergQuantity);
             parameters.AddOptionalParameter("stopIcebergQty", stopIcebergQuantity);
-            parameters.AddOptionalParameter("stopLimitTimeInForce", stopLimitTimeInForce == null ? null : JsonConvert.SerializeObject(stopLimitTimeInForce, new TimeInForceConverter(false)));
+            parameters.AddOptionalParameter("stopLimitTimeInForce", stopLimitTimeInForce == null ? null : JsonConvert.SerializeObject(stopLimitTimeInForce, StaticConverters.StaticTimeInForceConverter));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
             return await _baseClient.SendRequestInternal<BinanceOrderOcoList>(_baseClient.GetUrl(newOcoOrderEndpoint, api, signedVersion), HttpMethod.Post, ct, parameters, true).ConfigureAwait(false);
@@ -794,21 +794,21 @@ namespace Binance.Net.Clients.SpotApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
                 { "quantity", quantity.ToString(CultureInfo.InvariantCulture) },
                 { "price", price.ToString(CultureInfo.InvariantCulture) },
                 { "stopPrice", stopPrice.ToString(CultureInfo.InvariantCulture) }
             };
             parameters.AddOptionalParameter("stopLimitPrice", stopLimitPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("isIsolated", isIsolated?.ToString());
-            parameters.AddOptionalParameter("sideEffectType", sideEffectType == null ? null : JsonConvert.SerializeObject(sideEffectType, new SideEffectTypeConverter(false)));
+            parameters.AddOptionalParameter("sideEffectType", sideEffectType == null ? null : JsonConvert.SerializeObject(sideEffectType, StaticConverters.StaticSideEffectTypeConverter));
             parameters.AddOptionalParameter("listClientOrderId", listClientOrderId);
             parameters.AddOptionalParameter("limitClientOrderId", limitClientOrderId);
             parameters.AddOptionalParameter("stopClientOrderId", stopClientOrderId);
             parameters.AddOptionalParameter("limitIcebergQty", limitIcebergQuantity?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, new OrderResponseTypeConverter(false)));
+            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, StaticConverters.StaticOrderResponseTypeConverter));
             parameters.AddOptionalParameter("stopIcebergQty", stopIcebergQuantity?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("stopLimitTimeInForce", stopLimitTimeInForce == null ? null : JsonConvert.SerializeObject(stopLimitTimeInForce, new TimeInForceConverter(false)));
+            parameters.AddOptionalParameter("stopLimitTimeInForce", stopLimitTimeInForce == null ? null : JsonConvert.SerializeObject(stopLimitTimeInForce, StaticConverters.StaticTimeInForceConverter));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
             return await _baseClient.SendRequestInternal<BinanceMarginOrderOcoList>(_baseClient.GetUrl(newMarginOCOOrderEndpoint, marginApi, marginVersion), HttpMethod.Post, ct, parameters, true, weight: 6).ConfigureAwait(false);
@@ -1156,7 +1156,7 @@ namespace Binance.Net.Clients.SpotApi
         public async Task<WebCallResult<IEnumerable<BinanceC2CUserTrade>>> GetC2CTradeHistoryAsync(OrderSide side, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, long? receiveWindow = null, CancellationToken ct = default)
         {
             var parameters = new Dictionary<string, object>();
-            parameters.AddOptionalParameter("tradeType", JsonConvert.SerializeObject(side, new OrderSideConverter(false)));
+            parameters.AddOptionalParameter("tradeType", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter));
             parameters.AddOptionalParameter("startTimestamp", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTimestamp", DateTimeConverter.ConvertToMilliseconds(endTime));
             parameters.AddOptionalParameter("page", page);

--- a/Binance.Net/Clients/SpotApi/BinanceSocketClientSpotApiAccount.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceSocketClientSpotApiAccount.cs
@@ -9,7 +9,6 @@ using CryptoExchange.Net;
 using CryptoExchange.Net.Objects;
 using System.Collections.Generic;
 using Binance.Net.Objects.Models.Spot;
-using CryptoExchange.Net.Converters;
 using Binance.Net.Interfaces.Clients.SpotApi;
 using Binance.Net.Objects;
 

--- a/Binance.Net/Clients/SpotApi/BinanceSocketClientSpotApiExchangeData.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceSocketClientSpotApiExchangeData.cs
@@ -302,7 +302,7 @@ namespace Binance.Net.Clients.SpotApi
             symbols = symbols.SelectMany(a =>
                 intervals.Select(i =>
                     a.ToLower(CultureInfo.InvariantCulture) + "@kline" + "_" +
-                    JsonConvert.SerializeObject(i, new KlineIntervalConverter(false)))).ToArray();
+                    JsonConvert.SerializeObject(i, StaticConverters.StaticKlineIntervalConverter))).ToArray();
             return await _client.SubscribeAsync(_client.BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
 
@@ -511,7 +511,7 @@ namespace Binance.Net.Clients.SpotApi
             if (address == null)
                 throw new Exception("No url found for Blvt stream, check the `BlvtSocketAddress` in the client environment");
 
-            tokens = tokens.Select(a => a.ToUpper(CultureInfo.InvariantCulture) + "@nav_kline" + "_" + JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false))).ToArray();
+            tokens = tokens.Select(a => a.ToUpper(CultureInfo.InvariantCulture) + "@nav_kline" + "_" + JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter)).ToArray();
             var handler = new Action<DataEvent<BinanceCombinedStream<BinanceStreamKlineData>>>(data => onMessage(data.As(data.Data.Data, data.Data.Data.Symbol)));
             return await _client.SubscribeAsync(address.AppendPath("lvt-p"), tokens, handler, ct).ConfigureAwait(false);
         }

--- a/Binance.Net/Clients/SpotApi/BinanceSocketClientSpotApiTrading.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceSocketClientSpotApiTrading.cs
@@ -172,8 +172,8 @@ namespace Binance.Net.Clients.SpotApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
-                { "type", JsonConvert.SerializeObject(type, new SpotOrderTypeConverter(false)) },
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticSpotOrderTypeConverter) },
                 { "cancelReplaceMode", EnumConverter.GetString(cancelReplaceMode) }
             };
             parameters.AddOptionalParameter("cancelNewClientOrderId", newCancelClientOrderId);
@@ -185,10 +185,10 @@ namespace Binance.Net.Clients.SpotApi
             parameters.AddOptionalParameter("quantity", quantity?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("quoteOrderQty", quoteQuantity?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("price", price?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, new TimeInForceConverter(false)));
+            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, StaticConverters.StaticTimeInForceConverter));
             parameters.AddOptionalParameter("stopPrice", stopPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("icebergQty", icebergQty?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, new OrderResponseTypeConverter(false)));
+            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, StaticConverters.StaticOrderResponseTypeConverter));
             parameters.AddOptionalParameter("trailingDelta", trailingDelta?.ToString(CultureInfo.InvariantCulture));
 
             return await _client.QueryAsync<BinanceReplaceOrderResult>(_client.ClientOptions.Environment.SpotSocketApiAddress.AppendPath("ws-api/v3"), $"order.cancelReplace", parameters, true, true).ConfigureAwait(false);
@@ -249,7 +249,7 @@ namespace Binance.Net.Clients.SpotApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
                 { "quantity", quantity.ToString(CultureInfo.InvariantCulture) },
                 { "price", price.ToString(CultureInfo.InvariantCulture) },
                 { "stopPrice", stopPrice.ToString(CultureInfo.InvariantCulture) }
@@ -271,7 +271,7 @@ namespace Binance.Net.Clients.SpotApi
             parameters.AddOptionalParameter("stopIcebergQty", stopIcebergQty?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("stopIcebergQty", stopIcebergQuantity?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("stopClientOrderId", stopClientOrderId);
-            parameters.AddOptionalParameter("stopLimitTimeInForce", stopLimitTimeInForce == null ? null : JsonConvert.SerializeObject(stopLimitTimeInForce, new TimeInForceConverter(false)));
+            parameters.AddOptionalParameter("stopLimitTimeInForce", stopLimitTimeInForce == null ? null : JsonConvert.SerializeObject(stopLimitTimeInForce, StaticConverters.StaticTimeInForceConverter));
 
             return await _client.QueryAsync<BinanceOrderOcoList>(_client.ClientOptions.Environment.SpotSocketApiAddress.AppendPath("ws-api/v3"), $"orderList.place", parameters, true, true).ConfigureAwait(false);
         }

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiAccount.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiAccount.cs
@@ -108,7 +108,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "marginType", JsonConvert.SerializeObject(marginType, new FuturesMarginTypeConverter(false)) }
+                { "marginType", JsonConvert.SerializeObject(marginType, StaticConverters.StaticFuturesMarginTypeConverter) }
             };
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
@@ -126,9 +126,9 @@ namespace Binance.Net.Clients.UsdFuturesApi
             {
                 { "symbol", symbol },
                 { "amount", quantity.ToString(CultureInfo.InvariantCulture) },
-                { "type", JsonConvert.SerializeObject(type, new FuturesMarginChangeDirectionTypeConverter(false)) }
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticFuturesMarginChangeDirectionTypeConverter) }
             };
-            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, new PositionSideConverter(false)));
+            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, StaticConverters.StaticPositionSideConverter));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 
             return await _baseClient.SendRequestInternal<BinanceFuturesPositionMarginResult>(_baseClient.GetUrl(positionMarginEndpoint, api, signedVersion), HttpMethod.Post, ct, parameters, true).ConfigureAwait(false);
@@ -145,7 +145,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
             {
                 { "symbol", symbol }
             };
-            parameters.AddOptionalParameter("type", type.HasValue ? JsonConvert.SerializeObject(type, new FuturesMarginChangeDirectionTypeConverter(false)) : null);
+            parameters.AddOptionalParameter("type", type.HasValue ? JsonConvert.SerializeObject(type, StaticConverters.StaticFuturesMarginChangeDirectionTypeConverter) : null);
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiExchangeData.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiExchangeData.cs
@@ -171,7 +171,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
             var url = _baseClient.GetUrl(topLongShortAccountRatioEndpoint, tradingDataapi);
             var parameters = new Dictionary<string, object> {
                 { url.ToString().Contains("dapi") ? "pair": "symbol", symbolPair },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -193,7 +193,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
             var url = _baseClient.GetUrl(topLongShortPositionRatioEndpoint, tradingDataapi);
             var parameters = new Dictionary<string, object> {
                 { url.ToString().Contains("dapi") ? "pair": "symbol", symbolPair },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -215,7 +215,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
             var url = _baseClient.GetUrl(globalLongShortAccountRatioEndpoint, tradingDataapi);
             var parameters = new Dictionary<string, object> {
                 { url.ToString().Contains("dapi") ? "pair": "symbol", symbolPair },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -236,7 +236,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
 
             var parameters = new Dictionary<string, object> {
                 { "symbol", symbol },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -329,7 +329,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
             limit?.ValidateIntBetween(nameof(limit), 1, 1500);
             var parameters = new Dictionary<string, object> {
                 { "symbol", symbol },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
@@ -388,7 +388,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
 
             var parameters = new Dictionary<string, object> {
                 { "symbol", symbol },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -409,7 +409,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
 
             var parameters = new Dictionary<string, object> {
                 { "symbol", symbol },
-                { "period", JsonConvert.SerializeObject(period, new PeriodIntervalConverter(false)) }
+                { "period", JsonConvert.SerializeObject(period, StaticConverters.StaticPeriodIntervalConverter) }
             };
 
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
@@ -461,8 +461,8 @@ namespace Binance.Net.Clients.UsdFuturesApi
             limit?.ValidateIntBetween(nameof(limit), 1, 1500);
             var parameters = new Dictionary<string, object> {
                 { "pair", pair },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) },
-                { "contractType", JsonConvert.SerializeObject(contractType, new ContractTypeConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter) },
+                { "contractType", JsonConvert.SerializeObject(contractType, StaticConverters.StaticContractTypeConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
@@ -483,7 +483,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
             limit?.ValidateIntBetween(nameof(limit), 1, 1500);
             var parameters = new Dictionary<string, object> {
                 { "pair", pair },
-                { "interval", JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false)) }
+                { "interval", JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter) }
             };
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiTrading.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiTrading.cs
@@ -105,21 +105,21 @@ namespace Binance.Net.Clients.UsdFuturesApi
             var parameters = new Dictionary<string, object>
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
-                { "type", JsonConvert.SerializeObject(type, new FuturesOrderTypeConverter(false)) }
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
+                { "type", JsonConvert.SerializeObject(type, StaticConverters.StaticFuturesOrderTypeConverter) }
             };
             parameters.AddOptionalParameter("quantity", quantity?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("newClientOrderId", newClientOrderId);
             parameters.AddOptionalParameter("price", price?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, new TimeInForceConverter(false)));
-            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, new PositionSideConverter(false)));
+            parameters.AddOptionalParameter("timeInForce", timeInForce == null ? null : JsonConvert.SerializeObject(timeInForce, StaticConverters.StaticTimeInForceConverter));
+            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, StaticConverters.StaticPositionSideConverter));
             parameters.AddOptionalParameter("stopPrice", stopPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("activationPrice", activationPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("callbackRate", callbackRate?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("workingType", workingType == null ? null : JsonConvert.SerializeObject(workingType, new WorkingTypeConverter(false)));
+            parameters.AddOptionalParameter("workingType", workingType == null ? null : JsonConvert.SerializeObject(workingType, StaticConverters.StaticWorkingTypeConverter));
             parameters.AddOptionalParameter("reduceOnly", reduceOnly?.ToString().ToLower());
             parameters.AddOptionalParameter("closePosition", closePosition?.ToString().ToLower());
-            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, new OrderResponseTypeConverter(false)));
+            parameters.AddOptionalParameter("newOrderRespType", orderResponseType == null ? null : JsonConvert.SerializeObject(orderResponseType, StaticConverters.StaticOrderResponseTypeConverter));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("priceProtect", priceProtect?.ToString().ToUpper());
 
@@ -172,20 +172,20 @@ namespace Binance.Net.Clients.UsdFuturesApi
                 var orderParameters = new Dictionary<string, object>()
                 {
                     { "symbol", order.Symbol },
-                    { "side", JsonConvert.SerializeObject(order.Side, new OrderSideConverter(false)) },
-                    { "type", JsonConvert.SerializeObject(order.Type, new FuturesOrderTypeConverter(false)) },
+                    { "side", JsonConvert.SerializeObject(order.Side, StaticConverters.StaticOrderSideConverter) },
+                    { "type", JsonConvert.SerializeObject(order.Type, StaticConverters.StaticFuturesOrderTypeConverter) },
                     { "newOrderRespType", "RESULT" }
                 };
 
                 orderParameters.AddOptionalParameter("quantity", order.Quantity?.ToString(CultureInfo.InvariantCulture));
                 orderParameters.AddOptionalParameter("newClientOrderId", order.NewClientOrderId);
                 orderParameters.AddOptionalParameter("price", order.Price?.ToString(CultureInfo.InvariantCulture));
-                orderParameters.AddOptionalParameter("timeInForce", order.TimeInForce == null ? null : JsonConvert.SerializeObject(order.TimeInForce, new TimeInForceConverter(false)));
-                orderParameters.AddOptionalParameter("positionSide", order.PositionSide == null ? null : JsonConvert.SerializeObject(order.PositionSide, new PositionSideConverter(false)));
+                orderParameters.AddOptionalParameter("timeInForce", order.TimeInForce == null ? null : JsonConvert.SerializeObject(order.TimeInForce, StaticConverters.StaticTimeInForceConverter));
+                orderParameters.AddOptionalParameter("positionSide", order.PositionSide == null ? null : JsonConvert.SerializeObject(order.PositionSide, StaticConverters.StaticPositionSideConverter));
                 orderParameters.AddOptionalParameter("stopPrice", order.StopPrice?.ToString(CultureInfo.InvariantCulture));
                 orderParameters.AddOptionalParameter("activationPrice", order.ActivationPrice?.ToString(CultureInfo.InvariantCulture));
                 orderParameters.AddOptionalParameter("callbackRate", order.CallbackRate?.ToString(CultureInfo.InvariantCulture));
-                orderParameters.AddOptionalParameter("workingType", order.WorkingType == null ? null : JsonConvert.SerializeObject(order.WorkingType, new WorkingTypeConverter(false)));
+                orderParameters.AddOptionalParameter("workingType", order.WorkingType == null ? null : JsonConvert.SerializeObject(order.WorkingType, StaticConverters.StaticWorkingTypeConverter));
                 orderParameters.AddOptionalParameter("reduceOnly", order.ReduceOnly?.ToString().ToLower());
                 orderParameters.AddOptionalParameter("priceProtect", order.PriceProtect?.ToString().ToUpper());
                 parameterOrders[i] = orderParameters;
@@ -458,11 +458,11 @@ namespace Binance.Net.Clients.UsdFuturesApi
             var parameters = new Dictionary<string, object>()
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
                 { "quantity", quantity.ToString(CultureInfo.InvariantCulture) },
                 { "urgency", EnumConverter.GetString(urgency) },
             };
-            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, new PositionSideConverter(false)));
+            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, StaticConverters.StaticPositionSideConverter));
             parameters.AddOptionalParameter("clientAlgoId", clientOrderId);
             parameters.AddOptionalParameter("reduceOnly", reduceOnly);
             parameters.AddOptionalParameter("limitPrice", limitPrice);
@@ -490,11 +490,11 @@ namespace Binance.Net.Clients.UsdFuturesApi
             var parameters = new Dictionary<string, object>()
             {
                 { "symbol", symbol },
-                { "side", JsonConvert.SerializeObject(side, new OrderSideConverter(false)) },
+                { "side", JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter) },
                 { "quantity", quantity.ToString(CultureInfo.InvariantCulture) },
                 { "duration", duration },
             };
-            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, new PositionSideConverter(false)));
+            parameters.AddOptionalParameter("positionSide", positionSide == null ? null : JsonConvert.SerializeObject(positionSide, StaticConverters.StaticPositionSideConverter));
             parameters.AddOptionalParameter("clientAlgoId", clientOrderId);
             parameters.AddOptionalParameter("reduceOnly", reduceOnly);
             parameters.AddOptionalParameter("limitPrice", limitPrice);
@@ -538,7 +538,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
         {
             var parameters = new Dictionary<string, object>();
             parameters.AddOptionalParameter("symbol", symbol);
-            parameters.AddOptionalParameter("side", side == null? null: JsonConvert.SerializeObject(side, new OrderSideConverter(false)));
+            parameters.AddOptionalParameter("side", side == null? null: JsonConvert.SerializeObject(side, StaticConverters.StaticOrderSideConverter));
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
             parameters.AddOptionalParameter("page", page);

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceSocketClientUsdFuturesApi.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceSocketClientUsdFuturesApi.cs
@@ -127,7 +127,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
         {
             symbols.ValidateNotNull(nameof(symbols));
             var handler = new Action<DataEvent<BinanceCombinedStream<BinanceStreamKlineData>>>(data => onMessage(data.As<IBinanceStreamKlineData>(data.Data.Data, data.Data.Data.Symbol)));
-            symbols = symbols.SelectMany(a => intervals.Select(i => a.ToLower(CultureInfo.InvariantCulture) + klineStreamEndpoint + "_" + JsonConvert.SerializeObject(i, new KlineIntervalConverter(false)))).ToArray();
+            symbols = symbols.SelectMany(a => intervals.Select(i => a.ToLower(CultureInfo.InvariantCulture) + klineStreamEndpoint + "_" + JsonConvert.SerializeObject(i, StaticConverters.StaticKlineIntervalConverter))).ToArray();
             return await SubscribeAsync(BaseAddress, symbols, handler, ct).ConfigureAwait(false);
         }
 
@@ -145,10 +145,10 @@ namespace Binance.Net.Clients.UsdFuturesApi
             var handler = new Action<DataEvent<BinanceCombinedStream<BinanceStreamContinuousKlineData>>>(data => onMessage(data.As(data.Data.Data, data.Data.Data.Symbol)));
             pairs = pairs.Select(a => a.ToLower(CultureInfo.InvariantCulture) +
                                       "_" +
-                                      JsonConvert.SerializeObject(contractType, new ContractTypeConverter(false)).ToLower() +
+                                      JsonConvert.SerializeObject(contractType, StaticConverters.StaticContractTypeConverter).ToLower() +
                                       continuousContractKlineStreamEndpoint +
                                       "_" +
-                                      JsonConvert.SerializeObject(interval, new KlineIntervalConverter(false))).ToArray();
+                                      JsonConvert.SerializeObject(interval, StaticConverters.StaticKlineIntervalConverter)).ToArray();
             return await SubscribeAsync(BaseAddress, pairs, handler, ct).ConfigureAwait(false);
         }
 

--- a/Binance.Net/Converters/StaticConverters.cs
+++ b/Binance.Net/Converters/StaticConverters.cs
@@ -1,0 +1,45 @@
+﻿namespace Binance.Net.Converters
+{
+    internal class StaticConverters
+    {
+        internal readonly static OrderSideConverter StaticOrderSideConverter = new OrderSideConverter(false);
+
+        internal readonly static TimeInForceConverter StaticTimeInForceConverter = new TimeInForceConverter(false);
+
+        internal readonly static SideEffectTypeConverter StaticSideEffectTypeConverter = new SideEffectTypeConverter(false);
+
+        internal readonly static PositionSideConverter StaticPositionSideConverter = new PositionSideConverter(false);
+        
+        internal readonly static WorkingTypeConverter StaticWorkingTypeConverter = new WorkingTypeConverter(false);
+
+        internal readonly static OrderResponseTypeConverter StaticOrderResponseTypeConverter = new OrderResponseTypeConverter(false);
+        
+        internal readonly static FuturesOrderTypeConverter StaticFuturesOrderTypeConverter = new FuturesOrderTypeConverter(false);
+
+        internal readonly static WalletTypeConverter StaticWalletTypeConverter = new WalletTypeConverter(false);
+
+        internal readonly static WithdrawalStatusConverter StaticWithdrawalStatusConverter = new WithdrawalStatusConverter(false);
+
+        internal readonly static DepositStatusConverter StaticDepositStatusConverter = new DepositStatusConverter(false);
+
+        internal readonly static UniversalTransferTypeConverter StaticUniversalTransferTypeConverter = new UniversalTransferTypeConverter(false);
+
+        internal readonly static TransferDirectionTypeConverter StaticTransferDirectionTypeConverter = new TransferDirectionTypeConverter(false);
+
+        internal readonly static TransferDirectionConverter StaticTransferDirectionConverter = new TransferDirectionConverter(false);
+
+        internal readonly static IsolatedMarginTransferDirectionConverter StaticIsolatedMarginTransferDirectionConverter = new IsolatedMarginTransferDirectionConverter(false);
+
+        internal readonly static KlineIntervalConverter StaticKlineIntervalConverter = new KlineIntervalConverter(false);
+
+        internal readonly static ContractTypeConverter StaticContractTypeConverter = new ContractTypeConverter(false);
+
+        internal readonly static SpotOrderTypeConverter StaticSpotOrderTypeConverter = new SpotOrderTypeConverter(false);
+
+        internal readonly static FuturesMarginTypeConverter StaticFuturesMarginTypeConverter = new FuturesMarginTypeConverter(false);
+
+        internal readonly static FuturesMarginChangeDirectionTypeConverter StaticFuturesMarginChangeDirectionTypeConverter = new FuturesMarginChangeDirectionTypeConverter(false);
+
+        internal readonly static PeriodIntervalConverter StaticPeriodIntervalConverter = new PeriodIntervalConverter(false);
+    }
+}


### PR DESCRIPTION
The other pull request ran the standard cleanup, you could use this one instead

Closes https://github.com/JKorf/Binance.Net/issues/1275

```cs
new TimeInForceConverter(false)
```

There are lots of requests that are calling `new` when they don't need to, which slows down the request.

https://github.com/JKorf/Binance.Net/blob/e3c98cbc7d03b663a5a3bd43b19ae16cc00291f1/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApi.cs#L134

This is one example from `PlaceOrderInternal` but this is true for anywhere you see the converters **outside of an attribute** like below

```cs
new OrderSideConverter(false);
new SpotOrderTypeConverter(false);
new TimeInForceConverter(false);
new SideEffectTypeConverter(false);
new OrderResponseTypeConverter(false);
etc....
```

I solved this by creating a [static version of all these converters](https://github.com/NoParamedic/BinanceAPI.NET/blob/master/Binance-API/Binance-API/Converters/StaticConverters.cs)

I could do something similar and open a pull request if you want, let me know.