### PR TITLE
Add Travel Rule country list and region list endpoints

### DIFF
--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiAccount.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiAccount.cs
@@ -1377,6 +1377,34 @@ namespace Binance.Net.Clients.SpotApi
 
         #endregion
 
+        #region Get Travel Rule Country List
+        /// <inheritdoc />
+        public async Task<WebCallResult<BinanceTravelRuleCountryList>> GetTravelRuleCountryListAsync(
+            int? receiveWindow = null,
+            CancellationToken ct = default)
+        {
+            var parameters = new ParameterCollection();
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+            var request = _definitions.GetOrCreate(HttpMethod.Get, "sapi/v1/localentity/country/list", BinanceExchange.RateLimiter.SpotRestUid, 1, true);
+            return await _baseClient.SendAsync<BinanceTravelRuleCountryList>(request, parameters, ct).ConfigureAwait(false);
+        }
+        #endregion
+
+        #region Get Travel Rule Region List
+        /// <inheritdoc />
+        public async Task<WebCallResult<BinanceTravelRuleRegionList>> GetTravelRuleRegionListAsync(
+            string countryCode,
+            int? receiveWindow = null,
+            CancellationToken ct = default)
+        {
+            var parameters = new ParameterCollection();
+            parameters.Add("countryCode", countryCode);
+            parameters.AddOptionalParameter("recvWindow", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+            var request = _definitions.GetOrCreate(HttpMethod.Get, "sapi/v1/localentity/region/list", BinanceExchange.RateLimiter.SpotRestUid, 1, true);
+            return await _baseClient.SendAsync<BinanceTravelRuleRegionList>(request, parameters, ct).ConfigureAwait(false);
+        }
+        #endregion
+
         #region Submit Travel Rule Questionnaire
         /// <inheritdoc />
         public async Task<WebCallResult<BinanceTravelRuleSubmitResult>> SubmitTravelRuleQuestionnaireAsync(

--- a/Binance.Net/Converters/BinanceSourceGenerationContext.cs
+++ b/Binance.Net/Converters/BinanceSourceGenerationContext.cs
@@ -48,6 +48,8 @@ namespace Binance.Net.Converters
     [JsonSerializable(typeof(BinanceTravelRuleAddressWrapper))]
     [JsonSerializable(typeof(BinanceTravelRuleVasp[]))]
     [JsonSerializable(typeof(BinanceTravelRuleSubmitResult))]
+    [JsonSerializable(typeof(BinanceTravelRuleCountryList))]
+    [JsonSerializable(typeof(BinanceTravelRuleRegionList))]
 
     [JsonSerializable(typeof(BinanceResponse<BinanceSymbolAdlRate>))]
     [JsonSerializable(typeof(BinanceResponse<BinanceSymbolAdlRate[]>))]

--- a/Binance.Net/Interfaces/Clients/SpotApi/IBinanceRestClientSpotApiAccount.cs
+++ b/Binance.Net/Interfaces/Clients/SpotApi/IBinanceRestClientSpotApiAccount.cs
@@ -1264,6 +1264,30 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
             CancellationToken ct = default);
 
         /// <summary>
+        /// Gets the list of countries supported for travel rule questionnaires
+        /// <para><a href="https://developers.binance.com/docs/wallet/travel-rule/country-list" /></para>
+        /// </summary>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Travel rule country list</returns>
+        Task<WebCallResult<BinanceTravelRuleCountryList>> GetTravelRuleCountryListAsync(
+            int? receiveWindow = null,
+            CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets the list of valid region/city values for a given country for use in travel rule questionnaire city fields
+        /// <para><a href="https://developers.binance.com/docs/wallet/travel-rule/region-list" /></para>
+        /// </summary>
+        /// <param name="countryCode">["<c>countryCode</c>"] ISO 2-digit country code, lower case (e.g. "au")</param>
+        /// <param name="receiveWindow">The receive window for which this request is active. When the request takes longer than this to complete the server will reject the request</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Travel rule region list</returns>
+        Task<WebCallResult<BinanceTravelRuleRegionList>> GetTravelRuleRegionListAsync(
+            string countryCode,
+            int? receiveWindow = null,
+            CancellationToken ct = default);
+
+        /// <summary>
         /// Gets travel rule deposit history
         /// <para>
         /// Docs:<br />

--- a/Binance.Net/Objects/Models/Spot/BinanceTravelRuleCountry.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceTravelRuleCountry.cs
@@ -1,0 +1,57 @@
+namespace Binance.Net.Objects.Models.Spot
+{
+    /// <summary>
+    /// Travel rule country list response
+    /// </summary>
+    public record BinanceTravelRuleCountryList
+    {
+        /// <summary>
+        /// ["<c>countries</c>"] List of active countries
+        /// </summary>
+        [JsonPropertyName("countries")]
+        public BinanceTravelRuleCountry[] Countries { get; set; } = [];
+        /// <summary>
+        /// ["<c>lastUpdated</c>"] Last update time in epoch milliseconds
+        /// </summary>
+        [JsonConverter(typeof(DateTimeConverter))]
+        [JsonPropertyName("lastUpdated")]
+        public DateTime LastUpdated { get; set; }
+    }
+
+    /// <summary>
+    /// Travel rule country
+    /// </summary>
+    public record BinanceTravelRuleCountry
+    {
+        /// <summary>
+        /// ["<c>countryCode</c>"] ISO 2-digit country code, lower case
+        /// </summary>
+        [JsonPropertyName("countryCode")]
+        public string CountryCode { get; set; } = string.Empty;
+        /// <summary>
+        /// ["<c>countryName</c>"] Country display name
+        /// </summary>
+        [JsonPropertyName("countryName")]
+        public string CountryName { get; set; } = string.Empty;
+        /// <summary>
+        /// ["<c>blockType</c>"] Status: supported, limited, or blocked
+        /// </summary>
+        [JsonPropertyName("blockType")]
+        public string BlockType { get; set; } = string.Empty;
+        /// <summary>
+        /// ["<c>depositAllowed</c>"] Whether deposits are permitted from this country
+        /// </summary>
+        [JsonPropertyName("depositAllowed")]
+        public bool DepositAllowed { get; set; }
+        /// <summary>
+        /// ["<c>withdrawalAllowed</c>"] Whether withdrawals are permitted to this country
+        /// </summary>
+        [JsonPropertyName("withdrawalAllowed")]
+        public bool WithdrawalAllowed { get; set; }
+        /// <summary>
+        /// ["<c>hasRegionRestrictions</c>"] Whether the country has region-level restrictions requiring a specific city value in questionnaires
+        /// </summary>
+        [JsonPropertyName("hasRegionRestrictions")]
+        public bool HasRegionRestrictions { get; set; }
+    }
+}

--- a/Binance.Net/Objects/Models/Spot/BinanceTravelRuleRegion.cs
+++ b/Binance.Net/Objects/Models/Spot/BinanceTravelRuleRegion.cs
@@ -1,0 +1,52 @@
+namespace Binance.Net.Objects.Models.Spot
+{
+    /// <summary>
+    /// Travel rule region list response
+    /// </summary>
+    public record BinanceTravelRuleRegionList
+    {
+        /// <summary>
+        /// ["<c>countryCode</c>"] ISO 2-digit country code, lower case
+        /// </summary>
+        [JsonPropertyName("countryCode")]
+        public string CountryCode { get; set; } = string.Empty;
+        /// <summary>
+        /// ["<c>regions</c>"] List of active regions for the country
+        /// </summary>
+        [JsonPropertyName("regions")]
+        public BinanceTravelRuleRegion[] Regions { get; set; } = [];
+        /// <summary>
+        /// ["<c>lastUpdated</c>"] Last update time in epoch milliseconds
+        /// </summary>
+        [JsonConverter(typeof(DateTimeConverter))]
+        [JsonPropertyName("lastUpdated")]
+        public DateTime LastUpdated { get; set; }
+    }
+
+    /// <summary>
+    /// Travel rule region. The RegionName value is used in the city/bnfCorpCity/corpCity fields of travel rule questionnaires.
+    /// </summary>
+    public record BinanceTravelRuleRegion
+    {
+        /// <summary>
+        /// ["<c>regionName</c>"] Region/city name. Use this exact value in questionnaire city fields.
+        /// </summary>
+        [JsonPropertyName("regionName")]
+        public string RegionName { get; set; } = string.Empty;
+        /// <summary>
+        /// ["<c>blockType</c>"] Status: supported, limited, or blocked
+        /// </summary>
+        [JsonPropertyName("blockType")]
+        public string BlockType { get; set; } = string.Empty;
+        /// <summary>
+        /// ["<c>depositAllowed</c>"] Whether deposits are permitted from this region
+        /// </summary>
+        [JsonPropertyName("depositAllowed")]
+        public bool DepositAllowed { get; set; }
+        /// <summary>
+        /// ["<c>withdrawalAllowed</c>"] Whether withdrawals are permitted to this region
+        /// </summary>
+        [JsonPropertyName("withdrawalAllowed")]
+        public bool WithdrawalAllowed { get; set; }
+    }
+}


### PR DESCRIPTION
Adds GetTravelRuleCountryListAsync and GetTravelRuleRegionListAsync to support the Binance Travel Rule reference data APIs. These endpoints provide the valid country codes and city/region name values required when completing travel rule questionnaire fields (country, city, bnfCorpCity, corpCity etc.).

New endpoints:
  GET /sapi/v1/localentity/country/list  → BinanceTravelRuleCountryList
  GET /sapi/v1/localentity/region/list   → BinanceTravelRuleRegionList (countryCode param)

New models: BinanceTravelRuleCountryList, BinanceTravelRuleCountry,
            BinanceTravelRuleRegionList, BinanceTravelRuleRegion
Both types registered in BinanceSourceGenerationContext for AOT-safe serialization.