### PR TITLE
Added Gift Card API tests & fixed deserialization error

### DIFF
--- a/Binance.Net.UnitTests/Binance.Net.UnitTests.csproj
+++ b/Binance.Net.UnitTests/Binance.Net.UnitTests.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Folder Include="Endpoints\General\GiftCard\" />
     <Folder Include="Endpoints\General\SimpleEarn\" />
     <Folder Include="Endpoints\General\Staking\" />
     <Folder Include="Endpoints\General\SubAccount\" />

--- a/Binance.Net.UnitTests/Endpoints/General/GiftCard/CreateDualTokenGiftCard.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/GiftCard/CreateDualTokenGiftCard.txt
@@ -1,0 +1,13 @@
+POST
+/sapi/v1/giftcard/buyCode
+true
+{
+  "code": "000000",
+  "message": "success",
+  "data": {
+      "referenceNo": "0033002144060553",
+      "code": "6H9EKF5ECCWFBHGE",
+      "expiredTime": 1727417154000
+  },
+  "success": true
+}

--- a/Binance.Net.UnitTests/Endpoints/General/GiftCard/CreateSingleTokenGiftCard.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/GiftCard/CreateSingleTokenGiftCard.txt
@@ -1,0 +1,13 @@
+POST
+/sapi/v1/giftcard/createCode
+true
+{
+    "code": "000000",
+    "message": "success",
+    "data": {
+        "referenceNo": "0033002144060553",
+        "code": "6H9EKF5ECCWFBHGE",
+        "expiredTime": 1727417154000
+    },
+    "success": true
+}

--- a/Binance.Net.UnitTests/Endpoints/General/GiftCard/GetRsaPublicKey.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/GiftCard/GetRsaPublicKey.txt
@@ -1,0 +1,9 @@
+GET
+/sapi/v1/giftcard/cryptography/rsa-public-key
+true
+{
+   "code": "000000",
+   "message": "success",
+   "data": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCXBBVKLAc1GQ5FsIFFqOHrPTox5noBONIKr+IAedTR9FkVxq6e65updEbfdhRNkMOeYIO2i0UylrjGC0X8YSoIszmrVHeV0l06Zh1oJuZos1+7N+WLuz9JvlPaawof3GUakTxYWWCa9+8KIbLKsoKMdfS96VT+8iOXO3quMGKUmQIDAQAB",
+   "success": true
+}

--- a/Binance.Net.UnitTests/Endpoints/General/GiftCard/GetTokenLimit.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/GiftCard/GetTokenLimit.txt
@@ -1,0 +1,15 @@
+GET
+/sapi/v1/giftcard/buyCode/token-limit
+true
+{
+  "code": "000000",
+  "message": "success",
+  "data": [
+    {
+      "coin": "BNB",
+      "fromMin": "0.01",
+      "fromMax": "1"
+    }
+  ],
+  "success":true
+}

--- a/Binance.Net.UnitTests/Endpoints/General/GiftCard/RedeemGiftCard.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/GiftCard/RedeemGiftCard.txt
@@ -1,0 +1,14 @@
+POST
+/sapi/v1/giftcard/redeemCode
+true
+{
+  "code":"000000",
+  "message":"success",
+  "data":{
+    "referenceNo":"0033002328060227",
+    "identityNo":"10317392647411060736",
+    "token":"BNB",
+    "amount":"0.00000001"
+  },
+  "success":true
+}

--- a/Binance.Net.UnitTests/Endpoints/General/GiftCard/VerifyGiftCardByNumber.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/GiftCard/VerifyGiftCardByNumber.txt
@@ -1,0 +1,13 @@
+GET
+/sapi/v1/giftcard/verify
+true
+{
+   "code": "000000",
+   "message": "success",
+   "data": {
+    "valid":true,  
+    "token":"BNB",
+    "amount":"0.00000001"
+  }, 
+  "success": true
+}

