### PR TITLE
Change orderId  type

### DIFF
--- a/Binance.Net/Binance.Net.xml
+++ b/Binance.Net/Binance.Net.xml
@@ -1808,7 +1808,7 @@
         <member name="M:Binance.Net.Clients.SpotApi.BinanceSocketClientSpotApiTrading.GetOrderAsync(System.String,System.Nullable{System.Int32},System.String)">
             <inheritdoc />
         </member>
-        <member name="M:Binance.Net.Clients.SpotApi.BinanceSocketClientSpotApiTrading.CancelOrderAsync(System.String,System.Nullable{System.Int32},System.String,System.String)">
+        <member name="M:Binance.Net.Clients.SpotApi.BinanceSocketClientSpotApiTrading.CancelOrderAsync(System.String,System.Nullable{System.Int64},System.String,System.String)">
             <inheritdoc />
         </member>
         <member name="M:Binance.Net.Clients.SpotApi.BinanceSocketClientSpotApiTrading.ReplaceOrderAsync(System.String,Binance.Net.Enums.OrderSide,Binance.Net.Enums.SpotOrderType,Binance.Net.Enums.CancelReplaceMode,System.Nullable{System.Int64},System.String,System.String,System.String,System.Nullable{System.Decimal},System.Nullable{System.Decimal},System.Nullable{System.Decimal},System.Nullable{Binance.Net.Enums.TimeInForce},System.Nullable{System.Decimal},System.Nullable{System.Decimal},System.Nullable{Binance.Net.Enums.OrderResponseType},System.Nullable{System.Int32},System.Nullable{System.Int32},System.Nullable{System.Int32})">
@@ -10221,7 +10221,7 @@
             <param name="symbol">Filter by symbols</param>
             <returns></returns>
         </member>
-        <member name="M:Binance.Net.Interfaces.Clients.SpotApi.IBinanceSocketClientSpotApiTrading.GetOrderAsync(System.String,System.Nullable{System.Int32},System.String)">
+        <member name="M:Binance.Net.Interfaces.Clients.SpotApi.IBinanceSocketClientSpotApiTrading.GetOrderAsync(System.String,System.Nullable{System.Int64},System.String)">
             <summary>
             Get order by either orderId or clientOrderId
             <para><a href="https://binance-docs.github.io/apidocs/websocket_api/en/#query-order-user_data" /></para>

--- a/Binance.Net/Clients/SpotApi/BinanceSocketClientSpotApiTrading.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceSocketClientSpotApiTrading.cs
@@ -123,7 +123,7 @@ namespace Binance.Net.Clients.SpotApi
         #region Get Order
 
         /// <inheritdoc />
-        public async Task<CallResult<BinanceResponse<BinanceOrder>>> GetOrderAsync(string symbol, int? orderId = null, string? clientOrderId = null)
+        public async Task<CallResult<BinanceResponse<BinanceOrder>>> GetOrderAsync(string symbol, long? orderId = null, string? clientOrderId = null)
         {
             var parameters = new Dictionary<string, object>();
             parameters.AddParameter("symbol", symbol);
@@ -137,7 +137,7 @@ namespace Binance.Net.Clients.SpotApi
         #region Cancel Order
 
         /// <inheritdoc />
-        public async Task<CallResult<BinanceResponse<BinanceOrder>>> CancelOrderAsync(string symbol, int? orderId = null, string? clientOrderId = null, string? newClientOrderId = null)
+        public async Task<CallResult<BinanceResponse<BinanceOrder>>> CancelOrderAsync(string symbol, long? orderId = null, string? clientOrderId = null, string? newClientOrderId = null)
         {
             var parameters = new Dictionary<string, object>();
             parameters.AddParameter("symbol", symbol);

--- a/Binance.Net/Interfaces/Clients/SpotApi/IBinanceSocketClientSpotApiTrading.cs
+++ b/Binance.Net/Interfaces/Clients/SpotApi/IBinanceSocketClientSpotApiTrading.cs
@@ -39,7 +39,7 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         /// <param name="clientOrderId">Client order id</param>
         /// <param name="newClientOrderId">New client order id for the order</param>
         /// <returns></returns>
-        Task<CallResult<BinanceResponse<BinanceOrder>>> CancelOrderAsync(string symbol, int? orderId = null, string? clientOrderId = null, string? newClientOrderId = null);
+        Task<CallResult<BinanceResponse<BinanceOrder>>> CancelOrderAsync(string symbol, long? orderId = null, string? clientOrderId = null, string? newClientOrderId = null);
         /// <summary>
         /// Get an oco order by either orderId or clientOrderId
         /// <para><a href="https://binance-docs.github.io/apidocs/websocket_api/en/#account-oco-history-user_data" /></para>
@@ -79,7 +79,7 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         /// <param name="orderId">Order id</param>
         /// <param name="clientOrderId">Client order id</param>
         /// <returns></returns>
-        Task<CallResult<BinanceResponse<BinanceOrder>>> GetOrderAsync(string symbol, int? orderId = null, string? clientOrderId = null);
+        Task<CallResult<BinanceResponse<BinanceOrder>>> GetOrderAsync(string symbol, long? orderId = null, string? clientOrderId = null);
         /// <summary>
         /// Get order history
         /// <para><a href="https://binance-docs.github.io/apidocs/websocket_api/en/#account-order-history-user_data" /></para>


### PR DESCRIPTION
Change type of orderId parameter in GetOrderAsync and CancelOrderAsync
Your code has incorrect type of orderId parameter in GetOrderAsync and CancelOrderAsync in IBinanceSocketClientSpotApiTrading.  
int? is specified instead of long.
To see the problem you can place an order or get the real clientId from an existing order. For example, the real identifier (2712825989) cannot be converted to Int32