### PR TITLE
Add PriceMatch parameter to order editing

### DIFF
--- a/Binance.Net.UnitTests/RestRequestTests.cs
+++ b/Binance.Net.UnitTests/RestRequestTests.cs
@@ -283,7 +283,7 @@ namespace Binance.Net.UnitTests
             await tester.ValidateAsync(client => client.UsdFuturesApi.Trading.GetOrderEditHistoryAsync("ETHUSDT", 123), "GetOrderEditHistory");
             await tester.ValidateAsync(client => client.UsdFuturesApi.Trading.CancelOrderAsync("ETHUSDT", 123), "CancelOrder");
             await tester.ValidateAsync(client => client.UsdFuturesApi.Trading.CancelAllOrdersAsync("ETHUSDT"), "CancelAllOrders");
-            await tester.ValidateAsync(client => client.UsdFuturesApi.Trading.EditOrderAsync("ETHUSDT", Enums.OrderSide.Buy, 1, 1, 123), "EditOrder");
+            await tester.ValidateAsync(client => client.UsdFuturesApi.Trading.EditOrderAsync("ETHUSDT", Enums.OrderSide.Buy, 1, 1, Enums.PriceMatch.None, 123), "EditOrder");
             await tester.ValidateAsync(client => client.UsdFuturesApi.Trading.EditMultipleOrdersAsync(new[] { new BinanceFuturesBatchEditOrder() }), "EditMultipleOrders", skipResponseValidation: true);
             await tester.ValidateAsync(client => client.UsdFuturesApi.Trading.CancelAllOrdersAfterTimeoutAsync("ETHUSDT", TimeSpan.Zero), "CancelAllOrdersAfterTimeout");
             await tester.ValidateAsync(client => client.UsdFuturesApi.Trading.CancelMultipleOrdersAsync("ETHUSDT", new List<long> { 123 }), "CancelMultipleOrders", skipResponseValidation: true);

--- a/Binance.Net/Binance.Net.xml
+++ b/Binance.Net/Binance.Net.xml
@@ -2214,7 +2214,7 @@
         <member name="M:Binance.Net.Clients.UsdFuturesApi.BinanceRestClientUsdFuturesApiTrading.CancelAllOrdersAsync(System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
-        <member name="M:Binance.Net.Clients.UsdFuturesApi.BinanceRestClientUsdFuturesApiTrading.EditOrderAsync(System.String,Binance.Net.Enums.OrderSide,System.Decimal,System.Decimal,System.Nullable{System.Int64},System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
+        <member name="M:Binance.Net.Clients.UsdFuturesApi.BinanceRestClientUsdFuturesApiTrading.EditOrderAsync(System.String,Binance.Net.Enums.OrderSide,System.Decimal,System.Nullable{System.Decimal},System.Nullable{Binance.Net.Enums.PriceMatch},System.Nullable{System.Int64},System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="M:Binance.Net.Clients.UsdFuturesApi.BinanceRestClientUsdFuturesApiTrading.EditMultipleOrdersAsync(System.Collections.Generic.IEnumerable{Binance.Net.Objects.Models.Futures.BinanceFuturesBatchEditOrder},System.Nullable{System.Int32},System.Threading.CancellationToken)">
@@ -2434,7 +2434,7 @@
         <member name="M:Binance.Net.Clients.UsdFuturesApi.BinanceSocketClientUsdFuturesApiTrading.PlaceOrderAsync(System.String,Binance.Net.Enums.OrderSide,Binance.Net.Enums.FuturesOrderType,System.Nullable{System.Decimal},System.Nullable{System.Decimal},System.Nullable{Binance.Net.Enums.PositionSide},System.Nullable{Binance.Net.Enums.TimeInForce},System.Nullable{System.Boolean},System.String,System.Nullable{System.Decimal},System.Nullable{System.Decimal},System.Nullable{System.Decimal},System.Nullable{Binance.Net.Enums.WorkingType},System.Nullable{System.Boolean},System.Nullable{Binance.Net.Enums.OrderResponseType},System.Nullable{System.Boolean},System.Nullable{Binance.Net.Enums.PriceMatch},System.Nullable{Binance.Net.Enums.SelfTradePreventionMode},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
