### PR TITLE
Updated SimpleEarn API to match latest Binance API; Added SimpleEarn Tests

### DIFF
--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetAccount.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetAccount.txt
@@ -1,0 +1,11 @@
+GET
+/sapi/v1/simple-earn/account
+true
+{
+  "totalAmountInBTC": "0.01067982",
+  "totalAmountInUSDT": "77.13289230",
+  "totalFlexibleAmountInBTC": "0.00000000",
+  "totalFlexibleAmountInUSDT": "0.00000000",
+  "totalLockedInBTC": "0.01067982",
+  "totalLockedInUSDT": "77.13289230"
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetCollateralRecords.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetCollateralRecords.txt
@@ -1,0 +1,17 @@
+GET
+/sapi/v1/simple-earn/flexible/history/collateralRecord
+true
+{
+  "rows": [
+    {
+      "amount": "100.00000000",
+      "productId": "BUSD001",
+      "asset": "USDT",
+      "createTime": 1575018510000,
+      "type": "REPAY",
+      "productName": "USDT",
+      "orderId": 26055
+    }
+  ],
+  "total": "1"
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetFlexiblePersonalQuotaLeft.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetFlexiblePersonalQuotaLeft.txt
@@ -1,0 +1,6 @@
+GET
+/sapi/v1/simple-earn/flexible/personalLeftQuota
+true
+{
+  "leftPersonalQuota": "1000"
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetFlexibleProductPositions.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetFlexibleProductPositions.txt
@@ -1,0 +1,27 @@
+GET
+/sapi/v1/simple-earn/flexible/position
+true
+{
+  "rows":[
+    {
+      "totalAmount": "75.46000000",
+      "tierAnnualPercentageRate": {
+        "0-5BTC": 0.05,
+        "5-10BTC": 0.03
+      },
+      "latestAnnualPercentageRate": "0.02599895",
+      "yesterdayAirdropPercentageRate": "0.02599895",
+      "asset": "USDT",
+      "airDropAsset": "BETH",
+      "canRedeem": true,
+      "collateralAmount": "232.23123213",
+      "productId": "USDT001",
+      "yesterdayRealTimeRewards": "0.10293829",
+      "cumulativeBonusRewards": "0.22759183",
+      "cumulativeRealTimeRewards": "0.22759183",
+      "cumulativeTotalRewards": "0.45459183",
+      "autoSubscribe": true
+    }
+  ],
+  "total": 1
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetFlexibleProducts.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetFlexibleProducts.txt
@@ -1,0 +1,25 @@
+GET
+/sapi/v1/simple-earn/flexible/list
+true
+{
+  "rows":[
+    {
+      "asset": "BTC",
+      "latestAnnualPercentageRate": "0.05000000",
+      "tierAnnualPercentageRate": {
+        "0-5BTC": 0.05,
+        "5-10BTC": 0.03
+      },
+      "airDropPercentageRate": "0.05000000",
+      "canPurchase": true,
+      "canRedeem": true,
+      "isSoldOut": true,
+      "hot": true,
+      "minPurchaseAmount": "0.01000000",
+      "productId": "BTC001",
+      "subscriptionStartTime": "1646182276000",
+      "status": "PURCHASING"
+    }
+  ],
+  "total": 1
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetFlexibleRedemptionRecords.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetFlexibleRedemptionRecords.txt
@@ -1,0 +1,17 @@
+GET
+/sapi/v1/simple-earn/flexible/history/redemptionRecord
+true
+{
+  "rows": [
+    {
+      "amount": "10.54000000",
+      "asset": "USDT",
+      "time": 1577257222000,
+      "projectId": "USDT001",
+      "redeemId": 40607,
+      "destAccount":"SPOT",
+      "status": "PAID"
+    }
+  ],
+  "total": 1
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetFlexibleRewardRecords.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetFlexibleRewardRecords.txt
@@ -1,0 +1,22 @@
+GET
+/sapi/v1/simple-earn/flexible/history/rewardsRecord
+true
+{
+  "rows": [
+    {
+      "asset": "BUSD",
+      "rewards": "0.00006408",
+      "projectId": "USDT001",
+      "type": "BONUS",
+      "time": 1577233578000
+    },
+    {
+      "asset": "USDT",
+      "rewards": "0.00687654",
+      "projectId": "USDT001",
+      "type": "REALTIME",
+      "time": 1577233562000
+    }
+  ],
+  "total": 2
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetFlexibleSubscriptionPreview.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetFlexibleSubscriptionPreview.txt
@@ -1,0 +1,11 @@
+GET
+/sapi/v1/simple-earn/flexible/subscriptionPreview
+true
+{
+  "totalAmount": "1232.32230982",
+  "rewardAsset": "BUSD",
+  "airDropAsset": "BETH",
+  "estDailyBonusRewards": "0.22759183",
+  "estDailyRealTimeRewards": "0.22759183",
+  "estDailyAirdropRewards": "0.22759183"
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetFlexibleSubscriptionRecords.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetFlexibleSubscriptionRecords.txt
@@ -1,0 +1,20 @@
+GET
+/sapi/v1/simple-earn/flexible/history/subscriptionRecord
+true
+{
+  "rows": [
+    {
+      "amount": "100.00000000",
+      "asset": "USDT",
+      "time": 1575018510000,
+      "purchaseId": 26055,
+      "productId": "USDT001",
+      "type": "AUTO",
+      "sourceAccount": "SPOT",
+      "amtFromSpot": "30",
+      "amtFromFunding": "70",
+      "status": "SUCCESS"
+    }
+  ],
+  "total": 1
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetLockedPersonalQuotaLeft.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetLockedPersonalQuotaLeft.txt
@@ -1,0 +1,6 @@
+GET
+/sapi/v1/simple-earn/locked/personalLeftQuota
+true
+{
+  "leftPersonalQuota": "1000"
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetLockedProductPositions.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetLockedProductPositions.txt
@@ -1,0 +1,43 @@
+GET
+/sapi/v1/simple-earn/locked/position
+true
+{
+  "rows": [
+    {
+      "positionId": 123123,
+      "parentPositionId": 123122,
+      "projectId": "Axs*90",
+      "asset": "AXS",
+      "amount": "122.09202928",
+      "purchaseTime": "1646182276000",
+      "duration": "60",
+      "accrualDays": "4",
+      "rewardAsset": "AXS",
+      "APY": "0.2032",
+      "rewardAmt": "5.17181528",
+      "extraRewardAsset": "BNB",
+      "extraRewardAPR": "0.0203",
+      "estExtraRewardAmt": "5.17181528",
+      "boostRewardAsset": "AXS",
+      "boostApr": "0.0121",
+      "totalBoostRewardAmt": "3.98201829",
+      "nextPay": "1.29295383",
+      "nextPayDate": "1646697600000",
+      "payPeriod": "1",
+      "redeemAmountEarly": "2802.24068892",
+      "rewardsEndDate": "1651449600000",
+      "deliverDate": "1651536000000",
+      "redeemPeriod": "1",
+      "redeemingAmt": "232.2323",
+      "redeemTo": "FLEXIBLE",
+      "partialAmtDeliverDate": "1651536000000",
+      "canRedeemEarly": true,
+      "canFastRedemption": true,
+      "autoSubscribe": true,
+      "type": "AUTO",
+      "status": "HOLDING",
+      "canReStake": true
+    }
+  ],
+  "total": 1
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetLockedProducts.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetLockedProducts.txt
@@ -1,0 +1,30 @@
+GET
+/sapi/v1/simple-earn/locked/list
+true
+{
+  "rows": [
+    {
+      "projectId": "Axs*90",
+      "detail": {
+        "asset": "AXS",
+        "rewardAsset": "AXS",
+        "duration": 90,
+        "renewable": true,
+        "isSoldOut": true,
+        "apr": "1.2069",
+        "status": "CREATED",
+        "subscriptionStartTime": "1646182276000",
+        "extraRewardAsset": "BNB",
+        "extraRewardAPR": "0.23",
+        "boostRewardAsset": "AXS",
+        "boostApr": "0.0121",
+        "boostEndTime": "1646182276000"
+      },
+      "quota": {
+        "totalPersonalQuota": "2",
+        "minimum": "0.001"
+      }
+    }
+  ],
+  "total": 1
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetLockedRedemptionRecords.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetLockedRedemptionRecords.txt
@@ -1,0 +1,26 @@
+GET
+/sapi/v1/simple-earn/locked/history/redemptionRecord
+true
+{
+  "rows": [
+    {
+      "positionId": 123123,
+      "redeemId": 40607,
+      "time": 1575018510000,
+      "asset": "BNB",
+      "lockPeriod": "30",
+      "amount": "21312.23223",
+      "originalAmount": "21312.23223",
+      "type": "MATURE",
+      "deliverDate": "1575018510000",
+      "lossAmount": "0.00001232",
+      "isComplete":true,
+      "rewardAsset":"AXS",
+      "rewardAmt": "5.17181528",
+      "extraRewardAsset":"BNB",
+      "estExtraRewardAmt": "5.17181528",
+      "status": "PAID"
+    }
+  ],
+  "total": 1
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetLockedRewardRecords.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetLockedRewardRecords.txt
@@ -1,0 +1,23 @@
+GET
+/sapi/v1/simple-earn/locked/history/rewardsRecord
+true
+{
+  "rows": [
+    {
+      "positionId": 123123,
+      "time": 1575018510000,
+      "asset": "BNB",
+      "lockPeriod": "30",
+      "amount": "21312.23223",
+      "type":"Locked Rewards"
+    },
+    {
+      "positionId": 123123,
+      "time":1575018510000,
+      "asset":"BNB",
+      "amount":"1.23223",
+      "type":"Boost Rewards"
+     }
+  ],
+  "total": 1
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetLockedSubscriptionPreview.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetLockedSubscriptionPreview.txt
@@ -1,0 +1,19 @@
+GET
+/sapi/v1/simple-earn/locked/subscriptionPreview
+true
+[
+  {
+    "rewardAsset": "AXS",
+    "totalRewardAmt": "5.17181528",
+    "extraRewardAsset": "BNB",
+    "estTotalExtraRewardAmt": "5.17181528",
+    "boostRewardAsset": "AXS",
+    "estDailyRewardAmt": "1.20928901",
+    "nextPay": "1.29295383",
+    "nextPayDate": "1646697600000",
+    "valueDate": "1646697600000",
+    "rewardsEndDate": "1651449600000",
+    "deliverDate": "1651536000000",
+    "nextSubscriptionDate": "1651536000000"
+  }
+]

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetLockedSubscriptionRecords.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetLockedSubscriptionRecords.txt
@@ -1,0 +1,22 @@
+GET
+/sapi/v1/simple-earn/locked/history/subscriptionRecord
+true
+{
+  "rows":[
+    {
+      "positionId": 123123,
+      "purchaseId": "26055",
+      "projectId": "Axs*90",
+      "time": 1575018510000,
+      "asset": "BNB",
+      "amount": "21312.23223",
+      "lockPeriod": "30",
+      "type": "AUTO",
+      "sourceAccount": "SPOT",
+      "amtFromSpot": "30",
+      "amtFromFunding": "70",
+      "status": "SUCCESS"
+    }
+  ],
+  "total": 1
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetRateHistory.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/GetRateHistory.txt
@@ -1,0 +1,14 @@
+GET
+/sapi/v1/simple-earn/flexible/history/rateHistory
+true
+{
+  "rows": [
+    {
+      "productId": "BUSD001",
+      "asset": "BUSD",
+      "annualPercentageRate": "0.00006408",
+      "time": 1577233578000
+    }
+  ],
+  "total": "1"
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/RedeemFlexibleProduct.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/RedeemFlexibleProduct.txt
@@ -1,0 +1,7 @@
+POST
+/sapi/v1/simple-earn/flexible/redeem
+true
+{
+  "redeemId": 40607,
+  "success": true
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/RedeemLockedProduct.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/RedeemLockedProduct.txt
@@ -1,0 +1,7 @@
+POST
+/sapi/v1/simple-earn/locked/redeem
+true
+{
+  "redeemId": 40607,
+  "success": true
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/SetFlexibleAutoSubscribe.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/SetFlexibleAutoSubscribe.txt
@@ -1,0 +1,6 @@
+POST
+/sapi/v1/simple-earn/flexible/setAutoSubscribe
+true
+{
+  "success": true
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/SetLockedAutoSubscribe.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/SetLockedAutoSubscribe.txt
@@ -1,0 +1,6 @@
+POST
+/sapi/v1/simple-earn/locked/setAutoSubscribe
+true
+{
+  "success": true
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/SetLockedRedeemOption.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/SetLockedRedeemOption.txt
@@ -1,0 +1,6 @@
+POST
+/sapi/v1/simple-earn/locked/setRedeemOption
+true
+{
+  "success": true
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/SubscribeFlexibleProduct.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/SubscribeFlexibleProduct.txt
@@ -1,0 +1,7 @@
+POST
+/sapi/v1/simple-earn/flexible/subscribe
+true
+{
+  "purchaseId": 40607,
+  "success": true
+}

--- a/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/SubscribeLockedProduct.txt
+++ b/Binance.Net.UnitTests/Endpoints/General/SimpleEarn/SubscribeLockedProduct.txt
@@ -1,0 +1,8 @@
+POST
+/sapi/v1/simple-earn/locked/subscribe
+true
+{
+  "purchaseId": 40607,
+  "positionId": "12345",
+  "success": true
+}

--- a/Binance.Net.UnitTests/RestRequestTests.cs
+++ b/Binance.Net.UnitTests/RestRequestTests.cs
@@ -1,4 +1,5 @@
 ﻿using Binance.Net.Clients;
+using Binance.Net.Enums;
 using Binance.Net.Interfaces;
 using Binance.Net.Objects.Models.Futures;
 using Binance.Net.Objects.Models.Spot;
@@ -503,6 +504,42 @@ namespace Binance.Net.UnitTests
             await tester.ValidateAsync(client => client.GeneralApi.Nft.GetNftWithdrawHistoryAsync(), "GetNftWithdrawHistory");
             await tester.ValidateAsync(client => client.GeneralApi.Nft.GetNftTransactionHistoryAsync(Enums.NftOrderType.PurchaseOrder), "GetNftTransactionHistory");
             await tester.ValidateAsync(client => client.GeneralApi.Nft.GetNftAssetAsync(), "GetNftAsset");
+        }
+
+        [Test]
+        public async Task ValidateGeneralSimpleEarnCalls()
+        {
+            var client = new BinanceRestClient(opts =>
+            {
+                opts.RateLimiterEnabled = false;
+                opts.AutoTimestamp = false;
+                opts.ApiCredentials = new CryptoExchange.Net.Authentication.ApiCredentials("123", "456");
+            });
+            var tester = new RestRequestValidator<BinanceRestClient>(client, "Endpoints/General/SimpleEarn", "https://api.binance.com", IsAuthenticated);
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.GetAccountAsync(),"GetAccount");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.GetFlexibleProductsAsync(),"GetFlexibleProducts");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.GetLockedProductsAsync(),"GetLockedProducts");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.GetFlexibleProductPositionsAsync(),"GetFlexibleProductPositions");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.GetLockedProductPositionsAsync(),"GetLockedProductPositions");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.GetFlexiblePersonalQuotaLeftAsync("123"),"GetFlexiblePersonalQuotaLeft");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.GetLockedPersonalQuotaLeftAsync("123"),"GetLockedPersonalQuotaLeft");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.SubscribeFlexibleProductAsync("123", 1),"SubscribeFlexibleProduct");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.SubscribeLockedProductAsync("123", 1),"SubscribeLockedProduct");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.RedeemFlexibleProductAsync("123"),"RedeemFlexibleProduct");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.RedeemLockedProductAsync("123"),"RedeemLockedProduct");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.SetFlexibleAutoSubscribeAsync("123", true),"SetFlexibleAutoSubscribe");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.SetLockedAutoSubscribeAsync("123", true),"SetLockedAutoSubscribe");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.GetFlexibleSubscriptionPreviewAsync("123", 1),"GetFlexibleSubscriptionPreview");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.GetLockedSubscriptionPreviewAsync("123", 1),"GetLockedSubscriptionPreview");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.SetLockedRedeemOptionAsync("123", RedeemDestination.Flexible),"SetLockedRedeemOption");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.GetFlexibleSubscriptionRecordsAsync(),"GetFlexibleSubscriptionRecords");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.GetLockedSubscriptionRecordsAsync(),"GetLockedSubscriptionRecords");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.GetFlexibleRedemptionRecordsAsync(),"GetFlexibleRedemptionRecords");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.GetLockedRedemptionRecordsAsync(),"GetLockedRedemptionRecords");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.GetFlexibleRewardRecordsAsync(RewardType.All),"GetFlexibleRewardRecords");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.GetLockedRewardRecordsAsync(),"GetLockedRewardRecords");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.GetCollateralRecordsAsync("123"),"GetCollateralRecords");
+            await tester.ValidateAsync(client => client.GeneralApi.SimpleEarn.GetRateHistoryAsync("123"),"GetRateHistory");
         }
 
         private bool IsAuthenticated(WebCallResult result)

