### PR TITLE
Add Australia (AU) Travel Rule questionnaire types

### DIFF
--- a/Binance.Net/Converters/BinanceSourceGenerationContext.cs
+++ b/Binance.Net/Converters/BinanceSourceGenerationContext.cs
@@ -34,6 +34,7 @@ namespace Binance.Net.Converters
     [JsonSerializable(typeof(BinanceWithdrawQuestionnaireIndia))]
     [JsonSerializable(typeof(BinanceWithdrawQuestionnaireEu))]
     [JsonSerializable(typeof(BinanceWithdrawQuestionnaireSouthAfrica))]
+    [JsonSerializable(typeof(BinanceWithdrawQuestionnaireAustralia))]
     [JsonSerializable(typeof(BinanceDepositQuestionnaireJapan))]
     [JsonSerializable(typeof(BinanceDepositQuestionnaireKazakhstan))]
     [JsonSerializable(typeof(BinanceDepositQuestionnaireBahrain))]
@@ -41,6 +42,7 @@ namespace Binance.Net.Converters
     [JsonSerializable(typeof(BinanceDepositQuestionnaireIndia))]
     [JsonSerializable(typeof(BinanceDepositQuestionnaireEu))]
     [JsonSerializable(typeof(BinanceDepositQuestionnaireSouthAfrica))]
+    [JsonSerializable(typeof(BinanceDepositQuestionnaireAustralia))]
 
     [JsonSerializable(typeof(BinanceTravelRuleDeposit[]))]
     [JsonSerializable(typeof(BinanceTravelRuleWithdrawal[]))]

--- a/Binance.Net/Objects/Models/Spot/BinanceDepositQuestionnaire.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceDepositQuestionnaire.cs
@@ -42,6 +42,11 @@ namespace Binance.Net.Objects.Models.Spot
         /// </summary>
         [JsonIgnore]
         public static BinanceDepositQuestionnaireSouthAfrica SouthAfrica => new BinanceDepositQuestionnaireSouthAfrica();
+        /// <summary>
+        /// Create a questionnaire for a deposit for Australia
+        /// </summary>
+        [JsonIgnore]
+        public static BinanceDepositQuestionnaireAustralia Australia => new BinanceDepositQuestionnaireAustralia();
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 #pragma warning disable IL3050 // Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
@@ -464,6 +469,100 @@ namespace Binance.Net.Objects.Models.Spot
         public string? VaspName { get; set; }
         /// <summary>
         /// ["<c>declaration</c>"] Declaration
