### PR TITLE
fx path SubscribeToUserDataUpdatesAsync for coin

### DIFF
--- a/Binance.Net/Clients/CoinFuturesApi/BinanceSocketClientCoinFuturesApiAccount.cs
+++ b/Binance.Net/Clients/CoinFuturesApi/BinanceSocketClientCoinFuturesApiAccount.cs
@@ -68,7 +68,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             listenKey.ValidateNotNull(nameof(listenKey));
 
             var subscription = new BinanceCoinFuturesUserDataSubscription(_logger, new List<string> { listenKey }, onOrderUpdate, onConfigUpdate, onMarginUpdate, onAccountUpdate, onListenKeyExpired, onStrategyUpdate, onGridUpdate);
-            return await _client.SubscribeInternalAsync(_client.BaseAddress.AppendPath("stream"), subscription, ct).ConfigureAwait(false);
+            return await _client.SubscribeInternalAsync(_client.BaseAddress, subscription, ct).ConfigureAwait(false);
         }
 
         #endregion


### PR DESCRIPTION
I deleted the extra path stream because there was a duplication of the path :wss://stream.binance.com/stream/stream