--- a/Binance.Net/Binance.Net.xml
+++ b/Binance.Net/Binance.Net.xml
@@ -1100,7 +1100,7 @@
         <member name="M:Binance.Net.Clients.GeneralApi.BinanceRestClientGeneralApiSimpleEarn.SubscribeFlexibleProductAsync(System.String,System.Decimal,System.Nullable{System.Boolean},System.Nullable{Binance.Net.Enums.AccountSource},System.Nullable{System.Int64},System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
-        <member name="M:Binance.Net.Clients.GeneralApi.BinanceRestClientGeneralApiSimpleEarn.SubscribeLockedProductAsync(System.String,System.Decimal,System.Nullable{System.Boolean},System.Nullable{Binance.Net.Enums.AccountSource},System.Nullable{System.Int64},System.Threading.CancellationToken)">
+        <member name="M:Binance.Net.Clients.GeneralApi.BinanceRestClientGeneralApiSimpleEarn.SubscribeLockedProductAsync(System.String,System.Decimal,System.Nullable{System.Boolean},System.Nullable{Binance.Net.Enums.AccountSource},System.Nullable{Binance.Net.Enums.RedeemDestination},System.Nullable{System.Int64},System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="M:Binance.Net.Clients.GeneralApi.BinanceRestClientGeneralApiSimpleEarn.RedeemFlexibleProductAsync(System.String,System.Nullable{System.Boolean},System.Nullable{System.Decimal},System.Nullable{Binance.Net.Enums.AccountSource},System.Nullable{System.Int64},System.Threading.CancellationToken)">
@@ -1152,6 +1152,9 @@
             <inheritdoc />
         </member>
         <member name="M:Binance.Net.Clients.GeneralApi.BinanceRestClientGeneralApiSimpleEarn.GetLockedSubscriptionPreviewAsync(System.String,System.Decimal,System.Nullable{System.Boolean},System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Binance.Net.Clients.GeneralApi.BinanceRestClientGeneralApiSimpleEarn.SetLockedRedeemOptionAsync(System.String,Binance.Net.Enums.RedeemDestination,System.Nullable{System.Int64},System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="M:Binance.Net.Clients.GeneralApi.BinanceRestClientGeneralApiSimpleEarn.GetRateHistoryAsync(System.String,System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Nullable{System.Int32},System.Nullable{System.Int64},System.Threading.CancellationToken)">
