### PR TITLE
Added GetMarginCapitalFlowData method and tests

### DIFF
--- a/Binance.Net.UnitTests/BinanceRestIntegrationTests.cs
+++ b/Binance.Net.UnitTests/BinanceRestIntegrationTests.cs
@@ -85,6 +85,7 @@ namespace Binance.Net.UnitTests
             await RunAndCheckResult(client => client.SpotApi.Account.GetBusdConvertHistoryAsync(DateTime.UtcNow.AddDays(-1), DateTime.UtcNow, default, default, default, default, default, default, default), true);
             await RunAndCheckResult(client => client.SpotApi.Account.GetCloudMiningHistoryAsync(DateTime.UtcNow.AddDays(-1), DateTime.UtcNow, default, default, default, default, default, default, default), true);
             await RunAndCheckResult(client => client.SpotApi.Account.GetIsolatedMarginFeeDataAsync(default, default, default, default), true);
+            await RunAndCheckResult(client => client.SpotApi.Account.GetMarginCapitalFlowDataAsync(default, default, default, default, default, default, default, default, default), true);
             await RunAndCheckResult(client => client.SpotApi.Account.GetTradeFeeAsync(default, default, default), true);
             await RunAndCheckResult(client => client.SpotApi.Account.GetAccountVipLevelAndStatusAsync(default, default), true);
             await RunAndCheckResult(client => client.SpotApi.Account.GetCommissionRatesAsync("ETHUSDT", default, default), true);

--- a/Binance.Net.UnitTests/Endpoints/Spot/Account/GetMarginCapitalFlowData.txt
+++ b/Binance.Net.UnitTests/Endpoints/Spot/Account/GetMarginCapitalFlowData.txt
@@ -1,0 +1,5 @@
+GET
+/sapi/v1/margin/capital-flow
+true
+[
+]

--- a/Binance.Net.UnitTests/RestRequestTests.cs
+++ b/Binance.Net.UnitTests/RestRequestTests.cs
@@ -96,6 +96,7 @@ namespace Binance.Net.UnitTests
             await tester.ValidateAsync(client => client.SpotApi.Account.GetBusdConvertHistoryAsync(DateTime.UtcNow.AddDays(-1), DateTime.UtcNow), "GetBusdConvertHistory");
             await tester.ValidateAsync(client => client.SpotApi.Account.GetCloudMiningHistoryAsync(DateTime.UtcNow.AddDays(-1), DateTime.UtcNow), "GetCloudMiningHistory");
             await tester.ValidateAsync(client => client.SpotApi.Account.GetIsolatedMarginFeeDataAsync(), "GetIsolatedMarginFeeData");
+            await tester.ValidateAsync(client => client.SpotApi.Account.GetMarginCapitalFlowDataAsync(), "GetMarginCapitalFlowData");
             await tester.ValidateAsync(client => client.SpotApi.Account.GetCrossMarginSmallLiabilityExchangeAssetsAsync(), "GetCrossMarginSmallLiabilityExchangeAssets");
             await tester.ValidateAsync(client => client.SpotApi.Account.CrossMarginSmallLiabilityExchangeAsync(new[] { "ETH" }), "CrossMarginSmallLiabilityExchange");
             await tester.ValidateAsync(client => client.SpotApi.Account.GetCrossMarginSmallLiabilityExchangeHistoryAsync(), "GetCrossMarginSmallLiabilityExchangeHistory");

--- a/Binance.Net/Binance.Net.xml
+++ b/Binance.Net/Binance.Net.xml
@@ -1629,6 +1629,9 @@
         <member name="M:Binance.Net.Clients.SpotApi.BinanceRestClientSpotApiAccount.GetIsolatedMarginFeeDataAsync(System.String,System.Nullable{System.Int32},System.Nullable{System.Int64},System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
+        <member name="M:Binance.Net.Clients.SpotApi.BinanceRestClientSpotApiAccount.GetMarginCapitalFlowDataAsync(System.String,System.String,System.Nullable{Binance.Net.Enums.CapitalTransactionType},System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int64},System.Nullable{System.Int32},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
         <member name="M:Binance.Net.Clients.SpotApi.BinanceRestClientSpotApiAccount.GetCrossMarginSmallLiabilityExchangeAssetsAsync(System.Nullable{System.Int32},System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
