### PR TITLE
Fix WS-API cancel-replace query discarding partial results on status 409

### DIFF
--- a/Binance.Net/Objects/Sockets/BinanceSpotOrderReplaceQuery.cs
+++ b/Binance.Net/Objects/Sockets/BinanceSpotOrderReplaceQuery.cs
@@ -29,7 +29,7 @@ namespace Binance.Net.Objects.Sockets
                     }, originalData);
                 }
 
-                if (message.Status == 400)
+                if (message.Status == 400 || message.Status == 409)
                 {
                     if (message.Error!.Data == null)
                         return new CallResult<BinanceResponse<BinanceReplaceOrderResult>>(new ServerError(message.Error.Code, _client.GetErrorInfo(message.Error.Code, message.Error.Message)));


### PR DESCRIPTION
## Background

On the WebSocket API `order.cancelReplace` endpoint, Binance returns status **409** for partial failures — where one operation succeeds but the other fails. The `BinanceSpotOrderReplaceQuery.HandleMessage` method only handled status 400, causing 409 responses to fall through to the generic error handler which discarded the `error.data` containing partial results.

This meant callers couldn't determine which operation succeeded or failed — e.g. a user wouldn't know their original order was already cancelled when the replacement was rejected.

## Changes

**BinanceSpotOrderReplaceQuery** — `HandleMessage`

Adds status 409 to the existing status 400 branch so partial results (`cancelResult`, `newOrderResult`, `cancelResponse`, `newOrderResponse`) are properly reconstructed into a `BinanceReplaceOrderResult` instead of being discarded as a generic `ServerError`.

## References

- [Binance Spot WebSocket API — Cancel and replace order](https://developers.binance.com/docs/binance-spot-api-docs/websocket-api/trading-requests#cancel-and-replace-order-trade)