@@ -10757,6 +10760,21 @@
             Referral kickback
             </summary>
         </member>
+        <member name="T:Binance.Net.Enums.RedeemDestination">
+            <summary>
+            Simple earn redemption type
+            </summary>
+        </member>
+        <member name="F:Binance.Net.Enums.RedeemDestination.Spot">
+            <summary>
+            Redeem to spot account
+            </summary>
+        </member>
+        <member name="F:Binance.Net.Enums.RedeemDestination.Flexible">
+            <summary>
+            Redeem to flexible product
+            </summary>
+        </member>
         <member name="T:Binance.Net.Enums.RedemptionType">
             <summary>
             Simple earn redemption type
@@ -14331,7 +14349,7 @@
             <param name="ct">Cancellation token</param>
             <returns></returns>
         </member>
-        <member name="M:Binance.Net.Interfaces.Clients.GeneralApi.IBinanceRestClientGeneralApiSimpleEarn.SubscribeLockedProductAsync(System.String,System.Decimal,System.Nullable{System.Boolean},System.Nullable{Binance.Net.Enums.AccountSource},System.Nullable{System.Int64},System.Threading.CancellationToken)">
+        <member name="M:Binance.Net.Interfaces.Clients.GeneralApi.IBinanceRestClientGeneralApiSimpleEarn.SubscribeLockedProductAsync(System.String,System.Decimal,System.Nullable{System.Boolean},System.Nullable{Binance.Net.Enums.AccountSource},System.Nullable{Binance.Net.Enums.RedeemDestination},System.Nullable{System.Int64},System.Threading.CancellationToken)">
             <summary>
             Subscribe to locked product
             <para><a href="https://binance-docs.github.io/apidocs/spot/en/#subscribe-locked-product-trade" /></para>
