### PR TITLE
Added missing margin market data endpoints

### DIFF
--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiExchangeData.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiExchangeData.cs
@@ -600,6 +600,47 @@ namespace Binance.Net.Clients.SpotApi
 
         #endregion
 
+        #region Query Isolated Margin Tier Data
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<IEnumerable<BinanceIsolatedMarginTier>>> QueryIsolatedMarginTierData(string symbol, int? tier = null, int? receiveWindow = null, CancellationToken ct = default)
+        {
+            var parameters = new ParameterCollection();
+            parameters.Add("symbol", symbol);
+            parameters.AddOptional("tier", tier);
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+
+            var request = _definitions.GetOrCreate(HttpMethod.Get, "sapi/v1/margin/isolatedMarginTier", BinanceExchange.RateLimiter.SpotRestIp, 1, true);
+            return await _baseClient.SendAsync<IEnumerable<BinanceIsolatedMarginTier>>(request, parameters, ct).ConfigureAwait(false);
+        }
+
+        #endregion
+
+        #region Query Margin Available Inventory
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<BinanceMarginAvailableInventory>> QueryMarginAvaliableInventory(MarginInventoryType type, CancellationToken ct = default)
+        {
+            var parameters = new ParameterCollection();
+            parameters.AddEnum("type", type);
+
+            var request = _definitions.GetOrCreate(HttpMethod.Get, "sapi/v1/margin/available-inventory", BinanceExchange.RateLimiter.SpotRestUid, 50, true);
+            return await _baseClient.SendAsync<BinanceMarginAvailableInventory>(request, parameters, ct).ConfigureAwait(false);
+        }
+
+        #endregion
+
+        #region Query Liability Coin Leverage Bracket in Cross Margin Pro Mode
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<IEnumerable<BinanceCrossMarginProLiabilityCoinLeverageBracket>>> QueryLiabilityCoinLeverageBracketInCrossMarginProMode(CancellationToken ct = default)
+        {
+            var request = _definitions.GetOrCreate(HttpMethod.Get, "sapi/v1/margin/leverageBracket", BinanceExchange.RateLimiter.SpotRestIp, 1);
+            return await _baseClient.SendAsync<IEnumerable<BinanceCrossMarginProLiabilityCoinLeverageBracket>>(request, null, ct).ConfigureAwait(false);
+        }
+
+        #endregion
+
         #region Convert
 
         #region Get Convert List All Pairs

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiExchangeData.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiExchangeData.cs
@@ -603,7 +603,7 @@ namespace Binance.Net.Clients.SpotApi
         #region Query Isolated Margin Tier Data
 
         /// <inheritdoc />
