### PR TITLE
Refs #1386: Correct goodTillDate timestamp format to milliseconds

### DIFF
--- a/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiTrading.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiTrading.cs
@@ -95,7 +95,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
             parameters.AddOptionalParameter("priceProtect", priceProtect?.ToString().ToUpper());
             parameters.AddOptionalEnum("priceMatch", priceMatch);
             parameters.AddOptionalEnum("selfTradePreventionMode", selfTradePreventionMode);
-            parameters.AddOptionalSeconds("goodTillDate", goodTillDate);
+            parameters.AddOptionalMilliseconds("goodTillDate", goodTillDate);
 
             var request = _definitions.GetOrCreate(HttpMethod.Post, "fapi/v1/order", BinanceExchange.RateLimiter.FuturesRest, 0, true);
             var result = await _baseClient.SendAsync<BinanceUsdFuturesOrder>(request, parameters, ct).ConfigureAwait(false);


### PR DESCRIPTION
This pull request fixes the issue where the `goodTillDate` timestamp for USD Futures limit orders was incorrectly sent in seconds, causing the order to fail. The timestamp is now correctly formatted in milliseconds.

**Related Issue:**
- Fixes #1386 

**Changes:**
- Changed `AddOptionalSeconds` to `AddOptionalMilliseconds` in the `BinanceRestClientUsdFuturesApiTrading`.

Thank you for considering this pull request!