@@ -14340,6 +14358,7 @@
             <param name="quantity">Quantity</param>
             <param name="autoSubscribe">Auto subscribe, default true</param>
             <param name="sourceAccount">Source account</param>
+            <param name="redeemDestination">Redeem destination, default "Flexible"</param>
             <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
             <param name="ct">Cancellation token</param>
             <returns></returns>
@@ -14558,6 +14577,17 @@
             <param name="projectId">Project id</param>
             <param name="quantity">Quantity</param>
             <param name="autoSubscribe">Auto subscribe</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.Clients.GeneralApi.IBinanceRestClientGeneralApiSimpleEarn.SetLockedRedeemOptionAsync(System.String,Binance.Net.Enums.RedeemDestination,System.Nullable{System.Int64},System.Threading.CancellationToken)">
+            <summary>
+            Set locked redeem option 
+            <para><a href="https://binance-docs.github.io/apidocs/spot/en/#set-locked-product-redeem-option" /></para>
+            </summary>
+            <param name="positionId">Position id</param>
+            <param name="redeemDestination">Account for redemption, SPOT or FLEXIBLE</param>
             <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
             <param name="ct">Cancellation token</param>
             <returns></returns>
@@ -30345,6 +30375,11 @@
             Purchase id
             </summary>
         </member>