--- a/Binance.Net.UnitTests/RestRequestTests.cs
+++ b/Binance.Net.UnitTests/RestRequestTests.cs
@@ -505,6 +505,24 @@ namespace Binance.Net.UnitTests
             await tester.ValidateAsync(client => client.GeneralApi.Nft.GetNftAssetAsync(), "GetNftAsset");
         }
 
+        [Test]
+        public async Task ValidateGeneralGiftCardCalls()
+        {
+            var client = new BinanceRestClient(opts =>
+            {
+                opts.RateLimiterEnabled = false;
+                opts.AutoTimestamp = false;
+                opts.ApiCredentials = new CryptoExchange.Net.Authentication.ApiCredentials("123", "456");
+            });
+            var tester = new RestRequestValidator<BinanceRestClient>(client, "Endpoints/General/GiftCard", "https://api.binance.com", IsAuthenticated);
+            await tester.ValidateAsync(client => client.GeneralApi.GiftCard.CreateSingleTokenGiftCardAsync("BUSD", 1.002), "CreateSingleTokenGiftCard");
+            await tester.ValidateAsync(client => client.GeneralApi.GiftCard.CreateDualTokenGiftCardAsync("BUSD", "BNB", 1.002), "CreateDualTokenGiftCard");
+            await tester.ValidateAsync(client => client.GeneralApi.GiftCard.RedeemGiftCardAsync("6H9EKF5ECCWFBHGE", useEncryption: false), "RedeemGiftCard");
+            await tester.ValidateAsync(client => client.GeneralApi.GiftCard.VerifyGiftCardByNumberAsync("0033002144060553"), "VerifyGiftCardByNumber");
+            await tester.ValidateAsync(client => client.GeneralApi.GiftCard.GetTokenLimitAsync("BUSD"), "GetTokenLimit");
+            await tester.ValidateAsync(client => client.GeneralApi.GiftCard.GetRsaPublicKeyAsync(), "GetRsaPublicKey");
+        }
+
         private bool IsAuthenticated(WebCallResult result)
         {
             return result.RequestUrl?.Contains("signature") == true || result.RequestBody?.Contains("signature=") == true;

--- a/Binance.Net/Binance.Net.xml
+++ b/Binance.Net/Binance.Net.xml
@@ -6713,7 +6713,7 @@
             Defines the source generated JSON serialization contract metadata for a given type.
             </summary>
         </member>
-        <member name="P:Binance.Net.Converters.BinanceSourceGenerationContext.BinanceGiftCardResponseBinanceGiftCardTokenLimit">
+        <member name="P:Binance.Net.Converters.BinanceSourceGenerationContext.BinanceGiftCardResponseBinanceGiftCardTokenLimitArray">
             <summary>
             Defines the source generated JSON serialization contract metadata for a given type.
             </summary>
@@ -6729,6 +6729,11 @@
             </summary>
         </member>
         <member name="P:Binance.Net.Converters.BinanceSourceGenerationContext.BinanceGiftCardTokenLimit">
+            <summary>
+            Defines the source generated JSON serialization contract metadata for a given type.
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Converters.BinanceSourceGenerationContext.BinanceGiftCardTokenLimitArray">
             <summary>
             Defines the source generated JSON serialization contract metadata for a given type.
             </summary>

--- a/Binance.Net/Clients/GeneralApi/BinanceRestClientGeneralApiGiftCard.cs
+++ b/Binance.Net/Clients/GeneralApi/BinanceRestClientGeneralApiGiftCard.cs
@@ -113,14 +113,14 @@ namespace Binance.Net.Clients.GeneralApi
         #region Fetch Token Limit
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BinanceGiftCardResponse<BinanceGiftCardTokenLimit>>> GetTokenLimitAsync(string baseToken, long? receiveWindow = null, CancellationToken ct = default)
+        public async Task<WebCallResult<BinanceGiftCardResponse<BinanceGiftCardTokenLimit[]>>> GetTokenLimitAsync(string baseToken, long? receiveWindow = null, CancellationToken ct = default)
         {
             var parameters = new ParameterCollection();
             parameters.Add("baseToken", baseToken);
             parameters.AddOptionalString("recvWindow", receiveWindow ?? (long)_baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds);
 
             var request = _definitions.GetOrCreate(HttpMethod.Get, "sapi/v1/giftcard/buyCode/token-limit", BinanceExchange.RateLimiter.SpotRestIp, 1, true);
-            return await _baseClient.SendAsync<BinanceGiftCardResponse<BinanceGiftCardTokenLimit>>(request, parameters, ct).ConfigureAwait(false);
+            return await _baseClient.SendAsync<BinanceGiftCardResponse<BinanceGiftCardTokenLimit[]>>(request, parameters, ct).ConfigureAwait(false);
         }
 
         #endregion

--- a/Binance.Net/Converters/BinanceSourceGenerationContext.cs
+++ b/Binance.Net/Converters/BinanceSourceGenerationContext.cs
@@ -20,7 +20,7 @@ namespace Binance.Net.Converters
     [JsonSerializable(typeof(BinanceGiftCardResponse<BinaceGiftCardData>))]
     [JsonSerializable(typeof(BinanceGiftCardResponse<BinanceGiftCardRedeemData>))]
     [JsonSerializable(typeof(BinanceGiftCardResponse<BinanceGiftCardValidity>))]
-    [JsonSerializable(typeof(BinanceGiftCardResponse<BinanceGiftCardTokenLimit>))]
+    [JsonSerializable(typeof(BinanceGiftCardResponse<BinanceGiftCardTokenLimit[]>))]
     [JsonSerializable(typeof(BinanceGiftCardResponse<string>))]
 
     [JsonSerializable(typeof(Dictionary<string, BinanceAssetDetails>))]

--- a/Binance.Net/Interfaces/Clients/GeneralApi/IBinanceRestClientGeneralApiGiftCard.cs
+++ b/Binance.Net/Interfaces/Clients/GeneralApi/IBinanceRestClientGeneralApiGiftCard.cs
@@ -64,7 +64,7 @@ namespace Binance.Net.Interfaces.Clients.GeneralApi
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
         
-        Task<WebCallResult<BinanceGiftCardResponse<BinanceGiftCardTokenLimit>>> GetTokenLimitAsync(string baseToken, long? receiveWindow = null, CancellationToken ct = default);
+        Task<WebCallResult<BinanceGiftCardResponse<BinanceGiftCardTokenLimit[]>>> GetTokenLimitAsync(string baseToken, long? receiveWindow = null, CancellationToken ct = default);
         
         /// <summary>
         /// Get RSA public key


### PR DESCRIPTION
## Added tests for the Gift Card API and fixed a response mapping issue. 
### Added test for endpoints:
- `POST /sapi/v1/giftcard/createCode`
- `POST /sapi/v1/giftcard/buyCode`
- `POST /sapi/v1/giftcard/redeemCode`
- `GET  /sapi/v1/giftcard/verify`
- `GET  /sapi/v1/giftcard/buyCode/token-limit`
- `GET  /sapi/v1/giftcard/cryptography/rsa-public-key`

### Fixed mapping Issue
While adding tests, a mapping issue was found in the `GetTokenLimitAsync` method, it was deserializing the response as a single object `BinanceGiftCardTokenLimit` instead of an array `BinanceGiftCardTokenLimit[]`. The response type has been corrected to handle array of items as returned by the API.

### Note (question) on T[] and IEnumerable<T>:
In apis that I implement I am trying to use `IEnumerable<T>`, but I noticed that `SourceGenerationContext` does only contain `T[]` and that some newer apis also use `T[]` instead of `IEnumerable<T>`.

Which approach is preferred?
