### PR TITLE
'Page' param added to the GetIncomeHistory method in futures coin account client

### DIFF
--- a/Binance.Net.UnitTests/BinanceRestIntegrationTests.cs
+++ b/Binance.Net.UnitTests/BinanceRestIntegrationTests.cs
@@ -237,7 +237,7 @@ namespace Binance.Net.UnitTests
         {
             await RunAndCheckResult(client => client.CoinFuturesApi.Account.GetPositionModeAsync(default, default), true);
             await RunAndCheckResult(client => client.CoinFuturesApi.Account.GetMarginChangeHistoryAsync("ETHUSD_PERP", default, default, default, default, default, default), true);
-            await RunAndCheckResult(client => client.CoinFuturesApi.Account.GetIncomeHistoryAsync(default, default, default, default, default, default, default), true);
+            await RunAndCheckResult(client => client.CoinFuturesApi.Account.GetIncomeHistoryAsync(default, default, default, default, default, default, default, default), true);
             await RunAndCheckResult(client => client.CoinFuturesApi.Account.GetBracketsAsync(default, default, default), true);
             await RunAndCheckResult(client => client.CoinFuturesApi.Account.GetPositionAdlQuantileEstimationAsync(default, default, default), true);
             await RunAndCheckResult(client => client.CoinFuturesApi.Account.GetAccountInfoAsync(default, default), true);

--- a/Binance.Net/Binance.Net.xml
+++ b/Binance.Net/Binance.Net.xml
@@ -389,7 +389,7 @@
         <member name="M:Binance.Net.Clients.CoinFuturesApi.BinanceRestClientCoinFuturesApiAccount.GetMarginChangeHistoryAsync(System.String,System.Nullable{Binance.Net.Enums.FuturesMarginChangeDirectionType},System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Nullable{System.Int64},System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
-        <member name="M:Binance.Net.Clients.CoinFuturesApi.BinanceRestClientCoinFuturesApiAccount.GetIncomeHistoryAsync(System.String,System.String,System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Nullable{System.Int64},System.Threading.CancellationToken)">
+        <member name="M:Binance.Net.Clients.CoinFuturesApi.BinanceRestClientCoinFuturesApiAccount.GetIncomeHistoryAsync(System.String,System.String,System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Nullable{System.Int32},System.Nullable{System.Int64},System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="M:Binance.Net.Clients.CoinFuturesApi.BinanceRestClientCoinFuturesApiAccount.GetBracketsAsync(System.String,System.Nullable{System.Int64},System.Threading.CancellationToken)">
@@ -12174,7 +12174,7 @@
             <param name="ct">Cancellation token</param>
             <returns>List of all margin changes for the symbol</returns>
         </member>
-        <member name="M:Binance.Net.Interfaces.Clients.CoinFuturesApi.IBinanceRestClientCoinFuturesApiAccount.GetIncomeHistoryAsync(System.String,System.String,System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Nullable{System.Int64},System.Threading.CancellationToken)">
+        <member name="M:Binance.Net.Interfaces.Clients.CoinFuturesApi.IBinanceRestClientCoinFuturesApiAccount.GetIncomeHistoryAsync(System.String,System.String,System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int32},System.Nullable{System.Int32},System.Nullable{System.Int64},System.Threading.CancellationToken)">
             <summary>
             Gets the income history for the futures account
             <para><a href="https://developers.binance.com/docs/derivatives/coin-margined-futures/account/rest-api/Get-Income-History" /></para>
@@ -12183,6 +12183,7 @@
             <param name="incomeType">The income type filter to apply to the request</param>
             <param name="startTime">Time to start getting income history from</param>
             <param name="endTime">Time to stop getting income history from</param>
+            <param name="page">Page number</param>
             <param name="limit">Max number of results</param>
             <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
             <param name="ct">Cancellation token</param>

--- a/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiAccount.cs
+++ b/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiAccount.cs
@@ -129,7 +129,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
         #region Get Income History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BinanceFuturesIncomeHistory[]>> GetIncomeHistoryAsync(string? symbol = null, string? incomeType = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, long? receiveWindow = null, CancellationToken ct = default)
+        public async Task<WebCallResult<BinanceFuturesIncomeHistory[]>> GetIncomeHistoryAsync(string? symbol = null, string? incomeType = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? limit = null, long? receiveWindow = null, CancellationToken ct = default)
         {
             limit?.ValidateIntBetween(nameof(limit), 1, 1000);
 
@@ -138,6 +138,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
             parameters.AddOptionalParameter("incomeType", incomeType);
             parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
             parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
+            parameters.AddOptionalParameter("page", page?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
 

--- a/Binance.Net/Interfaces/Clients/CoinFuturesApi/IBinanceRestClientCoinFuturesApiAccount.cs
+++ b/Binance.Net/Interfaces/Clients/CoinFuturesApi/IBinanceRestClientCoinFuturesApiAccount.cs
@@ -115,11 +115,12 @@ namespace Binance.Net.Interfaces.Clients.CoinFuturesApi
         /// <param name="incomeType">The income type filter to apply to the request</param>
         /// <param name="startTime">Time to start getting income history from</param>
         /// <param name="endTime">Time to stop getting income history from</param>
+        /// <param name="page">Page number</param>
         /// <param name="limit">Max number of results</param>
         /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns>The income history for the futures account</returns>
-        Task<WebCallResult<BinanceFuturesIncomeHistory[]>> GetIncomeHistoryAsync(string? symbol = null, string? incomeType = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, long? receiveWindow = null, CancellationToken ct = default);
+        Task<WebCallResult<BinanceFuturesIncomeHistory[]>> GetIncomeHistoryAsync(string? symbol = null, string? incomeType = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? limit = null, long? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
         /// Gets Notional and Leverage Brackets.


### PR DESCRIPTION
'Page' param added to the GetIncomeHistory method in futures coin account client accordingly to the Binance reast api documentation: 
https://developers.binance.com/docs/derivatives/coin-margined-futures/account/rest-api/Get-Income-History