### PR TITLE
Fix - List All Convert Pairs

### DIFF
--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiExchangeData.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiExchangeData.cs
@@ -726,9 +726,6 @@ namespace Binance.Net.Clients.SpotApi
         /// <inheritdoc />
         public async Task<WebCallResult<IEnumerable<BinanceConvertAssetPair>>> GetConvertListAllPairsAsync(string? quoteAsset = null, string? baseAsset = null, CancellationToken ct = default)
         {
-            if (quoteAsset == null && baseAsset == null)
-                throw new ArgumentException("Either one or both of the assets must be sent");
-
             var parameters = new Dictionary<string, object>();
             parameters.AddOptionalParameter("fromAsset", quoteAsset);
             parameters.AddOptionalParameter("toAsset", baseAsset);


### PR DESCRIPTION
The check has been removed because if values for both fromAsset and toAsset are not defined, only partial token pairs will be returned.

Info - https://binance-docs.github.io/apidocs/spot/en/#list-all-convert-pairs