+        /// </summary>
+        [JsonPropertyName("declaration")]
+        public bool Declaration { get; set; }
+    }
+
+    /// <summary>
+    /// Australia deposit questionnaire
+    /// </summary>
+    public record BinanceDepositQuestionnaireAustralia : BinanceDepositQuestionnaire
+    {
+        /// <summary>
+        /// ["<c>depositOriginator</c>"] 1:Myself, 2:Not Myself
+        /// </summary>
+        [JsonPropertyName("depositOriginator")]
+        public int DepositOriginator { get; set; }
+        /// <summary>
+        /// ["<c>orgType</c>"] 0:Individual, 1:Corporate/Entity
+        /// </summary>
+        [JsonPropertyName("orgType")]
+        public int OrgType { get; set; }
+        /// <summary>
+        /// ["<c>orgFirstName</c>"] Originator's first name. Required when OrgType is 0
+        /// </summary>
+        [JsonPropertyName("orgFirstName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? OrgFirstName { get; set; }
+        /// <summary>
+        /// ["<c>orgLastName</c>"] Originator's last name. Required when OrgType is 0
+        /// </summary>
+        [JsonPropertyName("orgLastName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? OrgLastName { get; set; }
+        /// <summary>
+        /// ["<c>country</c>"] Originator's country code, ISO 2 digit, lower case. Required when OrgType is 0
+        /// </summary>
+        [JsonPropertyName("country")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Country { get; set; }
+        /// <summary>
+        /// ["<c>city</c>"] Originator's city/town. Required when OrgType is 0
+        /// </summary>
+        [JsonPropertyName("city")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? City { get; set; }
+        /// <summary>
+        /// ["<c>corpName</c>"] Corporation/entity name. Required when OrgType is 1
+        /// </summary>
+        [JsonPropertyName("corpName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? CorpName { get; set; }
+        /// <summary>
+        /// ["<c>corpCountry</c>"] Corporation country code, ISO 2 digit, lower case. Required when OrgType is 1
+        /// </summary>
+        [JsonPropertyName("corpCountry")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? CorpCountry { get; set; }
+        /// <summary>
+        /// ["<c>corpCity</c>"] Corporation city/town. Required when OrgType is 1
+        /// </summary>
+        [JsonPropertyName("corpCity")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? CorpCity { get; set; }
+        /// <summary>
+        /// ["<c>identifierType</c>"] Identifier type. Required when DepositOriginator is 2.
+        /// Individual: PASSPORT, NATIONAL_ID. Corporate: ABN (11 digits), ACN (9 digits), OTHER
+        /// </summary>
+        [JsonPropertyName("identifierType")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? IdentifierType { get; set; }
+        /// <summary>
+        /// ["<c>identifier</c>"] Identifier value matching IdentifierType validation. Required when DepositOriginator is 2
+        /// </summary>
+        [JsonPropertyName("identifier")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Identifier { get; set; }
+        /// <summary>
+        /// ["<c>receiveFrom</c>"] 1:Private Wallet, 2:Another VASP
+        /// </summary>
+        [JsonPropertyName("receiveFrom")]
+        public int ReceiveFrom { get; set; }
+        /// <summary>
+        /// ["<c>vasp</c>"] VASP identifier of the originator. Required when ReceiveFrom is 2
+        /// </summary>
+        [JsonPropertyName("vasp")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Vasp { get; set; }
+        /// <summary>
+        /// ["<c>vaspName</c>"] Exchange name. Required when ReceiveFrom is 2 and Vasp is `others`
+        /// </summary>
+        [JsonPropertyName("vaspName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? VaspName { get; set; }
+        /// <summary>
+        /// ["<c>declaration</c>"] Declaration confirmation
         /// </summary>
         [JsonPropertyName("declaration")]
         public bool Declaration { get; set; }

--- a/Binance.Net/Objects/Models/Spot/BinanceWithdrawQuestionnaire.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceWithdrawQuestionnaire.cs
@@ -47,6 +47,11 @@ namespace Binance.Net.Objects.Models.Spot
         /// </summary>
         [JsonIgnore]
         public static BinanceWithdrawQuestionnaireSouthAfrica SouthAfrica => new BinanceWithdrawQuestionnaireSouthAfrica();
+        /// <summary>
+        /// Create a questionnaire for a withdrawal for Australia
+        /// </summary>
+        [JsonIgnore]
+        public static BinanceWithdrawQuestionnaireAustralia Australia => new BinanceWithdrawQuestionnaireAustralia();
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 #pragma warning disable IL3050 // Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
@@ -552,6 +557,88 @@ namespace Binance.Net.Objects.Models.Spot
         public string? Vasp { get; set; }
         /// <summary>
         /// ["<c>vaspName</c>"] VASP name, required when Vasp is `others`
+        /// </summary>
+        [JsonPropertyName("vaspName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? VaspName { get; set; }
+        /// <summary>
+        /// ["<c>declaration</c>"] Declaration confirmation
+        /// </summary>
+        [JsonPropertyName("declaration")]
+        public bool Declaration { get; set; }
+    }
+
+    /// <summary>
+    /// Australia withdraw questionnaire
+    /// </summary>
+    public record BinanceWithdrawQuestionnaireAustralia : BinanceWithdrawQuestionnaire
+    {
+        /// <summary>
+        /// ["<c>isAddressOwner</c>"] 1:Send to myself, 2:Send to another beneficiary
+        /// </summary>
+        [JsonPropertyName("isAddressOwner")]
+        public int IsAddressOwner { get; set; }
+        /// <summary>
+        /// ["<c>bnfType</c>"] 0:Individual, 1:Corporate/Entity, required when IsAddressOwner is 2
+        /// </summary>
+        [JsonPropertyName("bnfType")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public int? BnfType { get; set; }
+        /// <summary>
+        /// ["<c>bnfFirstName</c>"] Individual beneficiary first name, required when BnfType is 0
+        /// </summary>
+        [JsonPropertyName("bnfFirstName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? BnfFirstName { get; set; }
+        /// <summary>
+        /// ["<c>bnfLastName</c>"] Individual beneficiary last name, required when BnfType is 0
+        /// </summary>
+        [JsonPropertyName("bnfLastName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? BnfLastName { get; set; }
+        /// <summary>
+        /// ["<c>country</c>"] Beneficiary country code, ISO 2 digit, lower case. Required when BnfType is 0
+        /// </summary>
+        [JsonPropertyName("country")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Country { get; set; }
+        /// <summary>
+        /// ["<c>city</c>"] Beneficiary city/town. Required when BnfType is 0
+        /// </summary>
+        [JsonPropertyName("city")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? City { get; set; }
+        /// <summary>
+        /// ["<c>bnfCorpName</c>"] Beneficiary corporation name. Required when BnfType is 1
+        /// </summary>
+        [JsonPropertyName("bnfCorpName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? BnfCorpName { get; set; }
+        /// <summary>
+        /// ["<c>bnfCorpCountry</c>"] Beneficiary corporation country code, ISO 2 digit, lower case. Required when BnfType is 1
+        /// </summary>
+        [JsonPropertyName("bnfCorpCountry")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? BnfCorpCountry { get; set; }
+        /// <summary>
+        /// ["<c>bnfCorpCity</c>"] Beneficiary corporation city/town. Required when BnfType is 1
+        /// </summary>
+        [JsonPropertyName("bnfCorpCity")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? BnfCorpCity { get; set; }
+        /// <summary>
+        /// ["<c>sendTo</c>"] 1:Private Wallet, 2:Another VASP
+        /// </summary>
+        [JsonPropertyName("sendTo")]
+        public int SendTo { get; set; }
+        /// <summary>
+        /// ["<c>vasp</c>"] VASP identifier of the beneficiary. Required when SendTo is 2
+        /// </summary>
+        [JsonPropertyName("vasp")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Vasp { get; set; }
+        /// <summary>
+        /// ["<c>vaspName</c>"] VASP name. Required when SendTo is 2 and Vasp is `others`
         /// </summary>
         [JsonPropertyName("vaspName")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]


### PR DESCRIPTION
Adds BinanceWithdrawQuestionnaireAustralia and BinanceDepositQuestionnaireAustralia to support AUSTRAC Travel Rule compliance required for Australian users from 1 July 2026.

Withdrawal fields follow the AU questionnaire spec:
- isAddressOwner, bnfType, bnfFirstName, bnfLastName, country, city (individual)
- bnfCorpName, bnfCorpCountry, bnfCorpCity (corporate - bnfCorpCity is AU-specific)
- sendTo, vasp, vaspName, declaration

Deposit fields follow the AU questionnaire spec:
- depositOriginator, orgType (always required, not conditional)
- orgFirstName, orgLastName, country, city (individual)
- corpName, corpCountry, corpCity (corporate - corpCity is AU-specific)
- identifierType, identifier (AU-specific: PASSPORT/NATIONAL_ID/ABN/ACN/OTHER)
- receiveFrom, vasp, vaspName, declaration

Both types registered in BinanceSourceGenerationContext for AOT-safe serialization. Static factory properties Australia added to both base questionnaire classes.