@@ -2804,6 +2807,11 @@
             </summary>
         </member>
         <member name="P:Binance.Net.Converters.BinanceSourceGenerationContext.C2COrderStatus">
+            <summary>
+            Defines the source generated JSON serialization contract metadata for a given type.
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Converters.BinanceSourceGenerationContext.CapitalTransactionType">
             <summary>
             Defines the source generated JSON serialization contract metadata for a given type.
             </summary>
@@ -7443,6 +7451,16 @@
             Defines the source generated JSON serialization contract metadata for a given type.
             </summary>
         </member>
+        <member name="P:Binance.Net.Converters.BinanceSourceGenerationContext.BinanceMarginCapitalFlowData">
+            <summary>
+            Defines the source generated JSON serialization contract metadata for a given type.
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Converters.BinanceSourceGenerationContext.BinanceMarginCapitalFlowDataArray">
+            <summary>
+            Defines the source generated JSON serialization contract metadata for a given type.
+            </summary>
+        </member>
         <member name="P:Binance.Net.Converters.BinanceSourceGenerationContext.BinanceMarginDelistSchedule">
             <summary>
             Defines the source generated JSON serialization contract metadata for a given type.
@@ -9620,6 +9638,91 @@
         <member name="F:Binance.Net.Enums.CancelRestriction.OnlyPartiallyFilled">
             <summary>
             Cancel will succeed if order status is PartiallyFilled
+            </summary>
+        </member>
+        <member name="T:Binance.Net.Enums.CapitalTransactionType">
+            <summary>
+            Types of capital flow transactions
+            </summary>
+        </member>
+        <member name="F:Binance.Net.Enums.CapitalTransactionType.Transfer">
+            <summary>
+            Transfer
+            </summary>
+        </member>
+        <member name="F:Binance.Net.Enums.CapitalTransactionType.Borrow">
+            <summary>
+            Borrow
+            </summary>
+        </member>
+        <member name="F:Binance.Net.Enums.CapitalTransactionType.Repay">
+            <summary>
+            Repay
+            </summary>
+        </member>
+        <member name="F:Binance.Net.Enums.CapitalTransactionType.BuyTradingIncome">
+            <summary>
+            Buy-Trading Income
+            </summary>
+        </member>
+        <member name="F:Binance.Net.Enums.CapitalTransactionType.BuyTradingExpense">
+            <summary>
+            Buy-Trading Expense
+            </summary>
+        </member>
+        <member name="F:Binance.Net.Enums.CapitalTransactionType.SellTradingIncome">
+            <summary>
+            Sell-Trading Income
+            </summary>
+        </member>
+        <member name="F:Binance.Net.Enums.CapitalTransactionType.SellTradingExpense">
+            <summary>
+            Sell-Trading Expense
+            </summary>
+        </member>
+        <member name="F:Binance.Net.Enums.CapitalTransactionType.TradingCommission">
+            <summary>
+            Trading Commission
+            </summary>
+        </member>
+        <member name="F:Binance.Net.Enums.CapitalTransactionType.BuyLiquidation">
+            <summary>
+            Buy by Liquidation
+            </summary>
+        </member>
+        <member name="F:Binance.Net.Enums.CapitalTransactionType.SellLiquidation">
+            <summary>
+            Sell by Liquidation
+            </summary>
+        </member>
+        <member name="F:Binance.Net.Enums.CapitalTransactionType.RepayLiquidation">
+            <summary>
+            Repay by Liquidation
+            </summary>
+        </member>
+        <member name="F:Binance.Net.Enums.CapitalTransactionType.OtherLiquidation">
+            <summary>
+            Other Liquidation
+            </summary>
+        </member>
+        <member name="F:Binance.Net.Enums.CapitalTransactionType.LiquidationFee">
+            <summary>
+            Liquidation Fee
+            </summary>
+        </member>
+        <member name="F:Binance.Net.Enums.CapitalTransactionType.SmallBalanceConvert">
+            <summary>
+            Small Balance Convert
+            </summary>
+        </member>
+        <member name="F:Binance.Net.Enums.CapitalTransactionType.CommissionReturn">
+            <summary>
+            Commission Return
+            </summary>
+        </member>
+        <member name="F:Binance.Net.Enums.CapitalTransactionType.SmallConvert">
+            <summary>
+            Small Convert
             </summary>
         </member>
         <member name="T:Binance.Net.Enums.CloudMiningPaymentStatus">
