### PR TITLE
Add new underlying type and fix funding info update time to be nullable

### DIFF
--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiShared.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiShared.cs
@@ -897,7 +897,7 @@ namespace Binance.Net.Clients.SpotApi
         {
             if (status == DepositStatus.Success)
                 return SharedTransferStatus.Completed;
-            if (status == DepositStatus.Pending || status == DepositStatus.Completed || status == DepositStatus.WaitingUserConfirm)
+            if (status == DepositStatus.Pending || status == DepositStatus.Credited || status == DepositStatus.WaitingUserConfirm)
                 return SharedTransferStatus.InProgress;
             if (status == DepositStatus.Rejected || status == DepositStatus.WrongDeposit)
                 return SharedTransferStatus.Failed;

--- a/Binance.Net/Enums/DepositStatus.cs
+++ b/Binance.Net/Enums/DepositStatus.cs
@@ -24,17 +24,17 @@ namespace Binance.Net.Enums
         [Map("2")]
         Rejected,
         /// <summary>
-        /// ["<c>6</c>"] Completed
+        /// ["<c>6</c>"] Credited but cannot withdraw
         /// </summary>
         [Map("6")]
-        Completed,
+        Credited,
         /// <summary>
-        /// ["<c>7</c>"] Rejected
+        /// ["<c>7</c>"] Wrong deposit
         /// </summary>
         [Map("7")]
         WrongDeposit,
         /// <summary>
-        /// ["<c>8</c>"] Rejected
+        /// ["<c>8</c>"] Waiting user confirmation
         /// </summary>
         [Map("8")]
         WaitingUserConfirm,

--- a/Binance.Net/Enums/UnderlyingType.cs
+++ b/Binance.Net/Enums/UnderlyingType.cs
@@ -32,7 +32,12 @@ namespace Binance.Net.Enums
         /// ["<c>EQUITY</c>"] Equity
         /// </summary>
         [Map("EQUITY")]
-        Equity
+        Equity,
+        /// <summary>
+        /// ["<c>KR_EQUITY</c>"] Korean Equity
+        /// </summary>
+        [Map("KR_EQUITY")]
+        KrEquity
     }
 }
 

--- a/Binance.Net/Objects/Models/Futures/BinanceFuturesFundingInfo.cs
+++ b/Binance.Net/Objects/Models/Futures/BinanceFuturesFundingInfo.cs
@@ -27,10 +27,10 @@ namespace Binance.Net.Objects.Models.Futures
         [JsonPropertyName("fundingIntervalHours")]
         public int FundingIntervalHours { get; set; }
         /// <summary>
-        /// ["<c>updateTime</c>"] Funding interval in hours.
+        /// ["<c>updateTime</c>"] Last update time of the funding interval.
         /// </summary>
         [JsonPropertyName("updateTime")]
-        public DateTime UpdateTime { get; set; }
+        public DateTime? UpdateTime { get; set; }
     }
 }
 


### PR DESCRIPTION
This adds new underlying type Korean Equity as per recent changes 
https://developers.binance.com/docs/derivatives/change-log#2026-06-02

Also updates funding info update time to be nullable, since for some of the symbols API returns this:
```
{
    "symbol": "XRPUSDT",
    "adjustedFundingRateCap": "0.00375",
    "adjustedFundingRateFloor": "-0.00375",
    "fundingIntervalHours": 8,
    "disclaimer": true,
    "updateTime": null
}
```
which triggers this warning: `DateTime value of null, but property is not nullable. Resolver: BinanceSourceGenerationContext`

And fixes #1587 according to https://developers.binance.com/docs/wallet/capital/deposite-history#request-parameters