+        <member name="P:Binance.Net.Objects.Models.Spot.SimpleEarn.BinanceSimpleEarnFlexibleRecord.ProductId">
+            <summary>
+            Product id
+            </summary>
+        </member>
         <member name="P:Binance.Net.Objects.Models.Spot.SimpleEarn.BinanceSimpleEarnFlexibleRecord.Type">
             <summary>
             Subscription type
@@ -30453,6 +30488,11 @@
         <member name="P:Binance.Net.Objects.Models.Spot.SimpleEarn.BinanceSimpleEarnLockedPosition.PositionId">
             <summary>
             Position id
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Spot.SimpleEarn.BinanceSimpleEarnLockedPosition.ParentPositionId">
+            <summary>
+            Parent Position id
             </summary>
         </member>
         <member name="P:Binance.Net.Objects.Models.Spot.SimpleEarn.BinanceSimpleEarnLockedPosition.ProjectId">
@@ -30820,6 +30860,11 @@
             Purchase id
             </summary>
         </member>
+        <member name="P:Binance.Net.Objects.Models.Spot.SimpleEarn.BinanceSimpleEarnLockedRecord.ProjectId">
+            <summary>
+            Purchase id
+            </summary>
+        </member>
         <member name="P:Binance.Net.Objects.Models.Spot.SimpleEarn.BinanceSimpleEarnLockedRecord.Type">
             <summary>
             Subscription type
@@ -30860,9 +30905,44 @@
             Quantity
             </summary>
         </member>
+        <member name="P:Binance.Net.Objects.Models.Spot.SimpleEarn.BinanceSimpleEarnLockedRedemptionRecord.OriginalQuantity">
+            <summary>
+            Original quantity 
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Spot.SimpleEarn.BinanceSimpleEarnLockedRedemptionRecord.LossQuantity">
+            <summary>
+            Loss quantity 
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Spot.SimpleEarn.BinanceSimpleEarnLockedRedemptionRecord.Complete">
+            <summary>
+            Is complete 
+            </summary>
+        </member>
         <member name="P:Binance.Net.Objects.Models.Spot.SimpleEarn.BinanceSimpleEarnLockedRedemptionRecord.Asset">
             <summary>
             Asset
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Spot.SimpleEarn.BinanceSimpleEarnLockedRedemptionRecord.RewardAsset">
+            <summary>
+            Reward asset
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Spot.SimpleEarn.BinanceSimpleEarnLockedRedemptionRecord.RewardAmt">
+            <summary>
+            Reward amt 
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Spot.SimpleEarn.BinanceSimpleEarnLockedRedemptionRecord.extraRewardAsset">
+            <summary>
+            Extra reward asset
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Spot.SimpleEarn.BinanceSimpleEarnLockedRedemptionRecord.EstimateExtraRewardAmt">
+            <summary>
+            Estimate extra reward asset
             </summary>
         </member>
         <member name="P:Binance.Net.Objects.Models.Spot.SimpleEarn.BinanceSimpleEarnLockedRedemptionRecord.Timestamp">