@@ -17100,6 +17203,22 @@
             </summary>
             <param name="symbol">Filter by symbol, for example `ETHUSDT`</param>
             <param name="vipLevel">User's current specific margin data will be returned if vipLevel is omitted</param>
+            <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="M:Binance.Net.Interfaces.Clients.SpotApi.IBinanceRestClientSpotApiAccount.GetMarginCapitalFlowDataAsync(System.String,System.String,System.Nullable{Binance.Net.Enums.CapitalTransactionType},System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.Int64},System.Nullable{System.Int32},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+            Get cross and isolated margin capital flow data records of the last 90 days
+            <para><a href="https://developers.binance.com/docs/margin_trading/account/Query-Cross-Isolated-Margin-Capital-Flow" /></para>
+            </summary>
+            <param name="asset">Filter by asset, for example `ETH`</param>
+            <param name="symbol">Filter by symbol, for example `ETHUSDT`</param>
+            <param name="type">Filter by transaction type</param>
+            <param name="startTime">Filter by startTime</param>
+            <param name="endTime">Filter by endTime</param>
+            <param name="fromId">If set, data with 'Id' greater than 'fromId' will be returned. Otherwise, the latest data will be returned</param>
+            <param name="limit">Number of records to retrieve. Default: 500, Max: 1000</param>
             <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
             <param name="ct">Cancellation token</param>
             <returns></returns>
@@ -30542,6 +30661,46 @@
         <member name="P:Binance.Net.Objects.Models.Spot.Margin.BinanceMarginCallUpdate.MarginCallStatus">
             <summary>
             Margin call status
+            </summary>
+        </member>
+        <member name="T:Binance.Net.Objects.Models.Spot.Margin.BinanceMarginCapitalFlowData">
+            <summary>
+            Margin capital flow data
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Spot.Margin.BinanceMarginCapitalFlowData.Id">
+            <summary>
+            Id
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Spot.Margin.BinanceMarginCapitalFlowData.TransactionId">
+            <summary>
+            Transaction id
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Spot.Margin.BinanceMarginCapitalFlowData.Asset">
+            <summary>
+            Asset
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Spot.Margin.BinanceMarginCapitalFlowData.Symbol">
+            <summary>
+            Symbol
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Spot.Margin.BinanceMarginCapitalFlowData.Type">
+            <summary>
+            Transaction type
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Spot.Margin.BinanceMarginCapitalFlowData.Quantity">
+            <summary>
+            Quantity
+            </summary>
+        </member>
+        <member name="P:Binance.Net.Objects.Models.Spot.Margin.BinanceMarginCapitalFlowData.Timestamp">
+            <summary>
+            Timestamp
             </summary>
         </member>
         <member name="T:Binance.Net.Objects.Models.Spot.Margin.BinanceMarginDelistSchedule">

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiAccount.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiAccount.cs
@@ -1262,6 +1262,27 @@ namespace Binance.Net.Clients.SpotApi
 
         #endregion
 