-        public async Task<WebCallResult<IEnumerable<BinanceIsolatedMarginTier>>> GetIsolatedMarginTierData(string symbol, int? tier = null, int? receiveWindow = null, CancellationToken ct = default)
+        public async Task<WebCallResult<IEnumerable<BinanceIsolatedMarginTier>>> GetIsolatedMarginTierDataAsync(string symbol, int? tier = null, int? receiveWindow = null, CancellationToken ct = default)
         {
             var parameters = new ParameterCollection();
             parameters.Add("symbol", symbol);
@@ -619,7 +619,7 @@ namespace Binance.Net.Clients.SpotApi
         #region Query Margin Available Inventory
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BinanceMarginAvailableInventory>> GetMarginAvaliableInventory(MarginInventoryType type, CancellationToken ct = default)
+        public async Task<WebCallResult<BinanceMarginAvailableInventory>> GetMarginAvaliableInventoryAsync(MarginInventoryType type, CancellationToken ct = default)
         {
             var parameters = new ParameterCollection();
             parameters.AddEnum("type", type);
@@ -633,7 +633,7 @@ namespace Binance.Net.Clients.SpotApi
         #region Query Liability Coin Leverage Bracket in Cross Margin Pro Mode
 
         /// <inheritdoc />
-        public async Task<WebCallResult<IEnumerable<BinanceCrossMarginProLiabilityCoinLeverageBracket>>> GetLiabilityCoinLeverageBracketInCrossMarginProMode(CancellationToken ct = default)
+        public async Task<WebCallResult<IEnumerable<BinanceCrossMarginProLiabilityCoinLeverageBracket>>> GetLiabilityCoinLeverageBracketInCrossMarginProModeAsync(CancellationToken ct = default)
         {
             var request = _definitions.GetOrCreate(HttpMethod.Get, "sapi/v1/margin/leverageBracket", BinanceExchange.RateLimiter.SpotRestIp, 1);
             return await _baseClient.SendAsync<IEnumerable<BinanceCrossMarginProLiabilityCoinLeverageBracket>>(request, null, ct).ConfigureAwait(false);

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiExchangeData.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiExchangeData.cs
@@ -603,7 +603,7 @@ namespace Binance.Net.Clients.SpotApi
         #region Query Isolated Margin Tier Data
 
         /// <inheritdoc />
-        public async Task<WebCallResult<IEnumerable<BinanceIsolatedMarginTier>>> QueryIsolatedMarginTierData(string symbol, int? tier = null, int? receiveWindow = null, CancellationToken ct = default)
+        public async Task<WebCallResult<IEnumerable<BinanceIsolatedMarginTier>>> GetIsolatedMarginTierData(string symbol, int? tier = null, int? receiveWindow = null, CancellationToken ct = default)
         {
             var parameters = new ParameterCollection();
             parameters.Add("symbol", symbol);
@@ -619,7 +619,7 @@ namespace Binance.Net.Clients.SpotApi
         #region Query Margin Available Inventory
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BinanceMarginAvailableInventory>> QueryMarginAvaliableInventory(MarginInventoryType type, CancellationToken ct = default)
+        public async Task<WebCallResult<BinanceMarginAvailableInventory>> GetMarginAvaliableInventory(MarginInventoryType type, CancellationToken ct = default)
         {
             var parameters = new ParameterCollection();
             parameters.AddEnum("type", type);
@@ -633,7 +633,7 @@ namespace Binance.Net.Clients.SpotApi
         #region Query Liability Coin Leverage Bracket in Cross Margin Pro Mode
 
         /// <inheritdoc />
-        public async Task<WebCallResult<IEnumerable<BinanceCrossMarginProLiabilityCoinLeverageBracket>>> QueryLiabilityCoinLeverageBracketInCrossMarginProMode(CancellationToken ct = default)
+        public async Task<WebCallResult<IEnumerable<BinanceCrossMarginProLiabilityCoinLeverageBracket>>> GetLiabilityCoinLeverageBracketInCrossMarginProMode(CancellationToken ct = default)
         {
             var request = _definitions.GetOrCreate(HttpMethod.Get, "sapi/v1/margin/leverageBracket", BinanceExchange.RateLimiter.SpotRestIp, 1);
             return await _baseClient.SendAsync<IEnumerable<BinanceCrossMarginProLiabilityCoinLeverageBracket>>(request, null, ct).ConfigureAwait(false);

--- a/Binance.Net/Enums/MarginInventoryType.cs
+++ b/Binance.Net/Enums/MarginInventoryType.cs
@@ -1,0 +1,21 @@
+﻿using CryptoExchange.Net.Attributes;
+
+namespace Binance.Net.Enums
+{
+    /// <summary>
+    /// Type of margin inventory.
+    /// </summary>
+    public enum MarginInventoryType
+    {
+        /// <summary>
+        /// Represents a regular margin account.
+        /// </summary>
+        [Map("MARGIN")]
+        Margin,
+        /// <summary>
+        /// Represents an isolated margin account.
+        /// </summary>
+        [Map("ISOLATED")]
+        Isolated
+    }
+}

--- a/Binance.Net/Interfaces/Clients/SpotApi/IBinanceRestClientSpotApiExchangeData.cs
+++ b/Binance.Net/Interfaces/Clients/SpotApi/IBinanceRestClientSpotApiExchangeData.cs
@@ -405,7 +405,7 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<IEnumerable<BinanceIsolatedMarginTier>>> GetIsolatedMarginTierData(string symbol, int? tier = null, int? receiveWindow = null, CancellationToken ct = default);
+        Task<WebCallResult<IEnumerable<BinanceIsolatedMarginTier>>> GetIsolatedMarginTierDataAsync(string symbol, int? tier = null, int? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get Margin Available Inventory
@@ -414,7 +414,7 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         /// <param name="type">The margin type to query for</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BinanceMarginAvailableInventory>> GetMarginAvaliableInventory(MarginInventoryType type, CancellationToken ct = default);
+        Task<WebCallResult<BinanceMarginAvailableInventory>> GetMarginAvaliableInventoryAsync(MarginInventoryType type, CancellationToken ct = default);
 
         /// <summary>
         /// Get Liability Coin Leverage Bracket in Cross Margin Pro Mode
@@ -422,7 +422,7 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         /// </summary>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<IEnumerable<BinanceCrossMarginProLiabilityCoinLeverageBracket>>> GetLiabilityCoinLeverageBracketInCrossMarginProMode(CancellationToken ct = default);
+        Task<WebCallResult<IEnumerable<BinanceCrossMarginProLiabilityCoinLeverageBracket>>> GetLiabilityCoinLeverageBracketInCrossMarginProModeAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get list all convert pairs

--- a/Binance.Net/Interfaces/Clients/SpotApi/IBinanceRestClientSpotApiExchangeData.cs
+++ b/Binance.Net/Interfaces/Clients/SpotApi/IBinanceRestClientSpotApiExchangeData.cs
@@ -397,7 +397,7 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         Task<WebCallResult<IEnumerable<BinanceMarginDelistSchedule>>> GetMarginDelistScheduleAsync(int? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
-        /// Query Isolated Margin Tier Data
+        /// Get Isolated Margin Tier Data
         /// <para><a href="https://developers.binance.com/docs/margin_trading/market-data/Query-Isolated-Margin-Tier-Data" /></para>
         /// </summary>
         /// <param name="symbol">The symbol to get, for example `ETHUSDT`</param>
@@ -405,24 +405,24 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<IEnumerable<BinanceIsolatedMarginTier>>> QueryIsolatedMarginTierData(string symbol, int? tier = null, int? receiveWindow = null, CancellationToken ct = default);
+        Task<WebCallResult<IEnumerable<BinanceIsolatedMarginTier>>> GetIsolatedMarginTierData(string symbol, int? tier = null, int? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
-        /// Query Margin Available Inventory
+        /// Get Margin Available Inventory
         /// <para><a href="https://developers.binance.com/docs/margin_trading/market-data/Query-margin-avaliable-inventory" /></para>
         /// </summary>
         /// <param name="type">The margin type to query for</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BinanceMarginAvailableInventory>> QueryMarginAvaliableInventory(MarginInventoryType type, CancellationToken ct = default);
+        Task<WebCallResult<BinanceMarginAvailableInventory>> GetMarginAvaliableInventory(MarginInventoryType type, CancellationToken ct = default);
 
         /// <summary>
-        /// Query Liability Coin Leverage Bracket in Cross Margin Pro Mode
+        /// Get Liability Coin Leverage Bracket in Cross Margin Pro Mode
         /// <para><a href="https://developers.binance.com/docs/margin_trading/market-data/Query-Liability-Coin-Leverage-Bracket-in-Cross-Margin-Pro-Mode" /></para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<IEnumerable<BinanceCrossMarginProLiabilityCoinLeverageBracket>>> QueryLiabilityCoinLeverageBracketInCrossMarginProMode(CancellationToken ct = default);
+        Task<WebCallResult<IEnumerable<BinanceCrossMarginProLiabilityCoinLeverageBracket>>> GetLiabilityCoinLeverageBracketInCrossMarginProMode(CancellationToken ct = default);
 
         /// <summary>
         /// Get list all convert pairs

--- a/Binance.Net/Interfaces/Clients/SpotApi/IBinanceRestClientSpotApiExchangeData.cs
+++ b/Binance.Net/Interfaces/Clients/SpotApi/IBinanceRestClientSpotApiExchangeData.cs
@@ -397,6 +397,34 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         Task<WebCallResult<IEnumerable<BinanceMarginDelistSchedule>>> GetMarginDelistScheduleAsync(int? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
+        /// Query Isolated Margin Tier Data
+        /// <para><a href="https://developers.binance.com/docs/margin_trading/market-data/Query-Isolated-Margin-Tier-Data" /></para>
+        /// </summary>
+        /// <param name="symbol">The symbol to get, for example `ETHUSDT`</param>
+        /// <param name="tier">Tier level</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<WebCallResult<IEnumerable<BinanceIsolatedMarginTier>>> QueryIsolatedMarginTierData(string symbol, int? tier = null, int? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Query Margin Available Inventory
+        /// <para><a href="https://developers.binance.com/docs/margin_trading/market-data/Query-margin-avaliable-inventory" /></para>
+        /// </summary>
+        /// <param name="type">The margin type to query for</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<WebCallResult<BinanceMarginAvailableInventory>> QueryMarginAvaliableInventory(MarginInventoryType type, CancellationToken ct = default);
+
+        /// <summary>
+        /// Query Liability Coin Leverage Bracket in Cross Margin Pro Mode
+        /// <para><a href="https://developers.binance.com/docs/margin_trading/market-data/Query-Liability-Coin-Leverage-Bracket-in-Cross-Margin-Pro-Mode" /></para>
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<WebCallResult<IEnumerable<BinanceCrossMarginProLiabilityCoinLeverageBracket>>> QueryLiabilityCoinLeverageBracketInCrossMarginProMode(CancellationToken ct = default);
+
+        /// <summary>
         /// Get list all convert pairs
         /// <para><a href="https://developers.binance.com/docs/convert/market-data" /></para>
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Margin/BinanceCrossMarginProLiabilityCoinLeverageBracket.cs
+++ b/Binance.Net/Objects/Models/Spot/Margin/BinanceCrossMarginProLiabilityCoinLeverageBracket.cs
@@ -1,0 +1,56 @@
+﻿namespace Binance.Net.Objects.Models.Spot.Margin
+{
+    /// <summary>
+    /// Cross margin pro liability coin leverage bracket data
+    /// </summary>
+    public record BinanceCrossMarginProLiabilityCoinLeverageBracket
+    {
+        /// <summary>
+        /// Asset names
+        /// </summary>
+        [JsonPropertyName("assetNames")]
+        public IEnumerable<string> AssetNames { get; set; } = Array.Empty<string>();
+        /// <summary>
+        /// Rank
+        /// </summary>
+        [JsonPropertyName("rank")]
+        public int Rank { get; set; }
+        /// <summary>
+        /// Brackets
+        /// </summary>
+        [JsonPropertyName("brackets")]
+        public IEnumerable<BinanceCrossMarginProBracket> Brackets { get; set; } = Array.Empty<BinanceCrossMarginProBracket>();
+    }
+
+    /// <summary>
+    /// Cross margin pro bracket data
+    /// </summary>
+    public record BinanceCrossMarginProBracket
+    {
+        /// <summary>
+        /// Leverage
+        /// </summary>
+        [JsonPropertyName("leverage")]
+        public int Leverage { get; set; }
+        /// <summary>
+        /// Max debt
+        /// </summary>
+        [JsonPropertyName("maxDebt")]
+        public decimal MaxDebt { get; set; }
+        /// <summary>
+        /// Maintenance margin rate
+        /// </summary>
+        [JsonPropertyName("maintenanceMarginRate")]
+        public decimal MaintenanceMarginRate { get; set; }
+        /// <summary>
+        /// Initial margin rate
+        /// </summary>
+        [JsonPropertyName("initialMarginRate")]
+        public decimal InitialMarginRate { get; set; }
+        /// <summary>
+        /// Fast num
+        /// </summary>
+        [JsonPropertyName("fastNum")]
+        public decimal FastNum { get; set; }
+    }
+}

--- a/Binance.Net/Objects/Models/Spot/Margin/BinanceIsolatedMarginTier.cs
+++ b/Binance.Net/Objects/Models/Spot/Margin/BinanceIsolatedMarginTier.cs
@@ -1,0 +1,44 @@
+﻿namespace Binance.Net.Objects.Models.Spot.Margin
+{
+    /// <summary>
+    /// Binance isolated margin tier data
+    /// </summary>
+    public record BinanceIsolatedMarginTier
+    {
+        /// <summary>
+        /// Symbol
+        /// </summary>
+        [JsonPropertyName("symbol")]
+        public string Symbol { get; set; } = string.Empty;
+        /// <summary>
+        /// Tier
+        /// </summary>
+        [JsonPropertyName("tier")]
+        public int Tier { get; set; }
+        /// <summary>
+        /// Effective multiple
+        /// </summary>
+        [JsonPropertyName("effectiveMultiple")]
+        public string EffectiveMultiple { get; set; } = string.Empty;
+        /// <summary>
+        /// Initial risk ratio
+        /// </summary>
+        [JsonPropertyName("initialRiskRatio")]
+        public string InitialRiskRatio { get; set; } = string.Empty;
+        /// <summary>
+        /// Liquidation risk ratio
+        /// </summary>
+        [JsonPropertyName("liquidationRiskRatio")]
+        public string LiquidationRiskRatio { get; set; } = string.Empty;
+        /// <summary>
+        /// Base asset max borrowable
+        /// </summary>
+        [JsonPropertyName("baseAssetMaxBorrowable")]
+        public string BaseAssetMaxBorrowable { get; set; } = string.Empty;
+        /// <summary>
+        /// Quote asset max borrowable
+        /// </summary>
+        [JsonPropertyName("quoteAssetMaxBorrowable")]
+        public string QuoteAssetMaxBorrowable { get; set; } = string.Empty;
+    }
+}

--- a/Binance.Net/Objects/Models/Spot/Margin/BinanceIsolatedMarginTier.cs
+++ b/Binance.Net/Objects/Models/Spot/Margin/BinanceIsolatedMarginTier.cs
@@ -19,26 +19,26 @@
         /// Effective multiple
         /// </summary>
         [JsonPropertyName("effectiveMultiple")]
-        public string EffectiveMultiple { get; set; } = string.Empty;
+        public decimal? EffectiveMultiple { get; set; } = null;
         /// <summary>
         /// Initial risk ratio
         /// </summary>
         [JsonPropertyName("initialRiskRatio")]
-        public string InitialRiskRatio { get; set; } = string.Empty;
+        public decimal? InitialRiskRatio { get; set; } = null;
         /// <summary>
         /// Liquidation risk ratio
         /// </summary>
         [JsonPropertyName("liquidationRiskRatio")]
-        public string LiquidationRiskRatio { get; set; } = string.Empty;
+        public decimal? LiquidationRiskRatio { get; set; } = null;
         /// <summary>
         /// Base asset max borrowable
         /// </summary>
         [JsonPropertyName("baseAssetMaxBorrowable")]
-        public string BaseAssetMaxBorrowable { get; set; } = string.Empty;
+        public decimal? BaseAssetMaxBorrowable { get; set; } = null;
         /// <summary>
         /// Quote asset max borrowable
         /// </summary>
         [JsonPropertyName("quoteAssetMaxBorrowable")]
-        public string QuoteAssetMaxBorrowable { get; set; } = string.Empty;
+        public decimal? QuoteAssetMaxBorrowable { get; set; } = null;
     }
 }

--- a/Binance.Net/Objects/Models/Spot/Margin/BinanceMarginAvailableInventory.cs
+++ b/Binance.Net/Objects/Models/Spot/Margin/BinanceMarginAvailableInventory.cs
@@ -1,0 +1,19 @@
+﻿namespace Binance.Net.Objects.Models.Spot.Margin
+{
+    /// <summary>
+    /// Margin available inventory data
+    /// </summary>
+    public record BinanceMarginAvailableInventory
+    {
+        /// <summary>
+        /// Assets
+        /// </summary>
+        [JsonPropertyName("assets")]
+        public Dictionary<string, string> Assets { get; set; } = new();
+        /// <summary>
+        /// Update time
+        /// </summary>
+        [JsonPropertyName("updateTime")]
+        public DateTime UpdateTime { get; set; }
+    }
+}


### PR DESCRIPTION
Added support for missing margin market data endpoints:
- [Query Isolated Margin Tier Data](https://developers.binance.com/docs/margin_trading/market-data/Query-Isolated-Margin-Tier-Data)
- [Query Margin Available Inventory](https://developers.binance.com/docs/margin_trading/market-data/Query-margin-avaliable-inventory)
- [Query Liability Coin Leverage Bracket in Cross Margin Pro Mode](https://developers.binance.com/docs/margin_trading/market-data/Query-Liability-Coin-Leverage-Bracket-in-Cross-Margin-Pro-Mode)