--- a/Binance.Net/Clients/GeneralApi/BinanceRestClientGeneralApiSimpleEarn.cs
+++ b/Binance.Net/Clients/GeneralApi/BinanceRestClientGeneralApiSimpleEarn.cs
@@ -75,7 +75,7 @@ namespace Binance.Net.Clients.GeneralApi
         #region Subscribe Locked Product
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BinanceSimpleEarnPurchase>> SubscribeLockedProductAsync(string projectId, decimal quantity, bool? autoSubscribe = null, AccountSource? sourceAccount = null, long? receiveWindow = null, CancellationToken ct = default)
+        public async Task<WebCallResult<BinanceSimpleEarnPurchase>> SubscribeLockedProductAsync(string projectId, decimal quantity, bool? autoSubscribe = null, AccountSource? sourceAccount = null, RedeemDestination? redeemDestination = null, long? receiveWindow = null, CancellationToken ct = default)
         {
             var parameters = new ParameterCollection()
             {
@@ -84,6 +84,7 @@ namespace Binance.Net.Clients.GeneralApi
             };
             parameters.AddOptional("autoSubscribe", autoSubscribe);
             parameters.AddOptionalEnum("sourceAccount", sourceAccount);
+            parameters.AddOptionalEnum("redeemTo", redeemDestination);
             parameters.AddOptionalString("recvWindow", receiveWindow ?? (long)_baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds);
 
             var request = _definitions.GetOrCreate(HttpMethod.Post, "sapi/v1/simple-earn/locked/subscribe", BinanceExchange.RateLimiter.EndpointLimit, 1, true,
@@ -410,6 +411,24 @@ namespace Binance.Net.Clients.GeneralApi
 
             var request = _definitions.GetOrCreate(HttpMethod.Get, "sapi/v1/simple-earn/locked/subscriptionPreview", BinanceExchange.RateLimiter.SpotRestIp, 150, true);
             return await _baseClient.SendAsync<BinanceSimpleEarnLockedPreview[]>(request, parameters, ct).ConfigureAwait(false);
+        }
+
+        #endregion
+
+        #region Set Locked Redeem Option
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<BinanceSimpleEarnResult>> SetLockedRedeemOptionAsync(string positionId, RedeemDestination redeemDestination, long? receiveWindow = null, CancellationToken ct = default)
+        {
+            var parameters = new ParameterCollection
+            {
+                { "positionId", positionId },
+                { "redeemTo", redeemDestination }
+            };
+            parameters.AddOptionalString("recvWindow", receiveWindow ?? (long)_baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds);
+
+            var request = _definitions.GetOrCreate(HttpMethod.Post, "sapi/v1/simple-earn/locked/setRedeemOption", BinanceExchange.RateLimiter.SpotRestIp, 50, true);
+            return await _baseClient.SendAsync<BinanceSimpleEarnResult>(request, parameters, ct).ConfigureAwait(false);
         }
 
         #endregion

--- a/Binance.Net/Clients/GeneralApi/BinanceRestClientGeneralApiSimpleEarn.cs
+++ b/Binance.Net/Clients/GeneralApi/BinanceRestClientGeneralApiSimpleEarn.cs
@@ -436,10 +436,11 @@ namespace Binance.Net.Clients.GeneralApi
         #region Get Rate History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BinanceQueryRecords<BinanceSimpleEarnRateRecord>>> GetRateHistoryAsync(string productId, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, long? receiveWindow = null, CancellationToken ct = default)
+        public async Task<WebCallResult<BinanceQueryRecords<BinanceSimpleEarnRateRecord>>> GetRateHistoryAsync(string productId, AprPeriod? aprPeriod = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, long? receiveWindow = null, CancellationToken ct = default)
         {
             var parameters = new ParameterCollection();
             parameters.AddOptional("productId", productId);
+            parameters.AddOptionalEnum("aprPeriod", aprPeriod);
             parameters.AddOptionalMilliseconds("startTime", startTime);
             parameters.AddOptionalMilliseconds("endTime", endTime);
             parameters.AddOptional("current", page);

--- a/Binance.Net/Enums/AprPeriod.cs
+++ b/Binance.Net/Enums/AprPeriod.cs
@@ -1,0 +1,23 @@
+﻿using Binance.Net.Converters;
+using CryptoExchange.Net.Attributes;
+
+namespace Binance.Net.Enums
+{
+    /// <summary>
+    /// Apr period
+    /// </summary>
+    [JsonConverter(typeof(EnumConverter<AprPeriod>))]
+    public enum AprPeriod
+    {
+        /// <summary>
+        /// Year
+        /// </summary>
+        [Map("YEAR")]
+        Year,
+        /// <summary>
+        /// Day
+        /// </summary>
+        [Map("DAY")]
+        Day
+    }
+}

--- a/Binance.Net/Enums/RedeemDestination.cs
+++ b/Binance.Net/Enums/RedeemDestination.cs
@@ -1,0 +1,23 @@
+﻿using Binance.Net.Converters;
+using CryptoExchange.Net.Attributes;
+
+namespace Binance.Net.Enums
+{
+    /// <summary>
+    /// Simple earn redemption type
+    /// </summary>
+    [JsonConverter(typeof(EnumConverter<RedeemDestination>))]
+    public enum RedeemDestination
+    {
+        /// <summary>
+        /// Redeem to spot account
+        /// </summary>
+        [Map("SPOT")]
+        Spot,
+        /// <summary>
+        /// Redeem to flexible product
+        /// </summary>
+        [Map("FLEXIBLE")]
+        Flexible,
+    }
+}

--- a/Binance.Net/Interfaces/Clients/GeneralApi/IBinanceRestClientGeneralApiSimpleEarn.cs
+++ b/Binance.Net/Interfaces/Clients/GeneralApi/IBinanceRestClientGeneralApiSimpleEarn.cs
@@ -54,10 +54,11 @@ namespace Binance.Net.Interfaces.Clients.GeneralApi
         /// <param name="quantity">Quantity</param>
         /// <param name="autoSubscribe">Auto subscribe, default true</param>
         /// <param name="sourceAccount">Source account</param>
+        /// <param name="redeemDestination">Redeem destination, default "Flexible"</param>
         /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BinanceSimpleEarnPurchase>> SubscribeLockedProductAsync(string projectId, decimal quantity, bool? autoSubscribe = null, AccountSource? sourceAccount = null, long? receiveWindow = null, CancellationToken ct = default);
+        Task<WebCallResult<BinanceSimpleEarnPurchase>> SubscribeLockedProductAsync(string projectId, decimal quantity, bool? autoSubscribe = null, AccountSource? sourceAccount = null, RedeemDestination? redeemDestination = null, long? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
         /// Redeem flexible product
@@ -276,6 +277,17 @@ namespace Binance.Net.Interfaces.Clients.GeneralApi
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
         Task<WebCallResult<BinanceSimpleEarnLockedPreview[]>> GetLockedSubscriptionPreviewAsync(string projectId, decimal quantity, bool? autoSubscribe = null, long? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Set locked redeem option 
+        /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#set-locked-product-redeem-option" /></para>
+        /// </summary>
+        /// <param name="positionId">Position id</param>
+        /// <param name="redeemDestination">Account for redemption, SPOT or FLEXIBLE</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<WebCallResult<BinanceSimpleEarnResult>> SetLockedRedeemOptionAsync(string positionId, RedeemDestination redeemDestination, long? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get rate history

--- a/Binance.Net/Interfaces/Clients/GeneralApi/IBinanceRestClientGeneralApiSimpleEarn.cs
+++ b/Binance.Net/Interfaces/Clients/GeneralApi/IBinanceRestClientGeneralApiSimpleEarn.cs
@@ -294,6 +294,7 @@ namespace Binance.Net.Interfaces.Clients.GeneralApi
         /// <para><a href="https://binance-docs.github.io/apidocs/spot/en/#get-rate-history-user_data" /></para>
         /// </summary>
         /// <param name="productId">Product id</param>
+        /// <param name="aprPeriod">APR period</param>
         /// <param name="startTime">Filter by start time</param>
         /// <param name="endTime">Filter by end time</param>
         /// <param name="page">Current page</param>
@@ -301,7 +302,7 @@ namespace Binance.Net.Interfaces.Clients.GeneralApi
         /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BinanceQueryRecords<BinanceSimpleEarnRateRecord>>> GetRateHistoryAsync(string productId, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, long? receiveWindow = null, CancellationToken ct = default);
+        Task<WebCallResult<BinanceQueryRecords<BinanceSimpleEarnRateRecord>>> GetRateHistoryAsync(string productId, AprPeriod? aprPeriod = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, long? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get collateral records

--- a/Binance.Net/Objects/Models/Spot/SimpleEarn/BinanceSimpleEarnFlexibleRecord.cs
+++ b/Binance.Net/Objects/Models/Spot/SimpleEarn/BinanceSimpleEarnFlexibleRecord.cs
@@ -30,6 +30,11 @@ namespace Binance.Net.Objects.Models.Spot.SimpleEarn
         [JsonPropertyName("purchaseId")]
         public long PurchaseId { get; set; }
         /// <summary>
+        /// Product id
+        /// </summary>
+        [JsonPropertyName("productId")]
+        public string ProductId { get; set; } = string.Empty;
+        /// <summary>
         /// Subscription type
         /// </summary>
         [JsonPropertyName("type")]

--- a/Binance.Net/Objects/Models/Spot/SimpleEarn/BinanceSimpleEarnLockedPosition.cs
+++ b/Binance.Net/Objects/Models/Spot/SimpleEarn/BinanceSimpleEarnLockedPosition.cs
@@ -17,6 +17,11 @@
         [JsonPropertyName("positionId"), JsonConverter(typeof(NumberStringConverter))]
         public string PositionId { get; set; } = string.Empty;
         /// <summary>
+        /// Parent Position id
+        /// </summary>
+        [JsonPropertyName("parentPositionId"), JsonConverter(typeof(NumberStringConverter))]
+        public string ParentPositionId { get; set; } = string.Empty;
+        /// <summary>
         /// Project id
         /// </summary>
         [JsonPropertyName("projectId")]

--- a/Binance.Net/Objects/Models/Spot/SimpleEarn/BinanceSimpleEarnLockedRecord.cs
+++ b/Binance.Net/Objects/Models/Spot/SimpleEarn/BinanceSimpleEarnLockedRecord.cs
@@ -22,7 +22,7 @@ namespace Binance.Net.Objects.Models.Spot.SimpleEarn
         /// <summary>
         /// Position id
         /// </summary>
-        [JsonPropertyName("positionId")]
+        [JsonPropertyName("positionId"), JsonConverter(typeof(NumberStringConverter))]
         public string PositionId { get; set; } = string.Empty;
         /// <summary>
         /// Timestamp
@@ -34,6 +34,11 @@ namespace Binance.Net.Objects.Models.Spot.SimpleEarn
         /// </summary>
         [JsonPropertyName("purchaseId")]
         public long PurchaseId { get; set; }
+        /// <summary>
+        /// Purchase id
+        /// </summary>
+        [JsonPropertyName("projectId")]
+        public string ProjectId { get; set; } = string.Empty;
         /// <summary>
         /// Subscription type
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/SimpleEarn/BinanceSimpleEarnLockedRedemptionRecord.cs
+++ b/Binance.Net/Objects/Models/Spot/SimpleEarn/BinanceSimpleEarnLockedRedemptionRecord.cs
@@ -15,10 +15,45 @@ namespace Binance.Net.Objects.Models.Spot.SimpleEarn
         [JsonPropertyName("amount")]
         public decimal Quantity { get; set; }
         /// <summary>
+        /// Original quantity 
+        /// </summary>
+        [JsonPropertyName("originalAmount")]
+        public decimal OriginalQuantity { get; set; }
+        /// <summary>
+        /// Loss quantity 
+        /// </summary>
+        [JsonPropertyName("lossAmount")]
+        public decimal LossQuantity { get; set; }
+        /// <summary>
+        /// Is complete 
+        /// </summary>
+        [JsonPropertyName("isComplete")]
+        public bool Complete { get; set; }
+        /// <summary>
         /// Asset
         /// </summary>
         [JsonPropertyName("asset")]
         public string Asset { get; set; } = string.Empty;
+        /// <summary>
+        /// Reward asset
+        /// </summary>
+        [JsonPropertyName("rewardAsset")]
+        public string RewardAsset { get; set; } = string.Empty;
+        /// <summary>
+        /// Reward amt 
+        /// </summary>
+        [JsonPropertyName("rewardAmt")]
+        public decimal RewardAmt { get; set; }
+        /// <summary>
+        /// Extra reward asset
+        /// </summary>
+        [JsonPropertyName("extraRewardAsset")]
+        public string extraRewardAsset { get; set; } = string.Empty;
+        /// <summary>
+        /// Estimate extra reward asset
+        /// </summary>
+        [JsonPropertyName("estExtraRewardAmt")]
+        public decimal EstimateExtraRewardAmt { get; set; }
         /// <summary>
         /// Timestamp
         /// </summary>
@@ -27,7 +62,7 @@ namespace Binance.Net.Objects.Models.Spot.SimpleEarn
         /// <summary>
         /// Position id
         /// </summary>
-        [JsonPropertyName("positionId")]
+        [JsonPropertyName("positionId"), JsonConverter(typeof(NumberStringConverter))]
         public string PositionId { get; set; } = string.Empty;
         /// <summary>
         /// Redeem id


### PR DESCRIPTION
### Added Tests to SimpleEarn Api endpoints:
- `GET /sapi/v1/simple-earn/account`
- `GET /sapi/v1/simple-earn/flexible/list`
- `GET /sapi/v1/simple-earn/locked/list`
- `GET /sapi/v1/simple-earn/flexible/position`
- `GET /sapi/v1/simple-earn/locked/position`
- `GET /sapi/v1/simple-earn/flexible/personalLeftQuota`
- `GET /sapi/v1/simple-earn/locked/personalLeftQuota`
- `POST /sapi/v1/simple-earn/flexible/subscribe`
- `POST /sapi/v1/simple-earn/locked/subscribe`
- `POST /sapi/v1/simple-earn/flexible/redeem`
- `POST /sapi/v1/simple-earn/locked/redeem`
- `POST /sapi/v1/simple-earn/flexible/setAutoSubscribe`
- `POST /sapi/v1/simple-earn/locked/setAutoSubscribe`
- `GET /sapi/v1/simple-earn/flexible/subscriptionPreview`
- `GET /sapi/v1/simple-earn/locked/subscriptionPreview`
- `POST /sapi/v1/simple-earn/locked/setRedeemOption`
- `GET /sapi/v1/simple-earn/flexible/history/subscriptionRecord`
- `GET /sapi/v1/simple-earn/locked/history/subscriptionRecord`
- `GET /sapi/v1/simple-earn/flexible/history/redemptionRecord`
- `GET /sapi/v1/simple-earn/locked/history/redemptionRecord`
- `GET /sapi/v1/simple-earn/flexible/history/rewardsRecord`
- `GET /sapi/v1/simple-earn/locked/history/rewardsRecord`
- `GET /sapi/v1/simple-earn/flexible/history/collateralRecord`
- `GET /sapi/v1/simple-earn/flexible/history/rateHistory`

## Added Endpoint Support
- `POST /sapi/v1/simple-earn/locked/setRedeemOption`

## Api Updates:
- **Added Enums**:
    - `RedeemDestination`
    - `AprPeriod`
- **Updated Existing Methods**:
    - `GetRateHistoryAsync` – added `aprPeriod` parameter
    - `SubscribeLockedProductAsync` – added `redeemDestination` parameter

## Models Changed
### `BinanceSimpleEarnLockedRedemptionRecord`
- **Added missing fields:**
  - `originalAmount`
  - `lossAmount`
  - `isComplete`
  - `rewardAsset`
  - `rewardAmt`
  - `extraRewardAsset`
  - `extraRewardAmt`
- **Fixed issue:** Added `JsonConverter(typeof(NumberStringConverter))` to `positionId` field

### `BinanceSimpleEarnLockedRecord`
- **Added missing field:** `projectId`
- **Fixed issue:** Added `JsonConverter(typeof(NumberStringConverter))` to `positionId` field

### `BinanceSimpleEarnFlexibleRecord`
- **Added missing field:** `productId`

### `BinanceSimpleEarnLockedPosition`
- **Added missing field:** `parentPositionId`
