### PR TITLE
fx BinanceFuturesFundingRateHistory.MarkPrice

### DIFF
--- a/Binance.Net/Objects/Models/Futures/BinanceFuturesFundingRateHistory.cs
+++ b/Binance.Net/Objects/Models/Futures/BinanceFuturesFundingRateHistory.cs
@@ -26,6 +26,6 @@ namespace Binance.Net.Objects.Models.Futures
         /// The mark price
         /// </summary>
         [JsonProperty("markPrice")]
-        public decimal MarkPrice { get; set; }
+        public decimal? MarkPrice { get; set; }
     }
 }


### PR DESCRIPTION
Fixed BinanceFuturesFundingRateHistory.MarkPrice

Changed type to 'decimal?'
Oldest items have null MarkPrice.

Example:
https://fapi.binance.com/fapi/v1/fundingRate?symbol=BTCUSDT&limit=1000
{"symbol":"BTCUSDT","fundingTime":1678060800007,"fundingRate":"0.00004054","markPrice":""}

Doc:
https://binance-docs.github.io/apidocs/futures/en/#get-funding-rate-history