### PR TITLE
Added NFT Endpoints

### DIFF
--- a/Binance.Net/Clients/GeneralApi/BinanceRestClientGeneralApiNft.cs
+++ b/Binance.Net/Clients/GeneralApi/BinanceRestClientGeneralApiNft.cs
@@ -58,7 +58,7 @@ namespace Binance.Net.Clients.GeneralApi
         public async Task<WebCallResult<BinanceListRecords<BinanceNftTransaction>>> GetNftTransactionHistoryAsync(NftOrderType orderType, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? page = null, long? receiveWindow = null, CancellationToken ct = default)
         {
             var parameters = new ParameterCollection();
-            parameters.AddOptionalEnum("orderType", orderType);
+            parameters.AddEnum("orderType", orderType);
             parameters.AddOptionalMilliseconds("startTime", startTime);
             parameters.AddOptionalMilliseconds("endTime", endTime);
             parameters.AddOptional("limit", limit);

--- a/Binance.Net/Clients/GeneralApi/BinanceRestClientGeneralApiNft.cs
+++ b/Binance.Net/Clients/GeneralApi/BinanceRestClientGeneralApiNft.cs
@@ -1,0 +1,90 @@
+﻿using Binance.Net.Enums;
+using Binance.Net.Interfaces.Clients.GeneralApi;
+using Binance.Net.Objects.Models;
+using Binance.Net.Objects.Models.Spot.NFT;
+
+namespace Binance.Net.Clients.GeneralApi
+{
+    internal class BinanceRestClientGeneralApiNFT: IBinanceRestClientGeneralApiNft
+    {
+        private static readonly RequestDefinitionCache _definitions = new RequestDefinitionCache();
+
+        private readonly BinanceRestClientGeneralApi _baseClient;
+
+        internal BinanceRestClientGeneralApiNFT(BinanceRestClientGeneralApi baseClient)
+        {
+            _baseClient = baseClient;
+        }
+
+        #region  Get NFT Deposit History
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<BinanceListRecords<BinanceNftDeposit>>> GetNftDepositHistoryAsync(DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? page = null, long? receiveWindow = null, CancellationToken ct = default)
+        {
+            var parameters = new ParameterCollection();
+            parameters.AddOptionalMilliseconds("startTime", startTime);
+            parameters.AddOptionalMilliseconds("endTime", endTime);
+            parameters.AddOptional("limit", limit);
+            parameters.AddOptional("page", page);
+            parameters.AddOptionalString("recvWindow", receiveWindow ?? (long)_baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds);
+
+            var request = _definitions.GetOrCreate(HttpMethod.Get, "/sapi/v1/nft/history/deposit", BinanceExchange.RateLimiter.SpotRestIp, 3000, true);
+            return await _baseClient.SendAsync<BinanceListRecords<BinanceNftDeposit>>(request, parameters, ct).ConfigureAwait(false);
+        }
+
+        #endregion
+
+        #region Get NFT Withdraw History
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<BinanceListRecords<BinanceNftWithdraw>>> GetNftWithdrawHistoryAsync(DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? page = null, long? receiveWindow = null, CancellationToken ct = default)
+        {
+            var parameters = new ParameterCollection();
+            parameters.AddOptionalMilliseconds("startTime", startTime);
+            parameters.AddOptionalMilliseconds("endTime", endTime);
+            parameters.AddOptional("limit", limit);
+            parameters.AddOptional("page", page);
+            parameters.AddOptionalString("recvWindow", receiveWindow ?? (long)_baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds);
+
+            var request = _definitions.GetOrCreate(HttpMethod.Get, "/sapi/v1/nft/history/withdraw", BinanceExchange.RateLimiter.SpotRestIp, 3000, true);
+            return await _baseClient.SendAsync<BinanceListRecords<BinanceNftWithdraw>>(request, parameters, ct).ConfigureAwait(false);
+        }
+
+        #endregion
+
+        #region Get NFT Transaction History
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<BinanceListRecords<BinanceNftTransaction>>> GetNftTransactionHistoryAsync(NftOrderType orderType, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? page = null, long? receiveWindow = null, CancellationToken ct = default)
+        {
+            var parameters = new ParameterCollection();
+            parameters.AddOptionalEnum("orderType", orderType);
+            parameters.AddOptionalMilliseconds("startTime", startTime);
+            parameters.AddOptionalMilliseconds("endTime", endTime);
+            parameters.AddOptional("limit", limit);
+            parameters.AddOptional("page", page);
+            parameters.AddOptionalString("recvWindow", receiveWindow ?? (long)_baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds);
+
+            var request = _definitions.GetOrCreate(HttpMethod.Get, "/sapi/v1/nft/history/transactions", BinanceExchange.RateLimiter.SpotRestIp, 3000, true);
+            return await _baseClient.SendAsync<BinanceListRecords<BinanceNftTransaction>>(request, parameters, ct).ConfigureAwait(false);
+        }
+
+        #endregion
+
+        #region  Get NFT Asset
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<BinanceListRecords<BinanceNftAsset>>> GetNftAssetAsync(int? limit = null, int? page = null, long? receiveWindow = null, CancellationToken ct = default)
+        {
+            var parameters = new ParameterCollection();
+            parameters.AddOptional("limit", limit);
+            parameters.AddOptional("page", page);
+            parameters.AddOptionalString("recvWindow", receiveWindow ?? (long)_baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds);
+
+            var request = _definitions.GetOrCreate(HttpMethod.Get, "/sapi/v1/nft/user/getAsset", BinanceExchange.RateLimiter.SpotRestIp, 3000, true);
+            return await _baseClient.SendAsync<BinanceListRecords<BinanceNftAsset>>(request, parameters, ct).ConfigureAwait(false);
+        }
+
+        #endregion
+    }
+}

--- a/Binance.Net/Clients/GeneralApi/BinanceRestClientGeneralApiNft.cs
+++ b/Binance.Net/Clients/GeneralApi/BinanceRestClientGeneralApiNft.cs
@@ -28,7 +28,7 @@ namespace Binance.Net.Clients.GeneralApi
             parameters.AddOptional("page", page);
             parameters.AddOptionalString("recvWindow", receiveWindow ?? (long)_baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/sapi/v1/nft/history/deposit", BinanceExchange.RateLimiter.SpotRestIp, 3000, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, "sapi/v1/nft/history/deposit", BinanceExchange.RateLimiter.SpotRestIp, 3000, true);
             return await _baseClient.SendAsync<BinanceListRecords<BinanceNftDeposit>>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -46,7 +46,7 @@ namespace Binance.Net.Clients.GeneralApi
             parameters.AddOptional("page", page);
             parameters.AddOptionalString("recvWindow", receiveWindow ?? (long)_baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/sapi/v1/nft/history/withdraw", BinanceExchange.RateLimiter.SpotRestIp, 3000, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, "sapi/v1/nft/history/withdraw", BinanceExchange.RateLimiter.SpotRestIp, 3000, true);
             return await _baseClient.SendAsync<BinanceListRecords<BinanceNftWithdraw>>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -65,7 +65,7 @@ namespace Binance.Net.Clients.GeneralApi
             parameters.AddOptional("page", page);
             parameters.AddOptionalString("recvWindow", receiveWindow ?? (long)_baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/sapi/v1/nft/history/transactions", BinanceExchange.RateLimiter.SpotRestIp, 3000, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, "sapi/v1/nft/history/transactions", BinanceExchange.RateLimiter.SpotRestIp, 3000, true);
             return await _baseClient.SendAsync<BinanceListRecords<BinanceNftTransaction>>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -81,7 +81,7 @@ namespace Binance.Net.Clients.GeneralApi
             parameters.AddOptional("page", page);
             parameters.AddOptionalString("recvWindow", receiveWindow ?? (long)_baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/sapi/v1/nft/user/getAsset", BinanceExchange.RateLimiter.SpotRestIp, 3000, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, "sapi/v1/nft/user/getAsset", BinanceExchange.RateLimiter.SpotRestIp, 3000, true);
             return await _baseClient.SendAsync<BinanceListRecords<BinanceNftAsset>>(request, parameters, ct).ConfigureAwait(false);
         }
 

--- a/Binance.Net/Enums/NftOrderType.cs
+++ b/Binance.Net/Enums/NftOrderType.cs
@@ -1,0 +1,36 @@
+﻿using CryptoExchange.Net.Attributes;
+
+namespace Binance.Net.Enums
+{
+    /// <summary>
+    /// Order type for a NFT order
+    /// </summary>
+    public enum NftOrderType
+    {
+        /// <summary>
+        /// Purchase order made by the user to buy assets.
+        /// </summary>
+        [Map("0")]
+        PurchaseOrder,
+        /// <summary>
+        /// Sell order made by the user to sell assets.
+        /// </summary>
+        [Map("1")]
+        SellOrder,
+        /// <summary>
+        /// Income received as royalty from assets.
+        /// </summary>
+        [Map("2")]
+        RoyaltyIncome,
+        /// <summary>
+        /// Order placed during the primary market sale.
+        /// </summary>
+        [Map("3")]
+        PrimaryMarketOrder,
+        /// <summary>
+        /// Fee paid for minting assets.
+        /// </summary>
+        [Map("4")]
+        MintFee
+    }
+}

--- a/Binance.Net/Interfaces/Clients/GeneralApi/IBinanceRestClientGeneralApiNft.cs
+++ b/Binance.Net/Interfaces/Clients/GeneralApi/IBinanceRestClientGeneralApiNft.cs
@@ -1,0 +1,63 @@
+﻿using Binance.Net.Enums;
+using Binance.Net.Objects.Models;
+using Binance.Net.Objects.Models.Spot.NFT;
+
+namespace Binance.Net.Interfaces.Clients.GeneralApi
+{
+    /// <summary>
+    /// Binance NFT endpoints
+    /// </summary>
+    public interface IBinanceRestClientGeneralApiNft
+    {
+        /// <summary>
+        /// Get NFT deposit history
+        /// <para><a href="https://developers.binance.com/docs/nft/rest-api" /></para>
+        /// </summary>
+        /// <param name="startTime">Time to start getting deposit records from</param>
+        /// <param name="endTime">Time to stop getting deposit records from</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="page">Page number of the results to fetch</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<WebCallResult<BinanceListRecords<BinanceNftDeposit>>> GetNftDepositHistoryAsync(DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? page = null, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get NFT withdraw history
+        /// <para><a href="https://developers.binance.com/docs/nft/rest-api/Get-NFT-Withdraw-History" /></para>
+        /// </summary>
+        /// <param name="startTime">Time to start getting withdraw records from</param>
+        /// <param name="endTime">Time to stop getting withdraw records from</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="page">Page number of the results to fetch</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<WebCallResult<BinanceListRecords<BinanceNftWithdraw>>> GetNftWithdrawHistoryAsync(DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? page = null, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get NFT transaction history
+        /// <para><a href="https://developers.binance.com/docs/nft/rest-api/Get-NFT-Transaction-History" /></para>
+        /// </summary>
+        /// <param name="orderType">Order type</param>
+        /// <param name="startTime">Time to start getting transaction from</param>
+        /// <param name="endTime">Time to stop getting transaction from</param>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="page">Page number of the results to fetch</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<WebCallResult<BinanceListRecords<BinanceNftTransaction>>> GetNftTransactionHistoryAsync(NftOrderType orderType, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? page = null, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get NFT Asset
+        /// <para><a href="https://developers.binance.com/docs/nft/rest-api/Get-NFT-Asset" /></para>
+        /// </summary>
+        /// <param name="limit">Max number of results</param>
+        /// <param name="page">Page number of the results to fetch</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<WebCallResult<BinanceListRecords<BinanceNftAsset>>> GetNftAssetAsync(int? limit = null, int? page = null, long? receiveWindow = null, CancellationToken ct = default);
+    }
+}

--- a/Binance.Net/Objects/Models/BinanceListRecords.cs
+++ b/Binance.Net/Objects/Models/BinanceListRecords.cs
@@ -1,0 +1,20 @@
+﻿namespace Binance.Net.Objects.Models
+{
+    /// <summary>
+    /// Query results
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public record BinanceListRecords<T>
+    {
+        /// <summary>
+        /// The total count of the records
+        /// </summary>
+        [JsonPropertyName("total")]
+        public int Total { get; set; }
+        /// <summary>
+        /// The list records
+        /// </summary>
+        [JsonPropertyName("list")]
+        public IEnumerable<T> List { get; set; } = Array.Empty<T>();
+    }
+}

--- a/Binance.Net/Objects/Models/Spot/Nft/BinanceNftAsset.cs
+++ b/Binance.Net/Objects/Models/Spot/Nft/BinanceNftAsset.cs
@@ -1,5 +1,8 @@
 ﻿namespace Binance.Net.Objects.Models.Spot.NFT
 {
+    /// <summary>
+    /// NFT asset
+    /// </summary>
     public record BinanceNftAsset
     {
         /// <summary>

--- a/Binance.Net/Objects/Models/Spot/Nft/BinanceNftAsset.cs
+++ b/Binance.Net/Objects/Models/Spot/Nft/BinanceNftAsset.cs
@@ -1,0 +1,21 @@
+﻿namespace Binance.Net.Objects.Models.Spot.NFT
+{
+    public record BinanceNftAsset
+    {
+        /// <summary>
+        /// NFT network
+        /// </summary>
+        [JsonPropertyName("network")]
+        public string Network { get; set; } = string.Empty;
+        /// <summary>
+        /// NFT contract address
+        /// </summary>
+        [JsonPropertyName("contractAddress")]
+        public string ContractAddress { get; set; } = string.Empty;
+        /// <summary>
+        /// NFT token id
+        /// </summary>
+        [JsonPropertyName("tokenId")]
+        public string TokenId { get; set; } = string.Empty;
+    }
+}

--- a/Binance.Net/Objects/Models/Spot/Nft/BinanceNftDeposit.cs
+++ b/Binance.Net/Objects/Models/Spot/Nft/BinanceNftDeposit.cs
@@ -1,0 +1,31 @@
+﻿namespace Binance.Net.Objects.Models.Spot.NFT
+{
+    public record BinanceNftDeposit
+    {
+        /// <summary>
+        /// NFT network
+        /// </summary>
+        [JsonPropertyName("network")]
+        public string Network { get; set; } = string.Empty;
+        /// <summary>
+        /// Transaction id
+        /// </summary>
+        [JsonPropertyName("txID")]
+        public string? TxID { get; set; }
+        /// <summary>
+        /// NFT contract address
+        /// </summary>
+        [JsonPropertyName("contractAdrress")] // not a typo, spelled according to binance docs
+        public string ContractAddress { get; set; } = string.Empty;
+        /// <summary>
+        /// NFT token id
+        /// </summary>
+        [JsonPropertyName("tokenId")]
+        public string TokenId { get; set; } = string.Empty;
+        /// <summary>
+        /// Timestamp
+        /// </summary>
+        [JsonPropertyName("timestamp")]
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/Binance.Net/Objects/Models/Spot/Nft/BinanceNftDeposit.cs
+++ b/Binance.Net/Objects/Models/Spot/Nft/BinanceNftDeposit.cs
@@ -14,7 +14,7 @@
         /// Transaction id
         /// </summary>
         [JsonPropertyName("txID")]
-        public string? TxID { get; set; }
+        public string? TransactionId { get; set; }
         /// <summary>
         /// NFT contract address
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Nft/BinanceNftDeposit.cs
+++ b/Binance.Net/Objects/Models/Spot/Nft/BinanceNftDeposit.cs
@@ -1,5 +1,8 @@
 ﻿namespace Binance.Net.Objects.Models.Spot.NFT
 {
+    /// <summary>
+    /// NFT deposit
+    /// </summary>
     public record BinanceNftDeposit
     {
         /// <summary>

--- a/Binance.Net/Objects/Models/Spot/Nft/BinanceNftTransaction.cs
+++ b/Binance.Net/Objects/Models/Spot/Nft/BinanceNftTransaction.cs
@@ -1,5 +1,8 @@
 ﻿namespace Binance.Net.Objects.Models.Spot.NFT
 {
+    /// <summary>
+    /// NFT transaction
+    /// </summary>
     public record BinanceNftTransaction
     {
         /// <summary>

--- a/Binance.Net/Objects/Models/Spot/Nft/BinanceNftTransaction.cs
+++ b/Binance.Net/Objects/Models/Spot/Nft/BinanceNftTransaction.cs
@@ -24,7 +24,7 @@
         /// Trade amount
         /// </summary>
         [JsonPropertyName("tradeAmount")]
-        public string TradeAmount { get; set; } = string.Empty;
+        public decimal? TradeAmount { get; set; } = null;
         /// <summary>
         /// Trade currency
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Nft/BinanceNftTransaction.cs
+++ b/Binance.Net/Objects/Models/Spot/Nft/BinanceNftTransaction.cs
@@ -1,0 +1,31 @@
+﻿namespace Binance.Net.Objects.Models.Spot.NFT
+{
+    public record BinanceNftTransaction
+    {
+        /// <summary>
+        /// Order number, 0: purchase order, 1: sell order, 2: royalty income, 3: primary market order, 4: mint fee
+        /// </summary>
+        [JsonPropertyName("orderNo")]
+        public string OrderNo { get; set; } = string.Empty;
+        /// <summary>
+        /// Tokens
+        /// </summary>
+        [JsonPropertyName("tokens")]
+        public IEnumerable<BinanceNftAsset> Tokens { get; set; } = Array.Empty<BinanceNftAsset>();
+        /// <summary>
+        /// Trade time
+        /// </summary>
+        [JsonPropertyName("tradeTime")]
+        public DateTime TradeTime { get; set; }
+        /// <summary>
+        /// Trade amount
+        /// </summary>
+        [JsonPropertyName("tradeAmount")]
+        public string TradeAmount { get; set; } = string.Empty;
+        /// <summary>
+        /// Trade currency
+        /// </summary>
+        [JsonPropertyName("tradeCurrency")]
+        public string TradeCurrency { get; set; } = string.Empty;
+    }
+}

--- a/Binance.Net/Objects/Models/Spot/Nft/BinanceNftWithdraw.cs
+++ b/Binance.Net/Objects/Models/Spot/Nft/BinanceNftWithdraw.cs
@@ -14,7 +14,7 @@
         /// Transaction id
         /// </summary>
         [JsonPropertyName("txID")]
-        public string TxID { get; set; } = string.Empty;
+        public string TransactionId { get; set; } = string.Empty;
         /// <summary>
         /// NFT contract address
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Nft/BinanceNftWithdraw.cs
+++ b/Binance.Net/Objects/Models/Spot/Nft/BinanceNftWithdraw.cs
@@ -1,5 +1,8 @@
 ﻿namespace Binance.Net.Objects.Models.Spot.NFT
 {
+    /// <summary>
+    /// NFT withdraw
+    /// </summary>
     public record BinanceNftWithdraw
     {
         /// <summary>

--- a/Binance.Net/Objects/Models/Spot/Nft/BinanceNftWithdraw.cs
+++ b/Binance.Net/Objects/Models/Spot/Nft/BinanceNftWithdraw.cs
@@ -1,0 +1,41 @@
+﻿namespace Binance.Net.Objects.Models.Spot.NFT
+{
+    public record BinanceNftWithdraw
+    {
+        /// <summary>
+        /// NFT network
+        /// </summary>
+        [JsonPropertyName("network")]
+        public string Network { get; set; } = string.Empty;
+        /// <summary>
+        /// Transaction id
+        /// </summary>
+        [JsonPropertyName("txID")]
+        public string TxID { get; set; } = string.Empty;
+        /// <summary>
+        /// NFT contract address
+        /// </summary>
+        [JsonPropertyName("contractAdrress")] // not a typo, spelled according to binance docs
+        public string ContractAddress { get; set; } = string.Empty;
+        /// <summary>
+        /// NFT token id
+        /// </summary>
+        [JsonPropertyName("tokenId")]
+        public string TokenId { get; set; } = string.Empty;
+        /// <summary>
+        /// Timestamp
+        /// </summary>
+        [JsonPropertyName("timestamp")]
+        public DateTime Timestamp { get; set; }
+        /// <summary>
+        /// Withdraw fee
+        /// </summary>
+        [JsonPropertyName("fee")]
+        public decimal Fee { get; set; }
+        /// <summary>
+        /// Fee asset
+        /// </summary>
+        [JsonPropertyName("feeAsset")]
+        public string FeeAsset { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
### Summary
- Implemented `BinanceRestClientGeneralApiNft` class for handling NFT-related endpoints
- Added Interfaces:
  - `IBinanceRestClientGeneralApiNft`
- Added models:
  - `BinanceNftAsset`
  - `BinanceNftDeposit`
  - `BinanceNftTransaction`
  - `BinanceNftWithdraw`
  - `BinanceListRecords`
- Added enums:
  - `NftOrderType` 
  
- DOCS: https://developers.binance.com/docs/nft/rest-api