-        <member name="M:Binance.Net.Clients.UsdFuturesApi.BinanceSocketClientUsdFuturesApiTrading.EditOrderAsync(System.String,Binance.Net.Enums.OrderSide,System.Decimal,System.Decimal,System.Nullable{System.Int64},System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
+        <member name="M:Binance.Net.Clients.UsdFuturesApi.BinanceSocketClientUsdFuturesApiTrading.EditOrderAsync(System.String,Binance.Net.Enums.OrderSide,System.Decimal,System.Nullable{System.Decimal},System.Nullable{Binance.Net.Enums.PriceMatch},System.Nullable{System.Int64},System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="M:Binance.Net.Clients.UsdFuturesApi.BinanceSocketClientUsdFuturesApiTrading.CancelOrderAsync(System.String,System.Nullable{System.Int64},System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
@@ -12288,7 +12288,7 @@
             <param name="ct">Cancellation token</param>
             <returns>Id's for canceled order</returns>
         </member>
-        <member name="M:Binance.Net.Interfaces.Clients.UsdFuturesApi.IBinanceRestClientUsdFuturesApiTrading.EditOrderAsync(System.String,Binance.Net.Enums.OrderSide,System.Decimal,System.Decimal,System.Nullable{System.Int64},System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
+        <member name="M:Binance.Net.Interfaces.Clients.UsdFuturesApi.IBinanceRestClientUsdFuturesApiTrading.EditOrderAsync(System.String,Binance.Net.Enums.OrderSide,System.Decimal,System.Nullable{System.Decimal},System.Nullable{Binance.Net.Enums.PriceMatch},System.Nullable{System.Int64},System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
             <summary>
             Edit an existing order
             <para><a href="https://binance-docs.github.io/apidocs/futures/en/#modify-order-trade" /></para>
@@ -12297,6 +12297,7 @@
             <param name="side">Order side</param>
             <param name="quantity">New quantity</param>
             <param name="price">New price</param>
+            <param name="priceMatch">Only avaliable for Limit/Stop/TakeProfit order</param>
             <param name="orderId">Order id of the order to edit</param>
             <param name="origClientOrderId">Client order id of the order to edit</param>
             <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
@@ -12999,7 +13000,7 @@
             <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
             <param name="ct">Cancellation token</param>
         </member>
-        <member name="M:Binance.Net.Interfaces.Clients.UsdFuturesApi.IBinanceSocketClientUsdFuturesApiTrading.EditOrderAsync(System.String,Binance.Net.Enums.OrderSide,System.Decimal,System.Decimal,System.Nullable{System.Int64},System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
+        <member name="M:Binance.Net.Interfaces.Clients.UsdFuturesApi.IBinanceSocketClientUsdFuturesApiTrading.EditOrderAsync(System.String,Binance.Net.Enums.OrderSide,System.Decimal,System.Nullable{System.Decimal},System.Nullable{Binance.Net.Enums.PriceMatch},System.Nullable{System.Int64},System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
             <summary>
             Edit an existing order
             <para><a href="https://developers.binance.com/docs/derivatives/usds-margined-futures/trade/websocket-api/Modify-Order" /></para>
@@ -13008,6 +13009,7 @@
             <param name="side">Order side</param>
             <param name="quantity">New quantity</param>
             <param name="price">New price</param>
+            <param name="priceMatch">Only avaliable for Limit/Stop/TakeProfit order</param>
             <param name="orderId">Order id of the order to edit</param>
             <param name="origClientOrderId">Client order id of the order to edit</param>
             <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
@@ -26213,6 +26215,11 @@
         <member name="P:Binance.Net.Objects.Models.Futures.BinanceFuturesBatchEditOrder.Price">
             <summary>
             Price
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Futures.BinanceFuturesBatchEditOrder.PriceMatch">
+            <summary>
+            PriceMatch
             </summary>
         </member>
         <member name="T:Binance.Net.Objects.Models.Futures.BinanceFuturesBatchOrder">

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiTrading.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiTrading.cs
@@ -295,7 +295,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
         #region Edit Order
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BinanceUsdFuturesOrder>> EditOrderAsync(string symbol, OrderSide side, decimal quantity, decimal price, long? orderId = null, string? origClientOrderId = null, long? receiveWindow = null, CancellationToken ct = default)
+        public async Task<WebCallResult<BinanceUsdFuturesOrder>> EditOrderAsync(string symbol, OrderSide side, decimal quantity, decimal? price = null, PriceMatch? priceMatch = null, long? orderId = null, string? origClientOrderId = null, long? receiveWindow = null, CancellationToken ct = default)
         {
             if (!orderId.HasValue && string.IsNullOrEmpty(origClientOrderId))
                 throw new ArgumentException("Either orderId or origClientOrderId must be sent");
@@ -308,8 +308,9 @@ namespace Binance.Net.Clients.UsdFuturesApi
                 { "symbol", symbol },
                 { "side", EnumConverter.GetString(side) },
                 { "quantity", quantity.ToString(CultureInfo.InvariantCulture) },
-                { "price", price.ToString(CultureInfo.InvariantCulture) },
             };
+            parameters.AddOptionalParameter("price", price?.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptionalEnum("priceMatch", priceMatch);
             parameters.AddOptionalParameter("orderId", orderId?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("origClientOrderId", origClientOrderId);
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
@@ -341,8 +342,9 @@ namespace Binance.Net.Clients.UsdFuturesApi
                 {
                     { "symbol", order.Symbol },
                     { "quantity", order.Quantity.ToString(CultureInfo.InvariantCulture) },
-                    { "price", order.Price.ToString(CultureInfo.InvariantCulture) },
                 };
+                orderParameters.AddOptionalParameter("price", order.Price?.ToString(CultureInfo.InvariantCulture));
+                orderParameters.AddOptionalEnum("priceMatch", order.PriceMatch);
                 orderParameters.AddEnum("side", order.Side);
                 orderParameters.AddOptionalParameter("orderId", order.OrderId?.ToString(CultureInfo.InvariantCulture));
                 orderParameters.AddOptionalParameter("origClientOrderId", clientOrderId);

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceSocketClientUsdFuturesApiTrading.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceSocketClientUsdFuturesApiTrading.cs
@@ -89,7 +89,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
         #region Edit Order
 
         /// <inheritdoc />
-        public async Task<CallResult<BinanceResponse<BinanceUsdFuturesOrder>>> EditOrderAsync(string symbol, OrderSide side, decimal quantity, decimal price, long? orderId = null, string? origClientOrderId = null, long? receiveWindow = null, CancellationToken ct = default)
+        public async Task<CallResult<BinanceResponse<BinanceUsdFuturesOrder>>> EditOrderAsync(string symbol, OrderSide side, decimal quantity, decimal? price = null, PriceMatch? priceMatch = null, long? orderId = null, string? origClientOrderId = null, long? receiveWindow = null, CancellationToken ct = default)
         {
             if (!orderId.HasValue && string.IsNullOrEmpty(origClientOrderId))
                 throw new ArgumentException("Either orderId or origClientOrderId must be sent");
@@ -102,8 +102,9 @@ namespace Binance.Net.Clients.UsdFuturesApi
                 { "symbol", symbol },
                 { "side", EnumConverter.GetString(side) },
                 { "quantity", quantity.ToString(CultureInfo.InvariantCulture) },
-                { "price", price.ToString(CultureInfo.InvariantCulture) },
             };
+            parameters.AddOptionalParameter("price", price?.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptionalEnum("priceMatch", priceMatch);
             parameters.AddOptionalParameter("orderId", orderId?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("origClientOrderId", origClientOrderId);
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture));

--- a/Binance.Net/Interfaces/Clients/UsdFuturesApi/IBinanceRestClientUsdFuturesApiTrading.cs
+++ b/Binance.Net/Interfaces/Clients/UsdFuturesApi/IBinanceRestClientUsdFuturesApiTrading.cs
@@ -137,12 +137,13 @@ namespace Binance.Net.Interfaces.Clients.UsdFuturesApi
         /// <param name="side">Order side</param>
         /// <param name="quantity">New quantity</param>
         /// <param name="price">New price</param>
+        /// <param name="priceMatch">Only avaliable for Limit/Stop/TakeProfit order</param>
         /// <param name="orderId">Order id of the order to edit</param>
         /// <param name="origClientOrderId">Client order id of the order to edit</param>
         /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BinanceUsdFuturesOrder>> EditOrderAsync(string symbol, OrderSide side, decimal quantity, decimal price, long? orderId = null, string? origClientOrderId = null, long? receiveWindow = null, CancellationToken ct = default);
+        Task<WebCallResult<BinanceUsdFuturesOrder>> EditOrderAsync(string symbol, OrderSide side, decimal quantity, decimal? price, PriceMatch? priceMatch = null, long? orderId = null, string? origClientOrderId = null, long? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
         /// Edit multiple existing orders

--- a/Binance.Net/Interfaces/Clients/UsdFuturesApi/IBinanceSocketClientUsdFuturesApiTrading.cs
+++ b/Binance.Net/Interfaces/Clients/UsdFuturesApi/IBinanceSocketClientUsdFuturesApiTrading.cs
@@ -64,12 +64,13 @@ namespace Binance.Net.Interfaces.Clients.UsdFuturesApi
         /// <param name="side">Order side</param>
         /// <param name="quantity">New quantity</param>
         /// <param name="price">New price</param>
+        /// <param name="priceMatch">Only avaliable for Limit/Stop/TakeProfit order</param>
         /// <param name="orderId">Order id of the order to edit</param>
         /// <param name="origClientOrderId">Client order id of the order to edit</param>
         /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<CallResult<BinanceResponse<BinanceUsdFuturesOrder>>> EditOrderAsync(string symbol, OrderSide side, decimal quantity, decimal price, long? orderId = null, string? origClientOrderId = null, long? receiveWindow = null, CancellationToken ct = default);
+        Task<CallResult<BinanceResponse<BinanceUsdFuturesOrder>>> EditOrderAsync(string symbol, OrderSide side, decimal quantity, decimal? price = null, PriceMatch? priceMatch = null, long? orderId = null, string? origClientOrderId = null, long? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
         /// Cancels a pending order

--- a/Binance.Net/Objects/Models/Futures/BinanceFuturesBatchEditOrder.cs
+++ b/Binance.Net/Objects/Models/Futures/BinanceFuturesBatchEditOrder.cs
@@ -30,6 +30,10 @@ namespace Binance.Net.Objects.Models.Futures
         /// <summary>
         /// Price
         /// </summary>
-        public decimal Price { get; set; }
+        public decimal? Price { get; set; }
+        /// <summary>
+        /// PriceMatch
+        /// </summary>
+        public PriceMatch? PriceMatch { get; set; }
     }
 }


### PR DESCRIPTION
This adds a `PriceMatch` parameter to the USD-futures order editing methods (both REST and WS). This is useful for "chasing" limit orders to prevent market order fees.

Submitting as a draft for feedback.