+        #region Get Cross Isolated Margin Capital Flow Records
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<BinanceMarginCapitalFlowData[]>> GetMarginCapitalFlowDataAsync(string? asset = null, string? symbol = null, CapitalTransactionType? type = null, DateTime? startTime = null, DateTime? endTime = null, long? fromId = null, int? limit = null, int? receiveWindow = null, CancellationToken ct = default)
+        {
+            var parameters = new ParameterCollection();
+            parameters.AddOptionalParameter("asset", asset);
+            parameters.AddOptionalParameter("symbol", symbol);
+            parameters.AddOptionalEnum("type", type);
+            parameters.AddOptionalParameter("startTime", DateTimeConverter.ConvertToMilliseconds(startTime));
+            parameters.AddOptionalParameter("endTime", DateTimeConverter.ConvertToMilliseconds(endTime));
+            parameters.AddOptionalParameter("fromId", fromId?.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptionalParameter("limit", limit?.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+
+            var request = _definitions.GetOrCreate(HttpMethod.Get, "sapi/v1/margin/capital-flow", BinanceExchange.RateLimiter.SpotRestIp, 100, true);
+            return await _baseClient.SendAsync<BinanceMarginCapitalFlowData[]>(request, parameters, ct).ConfigureAwait(false);
+        }
+
+        #endregion
+
         #region Get Small Liability Exchange Assets
 
         /// <inheritdoc />

--- a/Binance.Net/Converters/BinanceSourceGenerationContext.cs
+++ b/Binance.Net/Converters/BinanceSourceGenerationContext.cs
@@ -470,6 +470,7 @@ namespace Binance.Net.Converters
     [JsonSerializable(typeof(Objects.Models.Spot.Margin.BinanceTransaction[]))]
     [JsonSerializable(typeof(Objects.Models.Spot.Margin.BinanceLoan[]))]
     [JsonSerializable(typeof(Objects.Models.Spot.Margin.BinanceRepay[]))]
+    [JsonSerializable(typeof(Objects.Models.Spot.Margin.BinanceMarginCapitalFlowData[]))]
     [JsonSerializable(typeof(Objects.Models.Spot.Margin.BinanceSmallLiabilityAsset[]))]
     [JsonSerializable(typeof(Objects.Models.Spot.Margin.BinanceSmallLiabilityHistory[]))]
     [JsonSerializable(typeof(Objects.Models.Spot.Margin.BinanceTransferHistory[]))]

--- a/Binance.Net/Enums/CapitalTransactionType.cs
+++ b/Binance.Net/Enums/CapitalTransactionType.cs
@@ -1,0 +1,92 @@
+﻿using CryptoExchange.Net.Attributes;
+
+namespace Binance.Net.Enums
+{
+    /// <summary>
+    /// Types of capital flow transactions
+    /// </summary>
+    [JsonConverter(typeof(EnumConverter<CapitalTransactionType>))]
+    public enum CapitalTransactionType
+    {
+        /// <summary>
+        /// Transfer
+        /// </summary>
+        [Map("TRANSFER")]
+        Transfer,
+        /// <summary>
+        /// Borrow
+        /// </summary>
+        [Map("BORROW")]
+        Borrow,
+        /// <summary>
+        /// Repay
+        /// </summary>
+        [Map("REPAY")]
+        Repay,
+        /// <summary>
+        /// Buy-Trading Income
+        /// </summary>
+        [Map("BUY_INCOME")]
+        BuyTradingIncome,
+        /// <summary>
+        /// Buy-Trading Expense
+        /// </summary>
+        [Map("BUY_EXPENSE")]
+        BuyTradingExpense,
+        /// <summary>
+        /// Sell-Trading Income
+        /// </summary>
+        [Map("SELL_INCOME")]
+        SellTradingIncome,
+        /// <summary>
+        /// Sell-Trading Expense
+        /// </summary>
+        [Map("SELL_EXPENSE")]
+        SellTradingExpense,
+        /// <summary>
+        /// Trading Commission
+        /// </summary>
+        [Map("TRADING_COMMISSION")]
+        TradingCommission,
+        /// <summary>
+        /// Buy by Liquidation
+        /// </summary>
+        [Map("BUY_LIQUIDATION")]
+        BuyLiquidation,
+        /// <summary>
+        /// Sell by Liquidation
+        /// </summary>
+        [Map("SELL_LIQUIDATION")]
+        SellLiquidation,
+        /// <summary>
+        /// Repay by Liquidation
+        /// </summary>
+        [Map("REPAY_LIQUIDATION")]
+        RepayLiquidation,
+        /// <summary>
+        /// Other Liquidation
+        /// </summary>
+        [Map("OTHER_LIQUIDATION")]
+        OtherLiquidation,
+        /// <summary>
+        /// Liquidation Fee
+        /// </summary>
+        [Map("LIQUIDATION_FEE")]
+        LiquidationFee,
+        /// <summary>
+        /// Small Balance Convert
+        /// </summary>
+        [Map("SMALL_BALANCE_CONVERT")]
+        SmallBalanceConvert,
+        /// <summary>
+        /// Commission Return
+        /// </summary>
+        [Map("COMMISSION_RETURN")]
+        CommissionReturn,
+        /// <summary>
+        /// Small Convert
+        /// </summary>
+        [Map("SMALL_CONVERT")]
+        SmallConvert
+    }
+}

--- a/Binance.Net/Interfaces/Clients/SpotApi/IBinanceRestClientSpotApiAccount.cs
+++ b/Binance.Net/Interfaces/Clients/SpotApi/IBinanceRestClientSpotApiAccount.cs
@@ -785,6 +785,22 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         Task<WebCallResult<BinanceIsolatedMarginFeeData[]>> GetIsolatedMarginFeeDataAsync(string? symbol = null, int? vipLevel = null, long? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
+        /// Get cross and isolated margin capital flow data records of the last 90 days
+        /// <para><a href="https://developers.binance.com/docs/margin_trading/account/Query-Cross-Isolated-Margin-Capital-Flow" /></para>
+        /// </summary>
+        /// <param name="asset">Filter by asset, for example `ETH`</param>
+        /// <param name="symbol">Filter by symbol, for example `ETHUSDT`</param>
+        /// <param name="type">Filter by transaction type</param>
+        /// <param name="startTime">Filter by startTime</param>
+        /// <param name="endTime">Filter by endTime</param>
+        /// <param name="fromId">If set, data with 'Id' greater than 'fromId' will be returned. Otherwise, the latest data will be returned</param>
+        /// <param name="limit">Number of records to retrieve. Default: 500, Max: 1000</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<WebCallResult<BinanceMarginCapitalFlowData[]>> GetMarginCapitalFlowDataAsync(string? asset = null, string? symbol = null, CapitalTransactionType? type = null, DateTime? startTime = null, DateTime? endTime = null, long? fromId = null, int? limit = null, int? receiveWindow = null, CancellationToken ct = default);
+
+        /// <summary>
         /// Query the coins which can be small liability exchange
         /// <para><a href="https://developers.binance.com/docs/margin_trading/trade/Get-Small-Liability-Exchange-Coin-List" /></para>
         /// </summary>

--- a/Binance.Net/Objects/Models/Spot/Margin/BinanceMarginCapitalFlowData.cs
+++ b/Binance.Net/Objects/Models/Spot/Margin/BinanceMarginCapitalFlowData.cs
@@ -1,0 +1,48 @@
+﻿using Binance.Net.Enums;
+
+namespace Binance.Net.Objects.Models.Spot.Margin
+{
+    /// <summary>
+    /// Margin capital flow data
+    /// </summary>
+    [SerializationModel]
+    public record BinanceMarginCapitalFlowData
+    {
+        /// <summary>
+        /// Id
+        /// </summary>
+        [JsonPropertyName("id")]
+        public long Id { get; set; }
+        /// <summary>
+        /// Transaction id
+        /// </summary>
+        [JsonPropertyName("tranId")]
+        public long TransactionId { get; set; }
+        /// <summary>
+        /// Asset
+        /// </summary>
+        [JsonPropertyName("asset")]
+        public string Asset { get; set; } = string.Empty;
+        /// <summary>
+        /// Symbol
+        /// </summary>
+        [JsonPropertyName("symbol")]
+        public string Symbol { get; set; } = string.Empty;
+        /// <summary>
+        /// Transaction type
+        /// </summary>
+        [JsonPropertyName("type")]
+        public CapitalTransactionType Type { get; set; }
+        /// <summary>
+        /// Quantity
+        /// </summary>
+        [JsonPropertyName("amount")]
+        public decimal Quantity { get; set; }
+        /// <summary>
+        /// Timestamp
+        /// </summary>
+        [JsonConverter(typeof(DateTimeConverter))]
+        [JsonPropertyName("timestamp")]
+        public DateTime Timestamp { get; set; }
+    }
+}


### PR DESCRIPTION
Added missing RestClient.SpotApi.Account.GetMarginCapitalFlowDataAsync method.
The method is used to query cross and isolated margin account transaction records for the last 90 days.
Added unit tests for it.
[Binance docs for Query Cross Isolated Margin Capital Flow](https://developers.binance.com/docs/margin_trading/account/Query-Cross-Isolated-Margin-Capital-Flow)