### PR TITLE
Shared asset types

### DIFF
--- a/Binance.Net/Binance.Net.csproj
+++ b/Binance.Net/Binance.Net.csproj
@@ -53,12 +53,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CryptoExchange.Net" Version="12.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/Binance.Net/Binance.Net.csproj
+++ b/Binance.Net/Binance.Net.csproj
@@ -53,10 +53,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CryptoExchange.Net" Version="12.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/Binance.Net/BinanceExchange.cs
+++ b/Binance.Net/BinanceExchange.cs
@@ -1,10 +1,16 @@
-﻿using Binance.Net.Converters;
+﻿using Binance.Net.Clients;
+using Binance.Net.Converters;
+using Binance.Net.Enums;
+using Binance.Net.Objects.Models.Futures;
+using Binance.Net.Objects.Models.Spot;
+using CryptoExchange.Net.Caching;
 using CryptoExchange.Net.Converters;
 using CryptoExchange.Net.RateLimiting;
 using CryptoExchange.Net.RateLimiting.Filters;
 using CryptoExchange.Net.RateLimiting.Guards;
 using CryptoExchange.Net.RateLimiting.Interfaces;
 using CryptoExchange.Net.SharedApis;
+using CryptoExchange.Net.SharedApis.Models;
 
 namespace Binance.Net
 {
@@ -109,6 +115,128 @@ namespace Binance.Net
         /// Rate limiter configuration for the Binance API
         /// </summary>
         public static BinanceRateLimiters RateLimiter { get; set; } = new BinanceRateLimiters();
+
+        private static HashSet<string> _exchangeSupportedFiatCurrencies = ["USD", "EUR"];
+
+#warning these should be in the shared interfaces
+        public static BinanceExchangeInfo? _spotExchangeInfo;
+        public static BinanceFuturesUsdtExchangeInfo? _usdtFuturesExchangeInfo;
+        public static BinanceProduct[]? _products;
+        public static ExchangeCache Cache { get; } = new ExchangeCache(
+            new CacheItemDefinition<SharedExchangeInfo>
+            {
+                Key = "Binance.Spot.live.ExchangeInfo",
+                Ttl = TimeSpan.FromMinutes(5),
+                ValueFactory = async () =>
+                {
+                    SharedAssetInfo MapAsset(string name, BinanceProduct[] products)
+                    {
+                        var product = products.FirstOrDefault(p => p.BaseAsset == name);
+                        if (product?.Tags.Contains("bStocks", StringComparer.InvariantCultureIgnoreCase) == true)
+                            return new SharedAssetInfo(name, SharedAssetType.Rwa, SharedAssetSubType.Stock);
+
+                        if (product?.Tags.Contains("tCommodities", StringComparer.InvariantCultureIgnoreCase) == true)
+                            return new SharedAssetInfo(name, SharedAssetType.Rwa, SharedAssetSubType.Commodity);
+
+                        // Stablecoins / Fiat
+                        if (LibraryHelpers.IsStableCoin(name))
+                            return new SharedAssetInfo(name, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
+
+                        if (_exchangeSupportedFiatCurrencies.Contains(name))
+                            return new SharedAssetInfo(name, SharedAssetType.Fiat, null);
+
+                        return new SharedAssetInfo(name, SharedAssetType.Crypto, null);
+                    }
+
+                    using var client = new BinanceRestClient();
+                    var tasks = new List<Task>();
+                    if (_spotExchangeInfo == null)
+                        tasks.Add(client.SpotApi.ExchangeData.GetExchangeInfoAsync(false, Enums.SymbolStatus.Trading));
+                    if (_products == null)
+                        tasks.Add(client.SpotApi.ExchangeData.GetProductsAsync());
+                    await Task.WhenAll(tasks).ConfigureAwait(false);
+
+                    if (_spotExchangeInfo == null || _products == null)
+                        throw new Exception($"Failed to retrieve exchange info");
+
+                    var exchangeInfo = new SharedExchangeInfo();
+                    foreach(var symbol in _spotExchangeInfo.Symbols)
+                    {
+                        if (!exchangeInfo.Assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo))
+                        {
+                            baseAssetInfo = MapAsset(symbol.BaseAsset, _products);
+                            exchangeInfo.Assets.Add(symbol.BaseAsset, baseAssetInfo);
+                        }
+                        if (!exchangeInfo.Assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo))
+                        {
+                            quoteAssetInfo = MapAsset(symbol.QuoteAsset, _products);
+                            exchangeInfo.Assets.Add(symbol.QuoteAsset, quoteAssetInfo);
+                        }
+
+                        exchangeInfo.Symbols.Add(symbol.Name, new SharedSymbolInfo(symbol.Name, baseAssetInfo, quoteAssetInfo));
+                    }
+
+                    return exchangeInfo;
+                },
+            },
+            new CacheItemDefinition<SharedExchangeInfo>
+            {
+                Key = "Binance.UsdtFutures.live.ExchangeInfo",
+                Ttl = TimeSpan.FromMinutes(5),
+                ValueFactory = async () =>
+                {
+                    SharedAssetInfo MapAsset(BinanceFuturesUsdtSymbol symbol)
+                    {
+                        if (symbol.ContractType == ContractType.PerpetualTradFi)
+                        {
+                            if (symbol.UnderlyingType == UnderlyingType.Commodity)
+                                return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Commodity);
+
+                            if (symbol.UnderlyingType == UnderlyingType.Equity
+                            || symbol.UnderlyingType == UnderlyingType.KrEquity
+                            || symbol.UnderlyingType == UnderlyingType.PreMarket)
+                                return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Stock);
+
+                            return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, null);
+                        }
+
+                        if (symbol.UnderlyingType == UnderlyingType.Coin || symbol.UnderlyingType == UnderlyingType.Index)
+                            return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Crypto, null);
+
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Unspecified, null);
+                    }
+
+                    using var client = new BinanceRestClient();
+                    var tasks = new List<Task>();
+                    if (_usdtFuturesExchangeInfo == null)
+                        tasks.Add(client.UsdFuturesApi.ExchangeData.GetExchangeInfoAsync());
+                    await Task.WhenAll(tasks).ConfigureAwait(false);
+
+                    if (_usdtFuturesExchangeInfo == null)
+                        throw new Exception($"Failed to retrieve exchange info");
+
+                    var exchangeInfo = new SharedExchangeInfo();
+                    foreach (var symbol in _usdtFuturesExchangeInfo.Symbols)
+                    {
+                        if (!exchangeInfo.Assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo))
+                        {
+                            baseAssetInfo = MapAsset(symbol);
+                            exchangeInfo.Assets.Add(symbol.BaseAsset, baseAssetInfo);
+                        }
+
+                        if (!exchangeInfo.Assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo))
+                        {
+                            quoteAssetInfo = new SharedAssetInfo(symbol.QuoteAsset, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
+                            exchangeInfo.Assets.Add(symbol.QuoteAsset, quoteAssetInfo);
+                        }
+
+                        exchangeInfo.Symbols.Add(symbol.Name, new SharedSymbolInfo(symbol.Name, baseAssetInfo, quoteAssetInfo));
+                    }
+
+                    return exchangeInfo;
+                },
+            }
+        );
     }
 
     /// <summary>

--- a/Binance.Net/BinanceExchange.cs
+++ b/Binance.Net/BinanceExchange.cs
@@ -1,9 +1,4 @@
-﻿using Binance.Net.Clients;
-using Binance.Net.Converters;
-using Binance.Net.Enums;
-using Binance.Net.Objects.Models.Futures;
-using Binance.Net.Objects.Models.Spot;
-using CryptoExchange.Net.Caching;
+﻿using Binance.Net.Converters;
 using CryptoExchange.Net.Converters;
 using CryptoExchange.Net.RateLimiting;
 using CryptoExchange.Net.RateLimiting.Filters;

--- a/Binance.Net/BinanceExchange.cs
+++ b/Binance.Net/BinanceExchange.cs
@@ -10,7 +10,6 @@ using CryptoExchange.Net.RateLimiting.Filters;
 using CryptoExchange.Net.RateLimiting.Guards;
 using CryptoExchange.Net.RateLimiting.Interfaces;
 using CryptoExchange.Net.SharedApis;
-using CryptoExchange.Net.SharedApis.Models;
 
 namespace Binance.Net
 {
@@ -115,128 +114,6 @@ namespace Binance.Net
         /// Rate limiter configuration for the Binance API
         /// </summary>
         public static BinanceRateLimiters RateLimiter { get; set; } = new BinanceRateLimiters();
-
-        private static HashSet<string> _exchangeSupportedFiatCurrencies = ["USD", "EUR"];
-
-#warning these should be in the shared interfaces
-        public static BinanceExchangeInfo? _spotExchangeInfo;
-        public static BinanceFuturesUsdtExchangeInfo? _usdtFuturesExchangeInfo;
-        public static BinanceProduct[]? _products;
-        public static ExchangeCache Cache { get; } = new ExchangeCache(
-            new CacheItemDefinition<SharedExchangeInfo>
-            {
-                Key = "Binance.Spot.live.ExchangeInfo",
-                Ttl = TimeSpan.FromMinutes(5),
-                ValueFactory = async () =>
-                {
-                    SharedAssetInfo MapAsset(string name, BinanceProduct[] products)
-                    {
-                        var product = products.FirstOrDefault(p => p.BaseAsset == name);
-                        if (product?.Tags.Contains("bStocks", StringComparer.InvariantCultureIgnoreCase) == true)
-                            return new SharedAssetInfo(name, SharedAssetType.Rwa, SharedAssetSubType.Stock);
-
-                        if (product?.Tags.Contains("tCommodities", StringComparer.InvariantCultureIgnoreCase) == true)
-                            return new SharedAssetInfo(name, SharedAssetType.Rwa, SharedAssetSubType.Commodity);
-
-                        // Stablecoins / Fiat
-                        if (LibraryHelpers.IsStableCoin(name))
-                            return new SharedAssetInfo(name, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
-
-                        if (_exchangeSupportedFiatCurrencies.Contains(name))
-                            return new SharedAssetInfo(name, SharedAssetType.Fiat, null);
-
-                        return new SharedAssetInfo(name, SharedAssetType.Crypto, null);
-                    }
-
-                    using var client = new BinanceRestClient();
-                    var tasks = new List<Task>();
-                    if (_spotExchangeInfo == null)
-                        tasks.Add(client.SpotApi.ExchangeData.GetExchangeInfoAsync(false, Enums.SymbolStatus.Trading));
-                    if (_products == null)
-                        tasks.Add(client.SpotApi.ExchangeData.GetProductsAsync());
-                    await Task.WhenAll(tasks).ConfigureAwait(false);
-
-                    if (_spotExchangeInfo == null || _products == null)
-                        throw new Exception($"Failed to retrieve exchange info");
-
-                    var exchangeInfo = new SharedExchangeInfo();
-                    foreach(var symbol in _spotExchangeInfo.Symbols)
-                    {
-                        if (!exchangeInfo.Assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo))
-                        {
-                            baseAssetInfo = MapAsset(symbol.BaseAsset, _products);
-                            exchangeInfo.Assets.Add(symbol.BaseAsset, baseAssetInfo);
-                        }
-                        if (!exchangeInfo.Assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo))
-                        {
-                            quoteAssetInfo = MapAsset(symbol.QuoteAsset, _products);
-                            exchangeInfo.Assets.Add(symbol.QuoteAsset, quoteAssetInfo);
-                        }
-
-                        exchangeInfo.Symbols.Add(symbol.Name, new SharedSymbolInfo(symbol.Name, baseAssetInfo, quoteAssetInfo));
-                    }
-
-                    return exchangeInfo;
-                },
-            },
-            new CacheItemDefinition<SharedExchangeInfo>
-            {
-                Key = "Binance.UsdtFutures.live.ExchangeInfo",
-                Ttl = TimeSpan.FromMinutes(5),
-                ValueFactory = async () =>
-                {
-                    SharedAssetInfo MapAsset(BinanceFuturesUsdtSymbol symbol)
-                    {
-                        if (symbol.ContractType == ContractType.PerpetualTradFi)
-                        {
-                            if (symbol.UnderlyingType == UnderlyingType.Commodity)
-                                return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Commodity);
-
-                            if (symbol.UnderlyingType == UnderlyingType.Equity
-                            || symbol.UnderlyingType == UnderlyingType.KrEquity
-                            || symbol.UnderlyingType == UnderlyingType.PreMarket)
-                                return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Stock);
-
-                            return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, null);
-                        }
-
-                        if (symbol.UnderlyingType == UnderlyingType.Coin || symbol.UnderlyingType == UnderlyingType.Index)
-                            return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Crypto, null);
-
-                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Unspecified, null);
-                    }
-
-                    using var client = new BinanceRestClient();
-                    var tasks = new List<Task>();
-                    if (_usdtFuturesExchangeInfo == null)
-                        tasks.Add(client.UsdFuturesApi.ExchangeData.GetExchangeInfoAsync());
-                    await Task.WhenAll(tasks).ConfigureAwait(false);
-
-                    if (_usdtFuturesExchangeInfo == null)
-                        throw new Exception($"Failed to retrieve exchange info");
-
-                    var exchangeInfo = new SharedExchangeInfo();
-                    foreach (var symbol in _usdtFuturesExchangeInfo.Symbols)
-                    {
-                        if (!exchangeInfo.Assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo))
-                        {
-                            baseAssetInfo = MapAsset(symbol);
-                            exchangeInfo.Assets.Add(symbol.BaseAsset, baseAssetInfo);
-                        }
-
-                        if (!exchangeInfo.Assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo))
-                        {
-                            quoteAssetInfo = new SharedAssetInfo(symbol.QuoteAsset, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
-                            exchangeInfo.Assets.Add(symbol.QuoteAsset, quoteAssetInfo);
-                        }
-
-                        exchangeInfo.Symbols.Add(symbol.Name, new SharedSymbolInfo(symbol.Name, baseAssetInfo, quoteAssetInfo));
-                    }
-
-                    return exchangeInfo;
-                },
-            }
-        );
     }
 
     /// <summary>

--- a/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiShared.cs
+++ b/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiShared.cs
@@ -20,9 +20,6 @@ namespace Binance.Net.Clients.CoinFuturesApi
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(BinanceExchange.Metadata, this);
 
-        private static ConcurrentDictionary<string, SharedSymbolCatalog> _exchangeInfoCache = new ConcurrentDictionary<string, SharedSymbolCatalog>();
-        private static ConcurrentDictionary<string, SemaphoreSlim> _exchangeInfoLocks = new ConcurrentDictionary<string, SemaphoreSlim>();
-
         #region Klines client
 
         GetKlinesOptions IKlineRestClient.GetKlinesOptions { get; } = new GetKlinesOptions(_exchangeName, false, true, true, 1500, false,
@@ -87,7 +84,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
         #endregion
 
         #region Futures Symbol client
-        SharedSymbolCatalog? IFuturesSymbolRestClient.SymbolCatalog => _exchangeInfoCache.TryGetValue(EnvironmentName, out var cache) ? cache : null;
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
 
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
@@ -100,78 +97,32 @@ namespace Binance.Net.Clients.CoinFuturesApi
             if (!exchangeInfo.Success)
                 return HttpResult.Fail<SharedFuturesSymbol[]>(exchangeInfo);
 
-            if (!_exchangeInfoCache.TryGetValue(EnvironmentName, out var catalog)
-                || ExchangeInfoChanged(catalog, exchangeInfo.Data))
-            {
-                var locker = _exchangeInfoLocks.GetOrAdd(EnvironmentName, x => new SemaphoreSlim(1, 1));
-                await locker.WaitAsync(ct).ConfigureAwait(false);
-                try
-                {
-                    // Another thread might've already retrieved it while waiting for the lock
-                    _exchangeInfoCache.TryGetValue(EnvironmentName, out var currentCatalog);
-                    if (currentCatalog == null || ReferenceEquals(currentCatalog, catalog)) // Still the same catalog so try to update it
-                    {
-                        catalog = CreateCatalog(exchangeInfo.Data);
-                        _exchangeInfoCache[EnvironmentName] = catalog;
-                    }
-                    else
-                    {
-                        catalog = currentCatalog;
-                    }
-                }
-                finally
-                {
-                    locker.Release();
-                }
-            }
+            var data = exchangeInfo.Data.Symbols
+                .Select(x => ParseSymbol(x)!)
+                .Where(x => x != null)
+                .ToArray();
 
-            var resultData = exchangeInfo.Data.Symbols.Where(x => x.ContractType != null).Select(x => ParseSymbol(x, catalog));
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.ToArray());
-            if (request.TradingMode != null)
-                resultData = resultData.Where(x => x.TradingMode == request.TradingMode);
-            if (request.BaseAssetType != null)
-                resultData = resultData.Where(x => x.BaseAssetType == request.BaseAssetType);
-            if (request.QuoteAssetType != null)
-                resultData = resultData.Where(x => x.QuoteAssetType == request.QuoteAssetType);
-            if (request.BaseAssetSubType != null)
-                resultData = resultData.Where(x => x.BaseAssetSubType == request.BaseAssetSubType);
-            if (request.QuoteAssetSubType != null)
-                resultData = resultData.Where(x => x.QuoteAssetSubType == request.QuoteAssetSubType);
-
-            return HttpResult.Ok(exchangeInfo, resultData.ToArray());
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, data);
+            return HttpResult.Ok(exchangeInfo, SharedUtils.ApplySymbolFilter(data, request));
         }
 
-        private bool ExchangeInfoChanged(SharedSymbolCatalog catalog, BinanceFuturesCoinExchangeInfo data)
-        {
-            if (catalog.Symbols.Count != data.Symbols.Length)
-                return true;
-
-            foreach (var symbol in data.Symbols)
-            {
-                if (!catalog.Symbols.ContainsKey(symbol.Name))
-                    return true;
-            }
-
-            return false;
-        }
-
-        private SharedSymbolCatalog CreateCatalog(BinanceFuturesCoinExchangeInfo exchangeInfo)
+        private SharedFuturesSymbol ParseSymbol(BinanceFuturesCoinSymbol s)
         {
             SharedAssetInfo MapAsset(BinanceFuturesCoinSymbol symbol)
             {
                 if (symbol.ContractType == ContractType.PerpetualTradFi)
                 {
                     if (symbol.UnderlyingType == UnderlyingType.Commodity)
-                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Commodity);
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.TradFi, SharedAssetSubType.Commodity);
 
                     if (symbol.UnderlyingType == UnderlyingType.Equity
                     || symbol.UnderlyingType == UnderlyingType.KrEquity
                     || symbol.UnderlyingType == UnderlyingType.PreMarket)
                     {
-                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Stock);
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.TradFi, SharedAssetSubType.Stock);
                     }
 
-                    return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, null);
+                    return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.TradFi, null);
                 }
 
                 if (symbol.UnderlyingType == UnderlyingType.Coin || symbol.UnderlyingType == UnderlyingType.Index)
@@ -185,37 +136,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
                 return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Unspecified, null);
             }
 
-            var assets = new Dictionary<string, SharedAssetInfo>();
-            var symbols = new Dictionary<string, SharedSymbolInfo>();
-            foreach (var symbol in exchangeInfo.Symbols)
-            {
-                if (!assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo))
-                {
-                    baseAssetInfo = MapAsset(symbol);
-                    assets.Add(symbol.BaseAsset, baseAssetInfo);
-                }
-
-                if (!assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo))
-                {
-                    quoteAssetInfo = new SharedAssetInfo(symbol.QuoteAsset, SharedAssetType.Fiat, null);
-                    assets.Add(symbol.QuoteAsset, quoteAssetInfo);
-                }
-
-                symbols.Add(symbol.Name, new SharedSymbolInfo(symbol.Name, baseAssetInfo, quoteAssetInfo));
-            }
-
-            return new SharedSymbolCatalog
-            {
-                Assets = assets,
-                Symbols = symbols
-            };
-        }
-
-        private SharedFuturesSymbol ParseSymbol(BinanceFuturesCoinSymbol s, SharedSymbolCatalog exchangeInfo)
-        {
-            exchangeInfo.Assets.TryGetValue(s.BaseAsset, out var baseAssetInfo);
-            exchangeInfo.Assets.TryGetValue(s.QuoteAsset, out var quoteAssetInfo);
-
+            var baseAssetInfo = MapAsset(s);
             var isPerp = s.ContractType == ContractType.Perpetual || s.ContractType == ContractType.PerpetualTradFi || s.ContractType == ContractType.PerpetualDelivering;
             return new SharedFuturesSymbol(
                     isPerp ? TradingMode.PerpetualInverse : TradingMode.DeliveryInverse,
@@ -233,8 +154,8 @@ namespace Binance.Net.Clients.CoinFuturesApi
                 DisplayName = s.Name,
                 BaseAssetType = baseAssetInfo?.Type ?? SharedAssetType.Unspecified,
                 BaseAssetSubType = baseAssetInfo?.SubType,
-                QuoteAssetType = quoteAssetInfo?.Type ?? SharedAssetType.Unspecified,
-                QuoteAssetSubType = quoteAssetInfo?.SubType,
+                QuoteAssetType = SharedAssetType.Fiat,
+                QuoteAssetSubType = null,
             };
         }
 

--- a/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiShared.cs
+++ b/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiShared.cs
@@ -84,7 +84,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
         #endregion
 
         #region Futures Symbol client
-        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
 
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)

--- a/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiShared.cs
+++ b/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiShared.cs
@@ -4,6 +4,7 @@ using CryptoExchange.Net.SharedApis;
 using Binance.Net.Interfaces;
 using Binance.Net.Objects.Models.Futures;
 using CryptoExchange.Net.Objects.Errors;
+using CryptoExchange.Net.Caching;
 
 namespace Binance.Net.Clients.CoinFuturesApi
 {
@@ -17,6 +18,81 @@ namespace Binance.Net.Clients.CoinFuturesApi
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(BinanceExchange.Metadata, this);
+
+        private static ExchangeCache Cache { get; } = new ExchangeCache(
+            new CacheItemDefinition<SharedSymbolCatalog>
+            {
+                Key = "Binance.CoinFutures.ExchangeInfo",
+                Ttl = TimeSpan.FromMinutes(5),
+                ValueFactory = () => GetExchangeInfoAsync(),
+            }
+        );
+
+        private static BinanceFuturesCoinExchangeInfo? _coinFuturesExchangeInfo;
+        private static async Task<SharedSymbolCatalog> GetExchangeInfoAsync()
+        {
+            SharedAssetInfo MapAsset(BinanceFuturesCoinSymbol symbol)
+            {
+                if (symbol.ContractType == ContractType.PerpetualTradFi)
+                {
+                    if (symbol.UnderlyingType == UnderlyingType.Commodity)
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Commodity);
+
+                    if (symbol.UnderlyingType == UnderlyingType.Equity
+                    || symbol.UnderlyingType == UnderlyingType.KrEquity
+                    || symbol.UnderlyingType == UnderlyingType.PreMarket)
+                    {
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Stock);
+                    }
+
+                    return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, null);
+                }
+
+                if (symbol.UnderlyingType == UnderlyingType.Coin || symbol.UnderlyingType == UnderlyingType.Index)
+                {
+                    if (LibraryHelpers.IsStableCoin(symbol.BaseAsset))
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
+
+                    return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Crypto, null);
+                }
+
+                return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Unspecified, null);
+            }
+
+            using var client = new BinanceRestClient();
+            var tasks = new List<Task>();
+            if (_coinFuturesExchangeInfo == null)
+                tasks.Add(client.CoinFuturesApi.ExchangeData.GetExchangeInfoAsync());
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            if (_coinFuturesExchangeInfo == null)
+                throw new Exception($"Failed to retrieve exchange info");
+
+            var assets = new Dictionary<string, SharedAssetInfo>();
+            var symbols = new Dictionary<string, SharedSymbolInfo>();
+            foreach (var symbol in _coinFuturesExchangeInfo.Symbols)
+            {
+                if (!assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo))
+                {
+                    baseAssetInfo = MapAsset(symbol);
+                    assets.Add(symbol.BaseAsset, baseAssetInfo);
+                }
+
+                if (!assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo))
+                {
+                    quoteAssetInfo = new SharedAssetInfo(symbol.QuoteAsset, SharedAssetType.Fiat, null);
+                    assets.Add(symbol.QuoteAsset, quoteAssetInfo);
+                }
+
+                symbols.Add(symbol.Name, new SharedSymbolInfo(symbol.Name, baseAssetInfo, quoteAssetInfo));
+            }
+
+            return new SharedSymbolCatalog
+            {
+                Assets = assets,
+                Symbols = symbols
+            };
+        }
 
         #region Klines client
 
@@ -82,6 +158,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
         #endregion
 
         #region Futures Symbol client
+        SharedSymbolCatalog? IFuturesSymbolRestClient.SymbolCatalog => Cache.Get<SharedSymbolCatalog?>("Binance.CoinFutures.live.ExchangeInfo");
 
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
@@ -94,28 +171,51 @@ namespace Binance.Net.Clients.CoinFuturesApi
             if (!result.Success)
                 return HttpResult.Fail<SharedFuturesSymbol[]>(result);
 
+            _coinFuturesExchangeInfo = result.Data;
+            var exchangeInfo = await Cache.GetOrRetrieveAsync<SharedSymbolCatalog>("Binance.CoinFutures.live.ExchangeInfo").ConfigureAwait(false);
+
             var data = result.Data.Symbols.Where(x => x.ContractType != null);
+            var resultData = data.Select(x => ParseSymbol(x, exchangeInfo));
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.ToArray());
+
             if (request.TradingMode != null)
-                data = data.Where(x => FilterContractType(request.TradingMode.Value, x.ContractType!.Value));
-            var resultData = data.Select(s =>
-            new SharedFuturesSymbol(
-                s.ContractType == ContractType.Perpetual ? TradingMode.PerpetualInverse : TradingMode.DeliveryInverse,
-                s.BaseAsset,
-                s.QuoteAsset,
-                s.Name,
-                s.Status == SymbolStatus.Trading)
+                resultData = resultData.Where(x => x.TradingMode == request.TradingMode);
+            if (request.BaseAssetType != null)
+                resultData = resultData.Where(x => x.BaseAssetType == request.BaseAssetType);
+            if (request.QuoteAssetType != null)
+                resultData = resultData.Where(x => x.QuoteAssetType == request.QuoteAssetType);
+            if (request.BaseAssetSubType != null)
+                resultData = resultData.Where(x => x.BaseAssetSubType == request.BaseAssetSubType);
+            if (request.QuoteAssetSubType != null)
+                resultData = resultData.Where(x => x.QuoteAssetSubType == request.QuoteAssetSubType);
+
+            return HttpResult.Ok(result, resultData.ToArray());
+        }
+
+        private SharedFuturesSymbol ParseSymbol(BinanceFuturesCoinSymbol s, SharedSymbolCatalog exchangeInfo)
+        {
+            exchangeInfo.Assets.TryGetValue(s.BaseAsset, out var baseAssetInfo);
+            exchangeInfo.Assets.TryGetValue(s.QuoteAsset, out var quoteAssetInfo);
+
+            return new SharedFuturesSymbol(
+                    s.ContractType == ContractType.Perpetual ? TradingMode.PerpetualInverse : TradingMode.DeliveryInverse,
+                    s.BaseAsset,
+                    s.QuoteAsset,
+                    s.Name,
+                    s.Status == SymbolStatus.Trading)
             {
                 MinTradeQuantity = s.LotSizeFilter?.MinQuantity,
                 MaxTradeQuantity = s.LotSizeFilter?.MaxQuantity,
                 QuantityStep = s.LotSizeFilter?.StepSize,
                 PriceStep = s.PriceFilter?.TickSize,
                 ContractSize = s.ContractSize,
-                DeliveryTime = s.DeliveryDate.Year == 2100 ? null : s.DeliveryDate
-            }).ToArray();
-
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData);
-            return HttpResult.Ok(result, resultData);
-
+                DeliveryTime = s.DeliveryDate.Year == 2100 ? null : s.DeliveryDate,
+                DisplayName = s.Name,
+                BaseAssetType = baseAssetInfo?.Type ?? SharedAssetType.Unspecified,
+                BaseAssetSubType = baseAssetInfo?.SubType,
+                QuoteAssetType = quoteAssetInfo?.Type ?? SharedAssetType.Unspecified,
+                QuoteAssetSubType = quoteAssetInfo?.SubType,
+            };
         }
 
         private bool FilterContractType(TradingMode mode, ContractType type)

--- a/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiShared.cs
+++ b/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiShared.cs
@@ -119,7 +119,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
                     || symbol.UnderlyingType == UnderlyingType.KrEquity
                     || symbol.UnderlyingType == UnderlyingType.PreMarket)
                     {
-                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.TradFi, SharedAssetSubType.Stock);
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.TradFi, SharedAssetSubType.Equity);
                     }
 
                     return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.TradFi, null);

--- a/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiShared.cs
+++ b/Binance.Net/Clients/CoinFuturesApi/BinanceRestClientCoinFuturesApiShared.cs
@@ -1,10 +1,11 @@
-using Binance.Net.Interfaces.Clients.CoinFuturesApi;
 using Binance.Net.Enums;
-using CryptoExchange.Net.SharedApis;
 using Binance.Net.Interfaces;
+using Binance.Net.Interfaces.Clients.CoinFuturesApi;
 using Binance.Net.Objects.Models.Futures;
-using CryptoExchange.Net.Objects.Errors;
 using CryptoExchange.Net.Caching;
+using CryptoExchange.Net.Objects.Errors;
+using CryptoExchange.Net.SharedApis;
+using System.Collections.Concurrent;
 
 namespace Binance.Net.Clients.CoinFuturesApi
 {
@@ -19,80 +20,8 @@ namespace Binance.Net.Clients.CoinFuturesApi
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(BinanceExchange.Metadata, this);
 
-        private static ExchangeCache Cache { get; } = new ExchangeCache(
-            new CacheItemDefinition<SharedSymbolCatalog>
-            {
-                Key = "Binance.CoinFutures.ExchangeInfo",
-                Ttl = TimeSpan.FromMinutes(5),
-                ValueFactory = () => GetExchangeInfoAsync(),
-            }
-        );
-
-        private static BinanceFuturesCoinExchangeInfo? _coinFuturesExchangeInfo;
-        private static async Task<SharedSymbolCatalog> GetExchangeInfoAsync()
-        {
-            SharedAssetInfo MapAsset(BinanceFuturesCoinSymbol symbol)
-            {
-                if (symbol.ContractType == ContractType.PerpetualTradFi)
-                {
-                    if (symbol.UnderlyingType == UnderlyingType.Commodity)
-                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Commodity);
-
-                    if (symbol.UnderlyingType == UnderlyingType.Equity
-                    || symbol.UnderlyingType == UnderlyingType.KrEquity
-                    || symbol.UnderlyingType == UnderlyingType.PreMarket)
-                    {
-                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Stock);
-                    }
-
-                    return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, null);
-                }
-
-                if (symbol.UnderlyingType == UnderlyingType.Coin || symbol.UnderlyingType == UnderlyingType.Index)
-                {
-                    if (LibraryHelpers.IsStableCoin(symbol.BaseAsset))
-                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
-
-                    return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Crypto, null);
-                }
-
-                return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Unspecified, null);
-            }
-
-            using var client = new BinanceRestClient();
-            var tasks = new List<Task>();
-            if (_coinFuturesExchangeInfo == null)
-                tasks.Add(client.CoinFuturesApi.ExchangeData.GetExchangeInfoAsync());
-            await Task.WhenAll(tasks).ConfigureAwait(false);
-
-            if (_coinFuturesExchangeInfo == null)
-                throw new Exception($"Failed to retrieve exchange info");
-
-            var assets = new Dictionary<string, SharedAssetInfo>();
-            var symbols = new Dictionary<string, SharedSymbolInfo>();
-            foreach (var symbol in _coinFuturesExchangeInfo.Symbols)
-            {
-                if (!assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo))
-                {
-                    baseAssetInfo = MapAsset(symbol);
-                    assets.Add(symbol.BaseAsset, baseAssetInfo);
-                }
-
-                if (!assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo))
-                {
-                    quoteAssetInfo = new SharedAssetInfo(symbol.QuoteAsset, SharedAssetType.Fiat, null);
-                    assets.Add(symbol.QuoteAsset, quoteAssetInfo);
-                }
-
-                symbols.Add(symbol.Name, new SharedSymbolInfo(symbol.Name, baseAssetInfo, quoteAssetInfo));
-            }
-
-            return new SharedSymbolCatalog
-            {
-                Assets = assets,
-                Symbols = symbols
-            };
-        }
+        private static ConcurrentDictionary<string, SharedSymbolCatalog> _exchangeInfoCache = new ConcurrentDictionary<string, SharedSymbolCatalog>();
+        private static ConcurrentDictionary<string, SemaphoreSlim> _exchangeInfoLocks = new ConcurrentDictionary<string, SemaphoreSlim>();
 
         #region Klines client
 
@@ -158,7 +87,7 @@ namespace Binance.Net.Clients.CoinFuturesApi
         #endregion
 
         #region Futures Symbol client
-        SharedSymbolCatalog? IFuturesSymbolRestClient.SymbolCatalog => Cache.Get<SharedSymbolCatalog?>("Binance.CoinFutures.live.ExchangeInfo");
+        SharedSymbolCatalog? IFuturesSymbolRestClient.SymbolCatalog => _exchangeInfoCache.TryGetValue(EnvironmentName, out var cache) ? cache : null;
 
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
@@ -167,17 +96,37 @@ namespace Binance.Net.Clients.CoinFuturesApi
             if (validationError != null)
                 return HttpResult.Fail<SharedFuturesSymbol[]>(Exchange, validationError);
 
-            var result = await ExchangeData.GetExchangeInfoAsync(ct).ConfigureAwait(false);
-            if (!result.Success)
-                return HttpResult.Fail<SharedFuturesSymbol[]>(result);
+            var exchangeInfo = await ExchangeData.GetExchangeInfoAsync(ct).ConfigureAwait(false);
+            if (!exchangeInfo.Success)
+                return HttpResult.Fail<SharedFuturesSymbol[]>(exchangeInfo);
 
-            _coinFuturesExchangeInfo = result.Data;
-            var exchangeInfo = await Cache.GetOrRetrieveAsync<SharedSymbolCatalog>("Binance.CoinFutures.live.ExchangeInfo").ConfigureAwait(false);
+            if (!_exchangeInfoCache.TryGetValue(EnvironmentName, out var catalog)
+                || ExchangeInfoChanged(catalog, exchangeInfo.Data))
+            {
+                var locker = _exchangeInfoLocks.GetOrAdd(EnvironmentName, x => new SemaphoreSlim(1, 1));
+                await locker.WaitAsync(ct).ConfigureAwait(false);
+                try
+                {
+                    // Another thread might've already retrieved it while waiting for the lock
+                    _exchangeInfoCache.TryGetValue(EnvironmentName, out var currentCatalog);
+                    if (currentCatalog == null || ReferenceEquals(currentCatalog, catalog)) // Still the same catalog so try to update it
+                    {
+                        catalog = CreateCatalog(exchangeInfo.Data);
+                        _exchangeInfoCache[EnvironmentName] = catalog;
+                    }
+                    else
+                    {
+                        catalog = currentCatalog;
+                    }
+                }
+                finally
+                {
+                    locker.Release();
+                }
+            }
 
-            var data = result.Data.Symbols.Where(x => x.ContractType != null);
-            var resultData = data.Select(x => ParseSymbol(x, exchangeInfo));
+            var resultData = exchangeInfo.Data.Symbols.Where(x => x.ContractType != null).Select(x => ParseSymbol(x, catalog));
             ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.ToArray());
-
             if (request.TradingMode != null)
                 resultData = resultData.Where(x => x.TradingMode == request.TradingMode);
             if (request.BaseAssetType != null)
@@ -189,7 +138,77 @@ namespace Binance.Net.Clients.CoinFuturesApi
             if (request.QuoteAssetSubType != null)
                 resultData = resultData.Where(x => x.QuoteAssetSubType == request.QuoteAssetSubType);
 
-            return HttpResult.Ok(result, resultData.ToArray());
+            return HttpResult.Ok(exchangeInfo, resultData.ToArray());
+        }
+
+        private bool ExchangeInfoChanged(SharedSymbolCatalog catalog, BinanceFuturesCoinExchangeInfo data)
+        {
+            if (catalog.Symbols.Count != data.Symbols.Length)
+                return true;
+
+            foreach (var symbol in data.Symbols)
+            {
+                if (!catalog.Symbols.ContainsKey(symbol.Name))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private SharedSymbolCatalog CreateCatalog(BinanceFuturesCoinExchangeInfo exchangeInfo)
+        {
+            SharedAssetInfo MapAsset(BinanceFuturesCoinSymbol symbol)
+            {
+                if (symbol.ContractType == ContractType.PerpetualTradFi)
+                {
+                    if (symbol.UnderlyingType == UnderlyingType.Commodity)
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Commodity);
+
+                    if (symbol.UnderlyingType == UnderlyingType.Equity
+                    || symbol.UnderlyingType == UnderlyingType.KrEquity
+                    || symbol.UnderlyingType == UnderlyingType.PreMarket)
+                    {
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Stock);
+                    }
+
+                    return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, null);
+                }
+
+                if (symbol.UnderlyingType == UnderlyingType.Coin || symbol.UnderlyingType == UnderlyingType.Index)
+                {
+                    if (LibraryHelpers.IsStableCoin(symbol.BaseAsset))
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
+
+                    return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Crypto, null);
+                }
+
+                return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Unspecified, null);
+            }
+
+            var assets = new Dictionary<string, SharedAssetInfo>();
+            var symbols = new Dictionary<string, SharedSymbolInfo>();
+            foreach (var symbol in exchangeInfo.Symbols)
+            {
+                if (!assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo))
+                {
+                    baseAssetInfo = MapAsset(symbol);
+                    assets.Add(symbol.BaseAsset, baseAssetInfo);
+                }
+
+                if (!assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo))
+                {
+                    quoteAssetInfo = new SharedAssetInfo(symbol.QuoteAsset, SharedAssetType.Fiat, null);
+                    assets.Add(symbol.QuoteAsset, quoteAssetInfo);
+                }
+
+                symbols.Add(symbol.Name, new SharedSymbolInfo(symbol.Name, baseAssetInfo, quoteAssetInfo));
+            }
+
+            return new SharedSymbolCatalog
+            {
+                Assets = assets,
+                Symbols = symbols
+            };
         }
 
         private SharedFuturesSymbol ParseSymbol(BinanceFuturesCoinSymbol s, SharedSymbolCatalog exchangeInfo)
@@ -197,8 +216,9 @@ namespace Binance.Net.Clients.CoinFuturesApi
             exchangeInfo.Assets.TryGetValue(s.BaseAsset, out var baseAssetInfo);
             exchangeInfo.Assets.TryGetValue(s.QuoteAsset, out var quoteAssetInfo);
 
+            var isPerp = s.ContractType == ContractType.Perpetual || s.ContractType == ContractType.PerpetualTradFi || s.ContractType == ContractType.PerpetualDelivering;
             return new SharedFuturesSymbol(
-                    s.ContractType == ContractType.Perpetual ? TradingMode.PerpetualInverse : TradingMode.DeliveryInverse,
+                    isPerp ? TradingMode.PerpetualInverse : TradingMode.DeliveryInverse,
                     s.BaseAsset,
                     s.QuoteAsset,
                     s.Name,
@@ -216,15 +236,6 @@ namespace Binance.Net.Clients.CoinFuturesApi
                 QuoteAssetType = quoteAssetInfo?.Type ?? SharedAssetType.Unspecified,
                 QuoteAssetSubType = quoteAssetInfo?.SubType,
             };
-        }
-
-        private bool FilterContractType(TradingMode mode, ContractType type)
-        {
-            var isPerp = type == ContractType.Perpetual || type == ContractType.PerpetualDelivering || type == ContractType.PerpetualTradFi;
-            if (mode == TradingMode.PerpetualInverse)
-                return isPerp;
-
-            return !isPerp;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiShared.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiShared.cs
@@ -1,9 +1,10 @@
 using Binance.Net.Enums;
 using Binance.Net.Interfaces.Clients.SpotApi;
 using Binance.Net.Objects.Models.Spot;
+using CryptoExchange.Net.Caching;
 using CryptoExchange.Net.Objects.Errors;
 using CryptoExchange.Net.SharedApis;
-using CryptoExchange.Net.SharedApis.Models;
+using System.Diagnostics;
 
 namespace Binance.Net.Clients.SpotApi
 {
@@ -16,6 +17,76 @@ namespace Binance.Net.Clients.SpotApi
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticExchangeParameters(Exchange);
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(BinanceExchange.Metadata, this);
+
+#warning move to public central location
+        private static HashSet<string> _exchangeSupportedFiatCurrencies = ["USD", "EUR"];
+        private static BinanceExchangeInfo? _spotExchangeInfo;
+        private static BinanceProduct[]? _products;
+        private static ExchangeCache Cache { get; } = new ExchangeCache(
+            new CacheItemDefinition<SharedSymbolCatalog>
+            {
+                Key = "Binance.Spot.ExchangeInfo",
+                Ttl = TimeSpan.FromMinutes(5),
+                ValueFactory = () => GetExchangeInfoAsync()
+            }
+        );
+
+        private static async Task<SharedSymbolCatalog> GetExchangeInfoAsync()
+        {
+            SharedAssetInfo MapAsset(string name)
+            {
+                var product = _products.FirstOrDefault(p => p.BaseAsset == name);
+                if (product?.Tags.Contains("bStocks", StringComparer.InvariantCultureIgnoreCase) == true)
+                    return new SharedAssetInfo(name, SharedAssetType.Rwa, SharedAssetSubType.Stock);
+
+                if (product?.Tags.Contains("tCommodities", StringComparer.InvariantCultureIgnoreCase) == true)
+                    return new SharedAssetInfo(name, SharedAssetType.Rwa, SharedAssetSubType.Commodity);
+
+                // Stablecoins / Fiat
+                if (LibraryHelpers.IsStableCoin(name))
+                    return new SharedAssetInfo(name, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
+
+                if (_exchangeSupportedFiatCurrencies.Contains(name))
+                    return new SharedAssetInfo(name, SharedAssetType.Fiat, null);
+
+                return new SharedAssetInfo(name, SharedAssetType.Crypto, null);
+            }
+
+            using var client = new BinanceRestClient();
+            var tasks = new List<Task>();
+            if (_spotExchangeInfo == null)
+                tasks.Add(client.SpotApi.ExchangeData.GetExchangeInfoAsync(false, Enums.SymbolStatus.Trading));
+            if (_products == null)
+                tasks.Add(client.SpotApi.ExchangeData.GetProductsAsync());
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            if (_spotExchangeInfo == null || _products == null)
+                throw new Exception($"Failed to retrieve exchange info");
+
+            var assets = new Dictionary<string, SharedAssetInfo>();
+            var symbols = new Dictionary<string, SharedSymbolInfo>();
+            foreach (var symbol in _spotExchangeInfo.Symbols)
+            {
+                if (!assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo))
+                {
+                    baseAssetInfo = MapAsset(symbol.BaseAsset);
+                    assets.Add(symbol.BaseAsset, baseAssetInfo);
+                }
+                if (!assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo))
+                {
+                    quoteAssetInfo = MapAsset(symbol.QuoteAsset);
+                    assets.Add(symbol.QuoteAsset, quoteAssetInfo);
+                }
+
+                symbols.Add(symbol.Name, new SharedSymbolInfo(symbol.Name, baseAssetInfo, quoteAssetInfo));
+            }
+
+            return new SharedSymbolCatalog
+            {
+                Assets = assets,
+                Symbols = symbols
+            };
+        }
 
         #region Klines Client
 
@@ -69,6 +140,8 @@ namespace Binance.Net.Clients.SpotApi
         #endregion
 
         #region Spot Symbol client
+        SharedSymbolCatalog? ISpotSymbolRestClient.SymbolCatalog => Cache.Get<SharedSymbolCatalog?>("Binance.Spot.live.ExchangeInfo");
+
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; }
             = new GetSpotSymbolsOptions(_exchangeName, false);
 
@@ -84,10 +157,10 @@ namespace Binance.Net.Clients.SpotApi
             if (!resultEx.Result.Success)
                 return HttpResult.Fail<SharedSpotSymbol[]>(resultEx.Result);
 
-            BinanceExchange._products = resultPr.Result.Data;
-            BinanceExchange._spotExchangeInfo = resultEx.Result.Data;
+            _products = resultPr.Result.Data;
+            _spotExchangeInfo = resultEx.Result.Data;
 
-            var exchangeInfo = await BinanceExchange.Cache.GetAsync<SharedExchangeInfo>("Binance.Spot.live.ExchangeInfo").ConfigureAwait(false);
+            var exchangeInfo = await Cache.GetOrRetrieveAsync<SharedSymbolCatalog>("Binance.Spot.live.ExchangeInfo").ConfigureAwait(false);
 
             var resultData = resultEx.Result.Data.Symbols.Select(x => ParseSymbol(x, exchangeInfo));
             ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.ToArray());
@@ -104,7 +177,7 @@ namespace Binance.Net.Clients.SpotApi
 
         }
 
-        private SharedSpotSymbol ParseSymbol(BinanceSymbol symbol, SharedExchangeInfo exchangeInfo)
+        private SharedSpotSymbol ParseSymbol(BinanceSymbol symbol, SharedSymbolCatalog exchangeInfo)
         {
             exchangeInfo.Assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo);
             exchangeInfo.Assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo);

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiShared.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiShared.cs
@@ -19,8 +19,6 @@ namespace Binance.Net.Clients.SpotApi
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticExchangeParameters(Exchange);
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(BinanceExchange.Metadata, this);
 
-        private static ConcurrentDictionary<string, SharedSymbolCatalog> _exchangeInfoCache = new ConcurrentDictionary<string, SharedSymbolCatalog>();
-        private static ConcurrentDictionary<string, SemaphoreSlim> _exchangeInfoLocks = new ConcurrentDictionary<string, SemaphoreSlim>();
         private static HashSet<string> _exchangeSupportedFiatCurrencies = ["AED", "ARS", "BRL", "COP", "EUR", "JPY", "KZT", "MXN", "UAH", "ZAR"];
 
         #region Klines Client
@@ -75,7 +73,7 @@ namespace Binance.Net.Clients.SpotApi
         #endregion
 
         #region Spot Symbol client
-        SharedSymbolCatalog? ISpotSymbolRestClient.SymbolCatalog => _exchangeInfoCache.TryGetValue(EnvironmentName, out var cache) ? cache : null;
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
 
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; }
             = new GetSpotSymbolsOptions(_exchangeName, false);
@@ -86,98 +84,33 @@ namespace Binance.Net.Clients.SpotApi
             if (validationError != null)
                 return HttpResult.Fail<SharedSpotSymbol[]>(Exchange, validationError);
 
-            var exchangeInfo = await ExchangeData.GetExchangeInfoAsync(false, SymbolStatus.Trading, ct: ct).ConfigureAwait(false);
-            if (!exchangeInfo.Success)
-                return HttpResult.Fail<SharedSpotSymbol[]>(exchangeInfo);
+            var exchangeInfoTask = ExchangeData.GetExchangeInfoAsync(false, SymbolStatus.Trading, ct: ct);
+            var productsTask = ExchangeData.GetProductsAsync(ct: ct);
+            await Task.WhenAll(exchangeInfoTask, productsTask).ConfigureAwait(false);
+            var exchangeInfoResult = exchangeInfoTask.Result;
+            var productsResult = productsTask.Result;
+            if (!exchangeInfoResult.Success)
+                return HttpResult.Fail<SharedSpotSymbol[]>(exchangeInfoResult);
 
-            if (!_exchangeInfoCache.TryGetValue(EnvironmentName, out var catalog)
-                || ExchangeInfoChanged(catalog, exchangeInfo.Data))
-            {
-                var locker = _exchangeInfoLocks.GetOrAdd(EnvironmentName, x => new SemaphoreSlim(1, 1));
-                await locker.WaitAsync(ct).ConfigureAwait(false);
-                try
-                {
-                    // Another thread might've already retrieved it while waiting for the lock
-                    _exchangeInfoCache.TryGetValue(EnvironmentName, out var currentCatalog);
-                    if (currentCatalog == null || ReferenceEquals(currentCatalog, catalog)) // Still the same catalog so try to update it
-                    {
-                        var products = await ExchangeData.GetProductsAsync(ct: ct).ConfigureAwait(false);
-                        if (!products.Success)
-                            _logger.LogWarning("Failed to retrieve product info for {Exchange} ({EnvironmentName}): {Error}", Exchange, EnvironmentName, products.Error);
-                        
-                        catalog = CreateCatalog(exchangeInfo.Data, products.Data);
-                        if (products.Success)
-                            _exchangeInfoCache[EnvironmentName] = catalog;
-                    }
-                    else
-                    {
-                        catalog = currentCatalog;
-                    }
-                }
-                finally
-                {
-                    locker.Release();
-                }
-            }
+            var data = exchangeInfoResult.Data.Symbols
+                .Select(x => ParseSymbol(x, productsResult.Data)!)
+                .Where(x => x != null)
+                .ToArray();
 
-            var resultData = exchangeInfo.Data.Symbols.Select(x => ParseSymbol(x, catalog));
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.ToArray());
-            if (request.BaseAssetType != null)
-                resultData = resultData.Where(x => x.BaseAssetType == request.BaseAssetType);
-            if (request.QuoteAssetType != null)
-                resultData = resultData.Where(x => x.QuoteAssetType == request.QuoteAssetType);
-            if (request.BaseAssetSubType != null)
-                resultData = resultData.Where(x => x.BaseAssetSubType == request.BaseAssetSubType);
-            if (request.QuoteAssetSubType != null)
-                resultData = resultData.Where(x => x.QuoteAssetSubType == request.QuoteAssetSubType);
-
-            return HttpResult.Ok(exchangeInfo, resultData.ToArray());
-
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, data);
+            return HttpResult.Ok(exchangeInfoResult, SharedUtils.ApplySymbolFilter(data, request));
         }
 
-        private bool ExchangeInfoChanged(SharedSymbolCatalog catalog, BinanceExchangeInfo data)
-        {
-            if (catalog.Symbols.Count != data.Symbols.Length)
-                return true;
-
-            foreach (var symbol in data.Symbols)
-            {
-                if (!catalog.Symbols.ContainsKey(symbol.Name))
-                    return true;
-            }
-
-            return false;
-        }
-
-        private SharedSpotSymbol ParseSymbol(BinanceSymbol symbol, SharedSymbolCatalog? exchangeInfo)
-        {
-            var baseAssetInfo = exchangeInfo?.Assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfoResult) == true ? baseAssetInfoResult : null;
-            var quoteAssetInfo = exchangeInfo?.Assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfoResult) == true ? quoteAssetInfoResult : null;
-            return new SharedSpotSymbol(symbol.BaseAsset, symbol.QuoteAsset, symbol.Name, symbol.Status == SymbolStatus.Trading && symbol.IsSpotTradingAllowed)
-            {
-                MinTradeQuantity = symbol.LotSizeFilter?.MinQuantity,
-                MaxTradeQuantity = symbol.LotSizeFilter?.MaxQuantity,
-                MinNotionalValue = symbol.MinNotionalFilter?.MinNotional ?? symbol.NotionalFilter?.MinNotional,
-                QuantityStep = symbol.LotSizeFilter?.StepSize,
-                PriceStep = symbol.PriceFilter?.TickSize,
-                DisplayName = symbol.Name,
-                BaseAssetType = baseAssetInfo?.Type ?? SharedAssetType.Unspecified,
-                BaseAssetSubType = baseAssetInfo?.SubType,
-                QuoteAssetType = quoteAssetInfo?.Type ?? SharedAssetType.Unspecified,
-                QuoteAssetSubType = quoteAssetInfo?.SubType
-            };
-        }
-
-        private SharedSymbolCatalog CreateCatalog(BinanceExchangeInfo exchangeInfo, BinanceProduct[]? products)
+        private SharedSpotSymbol ParseSymbol(BinanceSymbol symbol, BinanceProduct[]? products)
         {
             SharedAssetInfo MapAsset(string name)
             {
                 var product = products?.FirstOrDefault(p => p.BaseAsset == name);
                 if (product?.Tags.Contains("bStocks", StringComparer.InvariantCultureIgnoreCase) == true)
-                    return new SharedAssetInfo(name, SharedAssetType.Rwa, SharedAssetSubType.Stock);
+                    return new SharedAssetInfo(name, SharedAssetType.TradFi, SharedAssetSubType.Stock);
 
                 if (product?.Tags.Contains("tCommodities", StringComparer.InvariantCultureIgnoreCase) == true)
-                    return new SharedAssetInfo(name, SharedAssetType.Rwa, SharedAssetSubType.Commodity);
+                    return new SharedAssetInfo(name, SharedAssetType.TradFi, SharedAssetSubType.Commodity);
 
                 // Stablecoins / Fiat
                 if (LibraryHelpers.IsStableCoin(name))
@@ -192,30 +125,21 @@ namespace Binance.Net.Clients.SpotApi
                 return new SharedAssetInfo(name, SharedAssetType.Crypto, null);
             }
 
-            var assets = new Dictionary<string, SharedAssetInfo>();
-            var symbols = new Dictionary<string, SharedSymbolInfo>();
-            foreach (var symbol in exchangeInfo.Symbols)
+            var baseAssetInfo = MapAsset(symbol.BaseAsset);
+            var quoteAssetInfo = MapAsset(symbol.QuoteAsset);
+            return new SharedSpotSymbol(symbol.BaseAsset, symbol.QuoteAsset, symbol.Name, symbol.Status == SymbolStatus.Trading && symbol.IsSpotTradingAllowed)
             {
-                if (!assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo))
-                {
-                    baseAssetInfo = MapAsset(symbol.BaseAsset);
-                    assets.Add(symbol.BaseAsset, baseAssetInfo);
-                }
-                if (!assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo))
-                {
-                    quoteAssetInfo = MapAsset(symbol.QuoteAsset);
-                    assets.Add(symbol.QuoteAsset, quoteAssetInfo);
-                }
-
-                symbols.Add(symbol.Name, new SharedSymbolInfo(symbol.Name, baseAssetInfo, quoteAssetInfo));
-            }
-
-            var catalog = new SharedSymbolCatalog
-            {
-                Assets = assets,
-                Symbols = symbols
+                MinTradeQuantity = symbol.LotSizeFilter?.MinQuantity,
+                MaxTradeQuantity = symbol.LotSizeFilter?.MaxQuantity,
+                MinNotionalValue = symbol.MinNotionalFilter?.MinNotional ?? symbol.NotionalFilter?.MinNotional,
+                QuantityStep = symbol.LotSizeFilter?.StepSize,
+                PriceStep = symbol.PriceFilter?.TickSize,
+                DisplayName = symbol.Name,
+                BaseAssetType = baseAssetInfo?.Type ?? SharedAssetType.Unspecified,
+                BaseAssetSubType = baseAssetInfo?.SubType,
+                QuoteAssetType = quoteAssetInfo?.Type ?? SharedAssetType.Unspecified,
+                QuoteAssetSubType = quoteAssetInfo?.SubType
             };
-            return catalog;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiShared.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiShared.cs
@@ -4,6 +4,7 @@ using Binance.Net.Objects.Models.Spot;
 using CryptoExchange.Net.Caching;
 using CryptoExchange.Net.Objects.Errors;
 using CryptoExchange.Net.SharedApis;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 
 namespace Binance.Net.Clients.SpotApi
@@ -18,75 +19,9 @@ namespace Binance.Net.Clients.SpotApi
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticExchangeParameters(Exchange);
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(BinanceExchange.Metadata, this);
 
-#warning move to public central location
-        private static HashSet<string> _exchangeSupportedFiatCurrencies = ["USD", "EUR"];
-        private static BinanceExchangeInfo? _spotExchangeInfo;
-        private static BinanceProduct[]? _products;
-        private static ExchangeCache Cache { get; } = new ExchangeCache(
-            new CacheItemDefinition<SharedSymbolCatalog>
-            {
-                Key = "Binance.Spot.ExchangeInfo",
-                Ttl = TimeSpan.FromMinutes(5),
-                ValueFactory = () => GetExchangeInfoAsync()
-            }
-        );
-
-        private static async Task<SharedSymbolCatalog> GetExchangeInfoAsync()
-        {
-            SharedAssetInfo MapAsset(string name)
-            {
-                var product = _products.FirstOrDefault(p => p.BaseAsset == name);
-                if (product?.Tags.Contains("bStocks", StringComparer.InvariantCultureIgnoreCase) == true)
-                    return new SharedAssetInfo(name, SharedAssetType.Rwa, SharedAssetSubType.Stock);
-
-                if (product?.Tags.Contains("tCommodities", StringComparer.InvariantCultureIgnoreCase) == true)
-                    return new SharedAssetInfo(name, SharedAssetType.Rwa, SharedAssetSubType.Commodity);
-
-                // Stablecoins / Fiat
-                if (LibraryHelpers.IsStableCoin(name))
-                    return new SharedAssetInfo(name, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
-
-                if (_exchangeSupportedFiatCurrencies.Contains(name))
-                    return new SharedAssetInfo(name, SharedAssetType.Fiat, null);
-
-                return new SharedAssetInfo(name, SharedAssetType.Crypto, null);
-            }
-
-            using var client = new BinanceRestClient();
-            var tasks = new List<Task>();
-            if (_spotExchangeInfo == null)
-                tasks.Add(client.SpotApi.ExchangeData.GetExchangeInfoAsync(false, Enums.SymbolStatus.Trading));
-            if (_products == null)
-                tasks.Add(client.SpotApi.ExchangeData.GetProductsAsync());
-            await Task.WhenAll(tasks).ConfigureAwait(false);
-
-            if (_spotExchangeInfo == null || _products == null)
-                throw new Exception($"Failed to retrieve exchange info");
-
-            var assets = new Dictionary<string, SharedAssetInfo>();
-            var symbols = new Dictionary<string, SharedSymbolInfo>();
-            foreach (var symbol in _spotExchangeInfo.Symbols)
-            {
-                if (!assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo))
-                {
-                    baseAssetInfo = MapAsset(symbol.BaseAsset);
-                    assets.Add(symbol.BaseAsset, baseAssetInfo);
-                }
-                if (!assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo))
-                {
-                    quoteAssetInfo = MapAsset(symbol.QuoteAsset);
-                    assets.Add(symbol.QuoteAsset, quoteAssetInfo);
-                }
-
-                symbols.Add(symbol.Name, new SharedSymbolInfo(symbol.Name, baseAssetInfo, quoteAssetInfo));
-            }
-
-            return new SharedSymbolCatalog
-            {
-                Assets = assets,
-                Symbols = symbols
-            };
-        }
+        private static ConcurrentDictionary<string, SharedSymbolCatalog> _exchangeInfoCache = new ConcurrentDictionary<string, SharedSymbolCatalog>();
+        private static ConcurrentDictionary<string, SemaphoreSlim> _exchangeInfoLocks = new ConcurrentDictionary<string, SemaphoreSlim>();
+        private static HashSet<string> _exchangeSupportedFiatCurrencies = ["AED", "ARS", "BRL", "COP", "EUR", "JPY", "KZT", "MXN", "UAH", "ZAR"];
 
         #region Klines Client
 
@@ -140,7 +75,7 @@ namespace Binance.Net.Clients.SpotApi
         #endregion
 
         #region Spot Symbol client
-        SharedSymbolCatalog? ISpotSymbolRestClient.SymbolCatalog => Cache.Get<SharedSymbolCatalog?>("Binance.Spot.live.ExchangeInfo");
+        SharedSymbolCatalog? ISpotSymbolRestClient.SymbolCatalog => _exchangeInfoCache.TryGetValue(EnvironmentName, out var cache) ? cache : null;
 
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; }
             = new GetSpotSymbolsOptions(_exchangeName, false);
@@ -151,18 +86,41 @@ namespace Binance.Net.Clients.SpotApi
             if (validationError != null)
                 return HttpResult.Fail<SharedSpotSymbol[]>(Exchange, validationError);
 
-            var resultEx = ExchangeData.GetExchangeInfoAsync(false, SymbolStatus.Trading, ct: ct);
-            var resultPr = ExchangeData.GetProductsAsync(ct: ct);
-            await Task.WhenAll(resultEx, resultPr).ConfigureAwait(false);
-            if (!resultEx.Result.Success)
-                return HttpResult.Fail<SharedSpotSymbol[]>(resultEx.Result);
+            var exchangeInfo = await ExchangeData.GetExchangeInfoAsync(false, SymbolStatus.Trading, ct: ct).ConfigureAwait(false);
+            if (!exchangeInfo.Success)
+                return HttpResult.Fail<SharedSpotSymbol[]>(exchangeInfo);
 
-            _products = resultPr.Result.Data;
-            _spotExchangeInfo = resultEx.Result.Data;
+            if (!_exchangeInfoCache.TryGetValue(EnvironmentName, out var catalog)
+                || ExchangeInfoChanged(catalog, exchangeInfo.Data))
+            {
+                var locker = _exchangeInfoLocks.GetOrAdd(EnvironmentName, x => new SemaphoreSlim(1, 1));
+                await locker.WaitAsync(ct).ConfigureAwait(false);
+                try
+                {
+                    // Another thread might've already retrieved it while waiting for the lock
+                    _exchangeInfoCache.TryGetValue(EnvironmentName, out var currentCatalog);
+                    if (currentCatalog == null || ReferenceEquals(currentCatalog, catalog)) // Still the same catalog so try to update it
+                    {
+                        var products = await ExchangeData.GetProductsAsync(ct: ct).ConfigureAwait(false);
+                        if (!products.Success)
+                            _logger.LogWarning("Failed to retrieve product info for {Exchange} ({EnvironmentName}): {Error}", Exchange, EnvironmentName, products.Error);
+                        
+                        catalog = CreateCatalog(exchangeInfo.Data, products.Data);
+                        if (products.Success)
+                            _exchangeInfoCache[EnvironmentName] = catalog;
+                    }
+                    else
+                    {
+                        catalog = currentCatalog;
+                    }
+                }
+                finally
+                {
+                    locker.Release();
+                }
+            }
 
-            var exchangeInfo = await Cache.GetOrRetrieveAsync<SharedSymbolCatalog>("Binance.Spot.live.ExchangeInfo").ConfigureAwait(false);
-
-            var resultData = resultEx.Result.Data.Symbols.Select(x => ParseSymbol(x, exchangeInfo));
+            var resultData = exchangeInfo.Data.Symbols.Select(x => ParseSymbol(x, catalog));
             ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.ToArray());
             if (request.BaseAssetType != null)
                 resultData = resultData.Where(x => x.BaseAssetType == request.BaseAssetType);
@@ -173,14 +131,28 @@ namespace Binance.Net.Clients.SpotApi
             if (request.QuoteAssetSubType != null)
                 resultData = resultData.Where(x => x.QuoteAssetSubType == request.QuoteAssetSubType);
 
-            return HttpResult.Ok(resultEx.Result, resultData.ToArray());
+            return HttpResult.Ok(exchangeInfo, resultData.ToArray());
 
         }
 
-        private SharedSpotSymbol ParseSymbol(BinanceSymbol symbol, SharedSymbolCatalog exchangeInfo)
+        private bool ExchangeInfoChanged(SharedSymbolCatalog catalog, BinanceExchangeInfo data)
         {
-            exchangeInfo.Assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo);
-            exchangeInfo.Assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo);
+            if (catalog.Symbols.Count != data.Symbols.Length)
+                return true;
+
+            foreach (var symbol in data.Symbols)
+            {
+                if (!catalog.Symbols.ContainsKey(symbol.Name))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private SharedSpotSymbol ParseSymbol(BinanceSymbol symbol, SharedSymbolCatalog? exchangeInfo)
+        {
+            var baseAssetInfo = exchangeInfo?.Assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfoResult) == true ? baseAssetInfoResult : null;
+            var quoteAssetInfo = exchangeInfo?.Assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfoResult) == true ? quoteAssetInfoResult : null;
             return new SharedSpotSymbol(symbol.BaseAsset, symbol.QuoteAsset, symbol.Name, symbol.Status == SymbolStatus.Trading && symbol.IsSpotTradingAllowed)
             {
                 MinTradeQuantity = symbol.LotSizeFilter?.MinQuantity,
@@ -194,6 +166,56 @@ namespace Binance.Net.Clients.SpotApi
                 QuoteAssetType = quoteAssetInfo?.Type ?? SharedAssetType.Unspecified,
                 QuoteAssetSubType = quoteAssetInfo?.SubType
             };
+        }
+
+        private SharedSymbolCatalog CreateCatalog(BinanceExchangeInfo exchangeInfo, BinanceProduct[]? products)
+        {
+            SharedAssetInfo MapAsset(string name)
+            {
+                var product = products?.FirstOrDefault(p => p.BaseAsset == name);
+                if (product?.Tags.Contains("bStocks", StringComparer.InvariantCultureIgnoreCase) == true)
+                    return new SharedAssetInfo(name, SharedAssetType.Rwa, SharedAssetSubType.Stock);
+
+                if (product?.Tags.Contains("tCommodities", StringComparer.InvariantCultureIgnoreCase) == true)
+                    return new SharedAssetInfo(name, SharedAssetType.Rwa, SharedAssetSubType.Commodity);
+
+                // Stablecoins / Fiat
+                if (LibraryHelpers.IsStableCoin(name))
+                    return new SharedAssetInfo(name, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
+
+                if (_exchangeSupportedFiatCurrencies.Contains(name))
+                    return new SharedAssetInfo(name, SharedAssetType.Fiat, null);
+
+                if (products == null)
+                    return new SharedAssetInfo(name, SharedAssetType.Unspecified, null);
+
+                return new SharedAssetInfo(name, SharedAssetType.Crypto, null);
+            }
+
+            var assets = new Dictionary<string, SharedAssetInfo>();
+            var symbols = new Dictionary<string, SharedSymbolInfo>();
+            foreach (var symbol in exchangeInfo.Symbols)
+            {
+                if (!assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo))
+                {
+                    baseAssetInfo = MapAsset(symbol.BaseAsset);
+                    assets.Add(symbol.BaseAsset, baseAssetInfo);
+                }
+                if (!assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo))
+                {
+                    quoteAssetInfo = MapAsset(symbol.QuoteAsset);
+                    assets.Add(symbol.QuoteAsset, quoteAssetInfo);
+                }
+
+                symbols.Add(symbol.Name, new SharedSymbolInfo(symbol.Name, baseAssetInfo, quoteAssetInfo));
+            }
+
+            var catalog = new SharedSymbolCatalog
+            {
+                Assets = assets,
+                Symbols = symbols
+            };
+            return catalog;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiShared.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiShared.cs
@@ -3,6 +3,7 @@ using Binance.Net.Interfaces.Clients.SpotApi;
 using Binance.Net.Objects.Models.Spot;
 using CryptoExchange.Net.Objects.Errors;
 using CryptoExchange.Net.SharedApis;
+using CryptoExchange.Net.SharedApis.Models;
 
 namespace Binance.Net.Clients.SpotApi
 {
@@ -77,22 +78,49 @@ namespace Binance.Net.Clients.SpotApi
             if (validationError != null)
                 return HttpResult.Fail<SharedSpotSymbol[]>(Exchange, validationError);
 
-            var result = await ExchangeData.GetExchangeInfoAsync(false, SymbolStatus.Trading, ct: ct).ConfigureAwait(false);
-            if (!result.Success)
-                return HttpResult.Fail<SharedSpotSymbol[]>(result);
+            var resultEx = ExchangeData.GetExchangeInfoAsync(false, SymbolStatus.Trading, ct: ct);
+            var resultPr = ExchangeData.GetProductsAsync(ct: ct);
+            await Task.WhenAll(resultEx, resultPr).ConfigureAwait(false);
+            if (!resultEx.Result.Success)
+                return HttpResult.Fail<SharedSpotSymbol[]>(resultEx.Result);
 
-            var resultData = result.Data!.Symbols.Select(s => new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Name, s.Status == SymbolStatus.Trading && s.IsSpotTradingAllowed)
+            BinanceExchange._products = resultPr.Result.Data;
+            BinanceExchange._spotExchangeInfo = resultEx.Result.Data;
+
+            var exchangeInfo = await BinanceExchange.Cache.GetAsync<SharedExchangeInfo>("Binance.Spot.live.ExchangeInfo").ConfigureAwait(false);
+
+            var resultData = resultEx.Result.Data.Symbols.Select(x => ParseSymbol(x, exchangeInfo));
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.ToArray());
+            if (request.BaseAssetType != null)
+                resultData = resultData.Where(x => x.BaseAssetType == request.BaseAssetType);
+            if (request.QuoteAssetType != null)
+                resultData = resultData.Where(x => x.QuoteAssetType == request.QuoteAssetType);
+            if (request.BaseAssetSubType != null)
+                resultData = resultData.Where(x => x.BaseAssetSubType == request.BaseAssetSubType);
+            if (request.QuoteAssetSubType != null)
+                resultData = resultData.Where(x => x.QuoteAssetSubType == request.QuoteAssetSubType);
+
+            return HttpResult.Ok(resultEx.Result, resultData.ToArray());
+
+        }
+
+        private SharedSpotSymbol ParseSymbol(BinanceSymbol symbol, SharedExchangeInfo exchangeInfo)
+        {
+            exchangeInfo.Assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo);
+            exchangeInfo.Assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo);
+            return new SharedSpotSymbol(symbol.BaseAsset, symbol.QuoteAsset, symbol.Name, symbol.Status == SymbolStatus.Trading && symbol.IsSpotTradingAllowed)
             {
-                MinTradeQuantity = s.LotSizeFilter?.MinQuantity,
-                MaxTradeQuantity = s.LotSizeFilter?.MaxQuantity,
-                MinNotionalValue = s.MinNotionalFilter?.MinNotional ?? s.NotionalFilter?.MinNotional,
-                QuantityStep = s.LotSizeFilter?.StepSize,
-                PriceStep = s.PriceFilter?.TickSize
-            }).ToArray();
-
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData);
-            return HttpResult.Ok(result, resultData);
-
+                MinTradeQuantity = symbol.LotSizeFilter?.MinQuantity,
+                MaxTradeQuantity = symbol.LotSizeFilter?.MaxQuantity,
+                MinNotionalValue = symbol.MinNotionalFilter?.MinNotional ?? symbol.NotionalFilter?.MinNotional,
+                QuantityStep = symbol.LotSizeFilter?.StepSize,
+                PriceStep = symbol.PriceFilter?.TickSize,
+                DisplayName = symbol.Name,
+                BaseAssetType = baseAssetInfo?.Type ?? SharedAssetType.Unspecified,
+                BaseAssetSubType = baseAssetInfo?.SubType,
+                QuoteAssetType = quoteAssetInfo?.Type ?? SharedAssetType.Unspecified,
+                QuoteAssetSubType = quoteAssetInfo?.SubType
+            };
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiShared.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiShared.cs
@@ -73,7 +73,7 @@ namespace Binance.Net.Clients.SpotApi
         #endregion
 
         #region Spot Symbol client
-        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
 
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; }
             = new GetSpotSymbolsOptions(_exchangeName, false);

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiShared.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiShared.cs
@@ -107,7 +107,7 @@ namespace Binance.Net.Clients.SpotApi
             {
                 var product = products?.FirstOrDefault(p => p.BaseAsset == name);
                 if (product?.Tags.Contains("bStocks", StringComparer.InvariantCultureIgnoreCase) == true)
-                    return new SharedAssetInfo(name, SharedAssetType.TradFi, SharedAssetSubType.Stock);
+                    return new SharedAssetInfo(name, SharedAssetType.TradFi, SharedAssetSubType.Equity);
 
                 if (product?.Tags.Contains("tCommodities", StringComparer.InvariantCultureIgnoreCase) == true)
                     return new SharedAssetInfo(name, SharedAssetType.TradFi, SharedAssetSubType.Commodity);

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiShared.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiShared.cs
@@ -120,7 +120,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
         #endregion
 
         #region Futures Symbol client
-        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
 
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiShared.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiShared.cs
@@ -5,6 +5,7 @@ using Binance.Net.Objects.Models.Futures;
 using CryptoExchange.Net.Caching;
 using CryptoExchange.Net.Objects.Errors;
 using CryptoExchange.Net.SharedApis;
+using System.Collections.Concurrent;
 
 namespace Binance.Net.Clients.UsdFuturesApi
 {
@@ -18,80 +19,8 @@ namespace Binance.Net.Clients.UsdFuturesApi
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(BinanceExchange.Metadata, this);
 
-        private static ExchangeCache Cache { get; } = new ExchangeCache(
-            new CacheItemDefinition<SharedSymbolCatalog>
-            {
-                Key = "Binance.UsdtFutures.ExchangeInfo",
-                Ttl = TimeSpan.FromMinutes(5),
-                ValueFactory = () => GetExchangeInfoAsync(),
-            }
-        );
-
-        private static BinanceFuturesUsdtExchangeInfo? _usdtFuturesExchangeInfo;
-        private static async Task<SharedSymbolCatalog> GetExchangeInfoAsync()
-        {
-            SharedAssetInfo MapAsset(BinanceFuturesUsdtSymbol symbol)
-            {
-                if (symbol.ContractType == ContractType.PerpetualTradFi)
-                {
-                    if (symbol.UnderlyingType == UnderlyingType.Commodity)
-                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Commodity);
-
-                    if (symbol.UnderlyingType == UnderlyingType.Equity
-                    || symbol.UnderlyingType == UnderlyingType.KrEquity
-                    || symbol.UnderlyingType == UnderlyingType.PreMarket)
-                    {
-                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Stock);
-                    }
-
-                    return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, null);
-                }
-
-                if (symbol.UnderlyingType == UnderlyingType.Coin || symbol.UnderlyingType == UnderlyingType.Index)
-                {
-                    if (LibraryHelpers.IsStableCoin(symbol.BaseAsset))
-                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
-
-                    return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Crypto, null);
-                }
-
-                return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Unspecified, null);
-            }
-
-            using var client = new BinanceRestClient();
-            var tasks = new List<Task>();
-            if (_usdtFuturesExchangeInfo == null)
-                tasks.Add(client.UsdFuturesApi.ExchangeData.GetExchangeInfoAsync());
-            await Task.WhenAll(tasks).ConfigureAwait(false);
-
-            if (_usdtFuturesExchangeInfo == null)
-                throw new Exception($"Failed to retrieve exchange info");
-
-            var assets = new Dictionary<string, SharedAssetInfo>();
-            var symbols = new Dictionary<string, SharedSymbolInfo>();
-            foreach (var symbol in _usdtFuturesExchangeInfo.Symbols)
-            {
-                if (!assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo))
-                {
-                    baseAssetInfo = MapAsset(symbol);
-                    assets.Add(symbol.BaseAsset, baseAssetInfo);
-                }
-
-                if (!assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo))
-                {
-                    quoteAssetInfo = new SharedAssetInfo(symbol.QuoteAsset, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
-                    assets.Add(symbol.QuoteAsset, quoteAssetInfo);
-                }
-
-                symbols.Add(symbol.Name, new SharedSymbolInfo(symbol.Name, baseAssetInfo, quoteAssetInfo));
-            }
-
-            return new SharedSymbolCatalog
-            {
-                Assets = assets,
-                Symbols = symbols
-            };
-        }
+        private static ConcurrentDictionary<string, SharedSymbolCatalog> _exchangeInfoCache = new ConcurrentDictionary<string, SharedSymbolCatalog>();
+        private static ConcurrentDictionary<string, SemaphoreSlim> _exchangeInfoLocks = new ConcurrentDictionary<string, SemaphoreSlim>();
 
         #region Klines client
 
@@ -194,7 +123,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
         #endregion
 
         #region Futures Symbol client
-        SharedSymbolCatalog? IFuturesSymbolRestClient.SymbolCatalog => Cache.Get<SharedSymbolCatalog?>("Binance.UsdtFutures.live.ExchangeInfo");
+        SharedSymbolCatalog? IFuturesSymbolRestClient.SymbolCatalog => _exchangeInfoCache.TryGetValue(EnvironmentName, out var cache) ? cache : null;
 
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
@@ -203,17 +132,37 @@ namespace Binance.Net.Clients.UsdFuturesApi
             if (validationError != null)
                 return HttpResult.Fail<SharedFuturesSymbol[]>(Exchange, validationError);
 
-            var result = await ExchangeData.GetExchangeInfoAsync(ct).ConfigureAwait(false);
-            if (!result.Success)
-                return HttpResult.Fail<SharedFuturesSymbol[]>(result);
+            var exchangeInfo = await ExchangeData.GetExchangeInfoAsync(ct).ConfigureAwait(false);
+            if (!exchangeInfo.Success)
+                return HttpResult.Fail<SharedFuturesSymbol[]>(exchangeInfo);
 
-            _usdtFuturesExchangeInfo = result.Data;
-            var exchangeInfo = await Cache.GetOrRetrieveAsync<SharedSymbolCatalog>("Binance.UsdtFutures.live.ExchangeInfo").ConfigureAwait(false);
+            if (!_exchangeInfoCache.TryGetValue(EnvironmentName, out var catalog)
+                || ExchangeInfoChanged(catalog, exchangeInfo.Data))
+            {
+                var locker = _exchangeInfoLocks.GetOrAdd(EnvironmentName, x => new SemaphoreSlim(1, 1));
+                await locker.WaitAsync(ct).ConfigureAwait(false);
+                try
+                {
+                    // Another thread might've already retrieved it while waiting for the lock
+                    _exchangeInfoCache.TryGetValue(EnvironmentName, out var currentCatalog);
+                    if (currentCatalog == null || ReferenceEquals(currentCatalog, catalog)) // Still the same catalog so try to update it
+                    {
+                        catalog = CreateCatalog(exchangeInfo.Data);
+                        _exchangeInfoCache[EnvironmentName] = catalog;
+                    }
+                    else
+                    {
+                        catalog = currentCatalog;
+                    }
+                }
+                finally
+                {
+                    locker.Release();
+                }
+            }
 
-            var data = result.Data.Symbols.Where(x => x.ContractType != null);
-            var resultData = data.Select(x => ParseSymbol(x, exchangeInfo));
+            var resultData = exchangeInfo.Data.Symbols.Where(x => x.ContractType != null).Select(x => ParseSymbol(x, catalog));
             ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.ToArray());
-
             if (request.TradingMode != null)
                 resultData = resultData.Where(x => x.TradingMode == request.TradingMode);
             if (request.BaseAssetType != null)
@@ -225,15 +174,85 @@ namespace Binance.Net.Clients.UsdFuturesApi
             if (request.QuoteAssetSubType != null)
                 resultData = resultData.Where(x => x.QuoteAssetSubType == request.QuoteAssetSubType);
 
-            return HttpResult.Ok(result, resultData.ToArray());
+            return HttpResult.Ok(exchangeInfo, resultData.ToArray());
+        }
 
+        private bool ExchangeInfoChanged(SharedSymbolCatalog catalog, BinanceFuturesUsdtExchangeInfo data)
+        {
+            if (catalog.Symbols.Count != data.Symbols.Length)
+                return true;
+
+            foreach (var symbol in data.Symbols)
+            {
+                if (!catalog.Symbols.ContainsKey(symbol.Name))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private SharedSymbolCatalog CreateCatalog(BinanceFuturesUsdtExchangeInfo exchangeInfo)
+        {
+            SharedAssetInfo MapAsset(BinanceFuturesUsdtSymbol symbol)
+            {
+                if (symbol.ContractType == ContractType.PerpetualTradFi)
+                {
+                    if (symbol.UnderlyingType == UnderlyingType.Commodity)
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Commodity);
+
+                    if (symbol.UnderlyingType == UnderlyingType.Equity
+                    || symbol.UnderlyingType == UnderlyingType.KrEquity
+                    || symbol.UnderlyingType == UnderlyingType.PreMarket)
+                    {
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Stock);
+                    }
+
+                    return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, null);
+                }
+
+                if (symbol.UnderlyingType == UnderlyingType.Coin || symbol.UnderlyingType == UnderlyingType.Index)
+                {
+                    if (LibraryHelpers.IsStableCoin(symbol.BaseAsset))
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
+
+                    return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Crypto, null);
+                }
+
+                return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Unspecified, null);
+            }
+
+            var assets = new Dictionary<string, SharedAssetInfo>();
+            var symbols = new Dictionary<string, SharedSymbolInfo>();
+            foreach (var symbol in exchangeInfo.Symbols)
+            {
+                if (!assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo))
+                {
+                    baseAssetInfo = MapAsset(symbol);
+                    assets.Add(symbol.BaseAsset, baseAssetInfo);
+                }
+
+                if (!assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo))
+                {
+                    quoteAssetInfo = new SharedAssetInfo(symbol.QuoteAsset, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
+                    assets.Add(symbol.QuoteAsset, quoteAssetInfo);
+                }
+
+                symbols.Add(symbol.Name, new SharedSymbolInfo(symbol.Name, baseAssetInfo, quoteAssetInfo));
+            }
+
+            return new SharedSymbolCatalog
+            {
+                Assets = assets,
+                Symbols = symbols
+            };
         }
 
         private SharedFuturesSymbol ParseSymbol(BinanceFuturesUsdtSymbol s, SharedSymbolCatalog exchangeInfo)
         {
             exchangeInfo.Assets.TryGetValue(s.BaseAsset, out var baseAssetInfo);
             exchangeInfo.Assets.TryGetValue(s.QuoteAsset, out var quoteAssetInfo);
-            return new SharedFuturesSymbol(s.ContractType == ContractType.Perpetual ? TradingMode.PerpetualLinear : TradingMode.DeliveryLinear,
+            var isPerp = s.ContractType == ContractType.Perpetual || s.ContractType == ContractType.PerpetualTradFi || s.ContractType == ContractType.PerpetualDelivering;
+            return new SharedFuturesSymbol(isPerp ? TradingMode.PerpetualLinear : TradingMode.DeliveryLinear,
                 s.BaseAsset,
                 s.QuoteAsset,
                 s.Name,

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiShared.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiShared.cs
@@ -19,9 +19,6 @@ namespace Binance.Net.Clients.UsdFuturesApi
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(BinanceExchange.Metadata, this);
 
-        private static ConcurrentDictionary<string, SharedSymbolCatalog> _exchangeInfoCache = new ConcurrentDictionary<string, SharedSymbolCatalog>();
-        private static ConcurrentDictionary<string, SemaphoreSlim> _exchangeInfoLocks = new ConcurrentDictionary<string, SemaphoreSlim>();
-
         #region Klines client
 
         GetKlinesOptions IKlineRestClient.GetKlinesOptions { get; } = new GetKlinesOptions(_exchangeName, true, true, true, 1000, false);
@@ -123,7 +120,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
         #endregion
 
         #region Futures Symbol client
-        SharedSymbolCatalog? IFuturesSymbolRestClient.SymbolCatalog => _exchangeInfoCache.TryGetValue(EnvironmentName, out var cache) ? cache : null;
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
 
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
@@ -136,78 +133,32 @@ namespace Binance.Net.Clients.UsdFuturesApi
             if (!exchangeInfo.Success)
                 return HttpResult.Fail<SharedFuturesSymbol[]>(exchangeInfo);
 
-            if (!_exchangeInfoCache.TryGetValue(EnvironmentName, out var catalog)
-                || ExchangeInfoChanged(catalog, exchangeInfo.Data))
-            {
-                var locker = _exchangeInfoLocks.GetOrAdd(EnvironmentName, x => new SemaphoreSlim(1, 1));
-                await locker.WaitAsync(ct).ConfigureAwait(false);
-                try
-                {
-                    // Another thread might've already retrieved it while waiting for the lock
-                    _exchangeInfoCache.TryGetValue(EnvironmentName, out var currentCatalog);
-                    if (currentCatalog == null || ReferenceEquals(currentCatalog, catalog)) // Still the same catalog so try to update it
-                    {
-                        catalog = CreateCatalog(exchangeInfo.Data);
-                        _exchangeInfoCache[EnvironmentName] = catalog;
-                    }
-                    else
-                    {
-                        catalog = currentCatalog;
-                    }
-                }
-                finally
-                {
-                    locker.Release();
-                }
-            }
+            var data = exchangeInfo.Data.Symbols
+                .Select(x => ParseSymbol(x)!)
+                .Where(x => x != null)
+                .ToArray();
 
-            var resultData = exchangeInfo.Data.Symbols.Where(x => x.ContractType != null).Select(x => ParseSymbol(x, catalog));
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.ToArray());
-            if (request.TradingMode != null)
-                resultData = resultData.Where(x => x.TradingMode == request.TradingMode);
-            if (request.BaseAssetType != null)
-                resultData = resultData.Where(x => x.BaseAssetType == request.BaseAssetType);
-            if (request.QuoteAssetType != null)
-                resultData = resultData.Where(x => x.QuoteAssetType == request.QuoteAssetType);
-            if (request.BaseAssetSubType != null)
-                resultData = resultData.Where(x => x.BaseAssetSubType == request.BaseAssetSubType);
-            if (request.QuoteAssetSubType != null)
-                resultData = resultData.Where(x => x.QuoteAssetSubType == request.QuoteAssetSubType);
-
-            return HttpResult.Ok(exchangeInfo, resultData.ToArray());
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, data);
+            return HttpResult.Ok(exchangeInfo, SharedUtils.ApplySymbolFilter(data, request));
         }
 
-        private bool ExchangeInfoChanged(SharedSymbolCatalog catalog, BinanceFuturesUsdtExchangeInfo data)
-        {
-            if (catalog.Symbols.Count != data.Symbols.Length)
-                return true;
-
-            foreach (var symbol in data.Symbols)
-            {
-                if (!catalog.Symbols.ContainsKey(symbol.Name))
-                    return true;
-            }
-
-            return false;
-        }
-
-        private SharedSymbolCatalog CreateCatalog(BinanceFuturesUsdtExchangeInfo exchangeInfo)
+        private SharedFuturesSymbol ParseSymbol(BinanceFuturesUsdtSymbol s)
         {
             SharedAssetInfo MapAsset(BinanceFuturesUsdtSymbol symbol)
             {
                 if (symbol.ContractType == ContractType.PerpetualTradFi)
                 {
                     if (symbol.UnderlyingType == UnderlyingType.Commodity)
-                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Commodity);
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.TradFi, SharedAssetSubType.Commodity);
 
                     if (symbol.UnderlyingType == UnderlyingType.Equity
                     || symbol.UnderlyingType == UnderlyingType.KrEquity
                     || symbol.UnderlyingType == UnderlyingType.PreMarket)
                     {
-                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Stock);
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.TradFi, SharedAssetSubType.Stock);
                     }
 
-                    return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, null);
+                    return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.TradFi, null);
                 }
 
                 if (symbol.UnderlyingType == UnderlyingType.Coin || symbol.UnderlyingType == UnderlyingType.Index)
@@ -221,36 +172,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
                 return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Unspecified, null);
             }
 
-            var assets = new Dictionary<string, SharedAssetInfo>();
-            var symbols = new Dictionary<string, SharedSymbolInfo>();
-            foreach (var symbol in exchangeInfo.Symbols)
-            {
-                if (!assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo))
-                {
-                    baseAssetInfo = MapAsset(symbol);
-                    assets.Add(symbol.BaseAsset, baseAssetInfo);
-                }
-
-                if (!assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo))
-                {
-                    quoteAssetInfo = new SharedAssetInfo(symbol.QuoteAsset, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
-                    assets.Add(symbol.QuoteAsset, quoteAssetInfo);
-                }
-
-                symbols.Add(symbol.Name, new SharedSymbolInfo(symbol.Name, baseAssetInfo, quoteAssetInfo));
-            }
-
-            return new SharedSymbolCatalog
-            {
-                Assets = assets,
-                Symbols = symbols
-            };
-        }
-
-        private SharedFuturesSymbol ParseSymbol(BinanceFuturesUsdtSymbol s, SharedSymbolCatalog exchangeInfo)
-        {
-            exchangeInfo.Assets.TryGetValue(s.BaseAsset, out var baseAssetInfo);
-            exchangeInfo.Assets.TryGetValue(s.QuoteAsset, out var quoteAssetInfo);
+            var baseAssetInfo = MapAsset(s);
             var isPerp = s.ContractType == ContractType.Perpetual || s.ContractType == ContractType.PerpetualTradFi || s.ContractType == ContractType.PerpetualDelivering;
             return new SharedFuturesSymbol(isPerp ? TradingMode.PerpetualLinear : TradingMode.DeliveryLinear,
                 s.BaseAsset,
@@ -267,8 +189,8 @@ namespace Binance.Net.Clients.UsdFuturesApi
                 DeliveryTime = s.DeliveryDate.Year == 2100 ? null : s.DeliveryDate,
                 BaseAssetType = baseAssetInfo?.Type ?? SharedAssetType.Unspecified,
                 BaseAssetSubType = baseAssetInfo?.SubType,
-                QuoteAssetType = quoteAssetInfo?.Type ?? SharedAssetType.Unspecified,
-                QuoteAssetSubType = quoteAssetInfo?.SubType,
+                QuoteAssetType = SharedAssetType.Crypto,
+                QuoteAssetSubType = SharedAssetSubType.StableCoin,
                 DisplayName = s.Name
             };
         }

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiShared.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiShared.cs
@@ -4,6 +4,7 @@ using Binance.Net.Interfaces.Clients.UsdFuturesApi;
 using Binance.Net.Objects.Models.Futures;
 using CryptoExchange.Net.Objects.Errors;
 using CryptoExchange.Net.SharedApis;
+using CryptoExchange.Net.SharedApis.Models;
 
 namespace Binance.Net.Clients.UsdFuturesApi
 {
@@ -130,15 +131,37 @@ namespace Binance.Net.Clients.UsdFuturesApi
             if (!result.Success)
                 return HttpResult.Fail<SharedFuturesSymbol[]>(result);
 
+            BinanceExchange._usdtFuturesExchangeInfo = result.Data;
+            var exchangeInfo = await BinanceExchange.Cache.GetAsync<SharedExchangeInfo>("Binance.UsdtFutures.live.ExchangeInfo").ConfigureAwait(false);
+
             var data = result.Data.Symbols.Where(x => x.ContractType != null);
+            var resultData = data.Select(x => ParseSymbol(x, exchangeInfo));
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.ToArray());
+
             if (request.TradingMode != null)
-                data = data.Where(x => FilterContractType(request.TradingMode.Value, x.ContractType!.Value));
-            var resultData = data.Select(s =>
-            new SharedFuturesSymbol(s.ContractType == ContractType.Perpetual ? TradingMode.PerpetualLinear : TradingMode.DeliveryLinear,
-            s.BaseAsset,
-            s.QuoteAsset,
-            s.Name,
-            s.Status == SymbolStatus.Trading)
+                resultData = resultData.Where(x => x.TradingMode == request.TradingMode);
+            if (request.BaseAssetType != null)
+                resultData = resultData.Where(x => x.BaseAssetType == request.BaseAssetType);
+            if (request.QuoteAssetType != null)
+                resultData = resultData.Where(x => x.QuoteAssetType == request.QuoteAssetType);
+            if (request.BaseAssetSubType != null)
+                resultData = resultData.Where(x => x.BaseAssetSubType == request.BaseAssetSubType);
+            if (request.QuoteAssetSubType != null)
+                resultData = resultData.Where(x => x.QuoteAssetSubType == request.QuoteAssetSubType);
+
+            return HttpResult.Ok(result, resultData.ToArray());
+
+        }
+
+        private SharedFuturesSymbol ParseSymbol(BinanceFuturesUsdtSymbol s, SharedExchangeInfo exchangeInfo)
+        {
+            exchangeInfo.Assets.TryGetValue(s.BaseAsset, out var baseAssetInfo);
+            exchangeInfo.Assets.TryGetValue(s.QuoteAsset, out var quoteAssetInfo);
+            return new SharedFuturesSymbol(s.ContractType == ContractType.Perpetual ? TradingMode.PerpetualLinear : TradingMode.DeliveryLinear,
+                s.BaseAsset,
+                s.QuoteAsset,
+                s.Name,
+                s.Status == SymbolStatus.Trading)
             {
                 MinTradeQuantity = s.LotSizeFilter?.MinQuantity,
                 MaxTradeQuantity = s.LotSizeFilter?.MaxQuantity,
@@ -146,21 +169,13 @@ namespace Binance.Net.Clients.UsdFuturesApi
                 PriceStep = s.PriceFilter?.TickSize,
                 MinNotionalValue = s.MinNotionalFilter?.MinNotional,
                 ContractSize = 1,
-                DeliveryTime = s.DeliveryDate.Year == 2100 ? null : s.DeliveryDate
-            }).ToArray();
-
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData);
-            return HttpResult.Ok(result, resultData);
-
-        }
-
-        private bool FilterContractType(TradingMode mode, ContractType type)
-        {
-            var isPerp = type == ContractType.Perpetual || type == ContractType.PerpetualDelivering || type == ContractType.PerpetualTradFi;
-            if (mode == TradingMode.PerpetualLinear)
-                return isPerp;
-
-            return !isPerp;
+                DeliveryTime = s.DeliveryDate.Year == 2100 ? null : s.DeliveryDate,
+                BaseAssetType = baseAssetInfo?.Type ?? SharedAssetType.Unspecified,
+                BaseAssetSubType = baseAssetInfo?.SubType,
+                QuoteAssetType = quoteAssetInfo?.Type ?? SharedAssetType.Unspecified,
+                QuoteAssetSubType = quoteAssetInfo?.SubType,
+                DisplayName = s.Name
+            };
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiShared.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiShared.cs
@@ -155,7 +155,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
                     || symbol.UnderlyingType == UnderlyingType.KrEquity
                     || symbol.UnderlyingType == UnderlyingType.PreMarket)
                     {
-                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.TradFi, SharedAssetSubType.Stock);
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.TradFi, SharedAssetSubType.Equity);
                     }
 
                     return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.TradFi, null);

--- a/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiShared.cs
+++ b/Binance.Net/Clients/UsdFuturesApi/BinanceRestClientUsdFuturesApiShared.cs
@@ -2,9 +2,9 @@ using Binance.Net.Enums;
 using Binance.Net.Interfaces;
 using Binance.Net.Interfaces.Clients.UsdFuturesApi;
 using Binance.Net.Objects.Models.Futures;
+using CryptoExchange.Net.Caching;
 using CryptoExchange.Net.Objects.Errors;
 using CryptoExchange.Net.SharedApis;
-using CryptoExchange.Net.SharedApis.Models;
 
 namespace Binance.Net.Clients.UsdFuturesApi
 {
@@ -17,6 +17,81 @@ namespace Binance.Net.Clients.UsdFuturesApi
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(BinanceExchange.Metadata, this);
+
+        private static ExchangeCache Cache { get; } = new ExchangeCache(
+            new CacheItemDefinition<SharedSymbolCatalog>
+            {
+                Key = "Binance.UsdtFutures.ExchangeInfo",
+                Ttl = TimeSpan.FromMinutes(5),
+                ValueFactory = () => GetExchangeInfoAsync(),
+            }
+        );
+
+        private static BinanceFuturesUsdtExchangeInfo? _usdtFuturesExchangeInfo;
+        private static async Task<SharedSymbolCatalog> GetExchangeInfoAsync()
+        {
+            SharedAssetInfo MapAsset(BinanceFuturesUsdtSymbol symbol)
+            {
+                if (symbol.ContractType == ContractType.PerpetualTradFi)
+                {
+                    if (symbol.UnderlyingType == UnderlyingType.Commodity)
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Commodity);
+
+                    if (symbol.UnderlyingType == UnderlyingType.Equity
+                    || symbol.UnderlyingType == UnderlyingType.KrEquity
+                    || symbol.UnderlyingType == UnderlyingType.PreMarket)
+                    {
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, SharedAssetSubType.Stock);
+                    }
+
+                    return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Rwa, null);
+                }
+
+                if (symbol.UnderlyingType == UnderlyingType.Coin || symbol.UnderlyingType == UnderlyingType.Index)
+                {
+                    if (LibraryHelpers.IsStableCoin(symbol.BaseAsset))
+                        return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
+
+                    return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Crypto, null);
+                }
+
+                return new SharedAssetInfo(symbol.BaseAsset, SharedAssetType.Unspecified, null);
+            }
+
+            using var client = new BinanceRestClient();
+            var tasks = new List<Task>();
+            if (_usdtFuturesExchangeInfo == null)
+                tasks.Add(client.UsdFuturesApi.ExchangeData.GetExchangeInfoAsync());
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            if (_usdtFuturesExchangeInfo == null)
+                throw new Exception($"Failed to retrieve exchange info");
+
+            var assets = new Dictionary<string, SharedAssetInfo>();
+            var symbols = new Dictionary<string, SharedSymbolInfo>();
+            foreach (var symbol in _usdtFuturesExchangeInfo.Symbols)
+            {
+                if (!assets.TryGetValue(symbol.BaseAsset, out var baseAssetInfo))
+                {
+                    baseAssetInfo = MapAsset(symbol);
+                    assets.Add(symbol.BaseAsset, baseAssetInfo);
+                }
+
+                if (!assets.TryGetValue(symbol.QuoteAsset, out var quoteAssetInfo))
+                {
+                    quoteAssetInfo = new SharedAssetInfo(symbol.QuoteAsset, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
+                    assets.Add(symbol.QuoteAsset, quoteAssetInfo);
+                }
+
+                symbols.Add(symbol.Name, new SharedSymbolInfo(symbol.Name, baseAssetInfo, quoteAssetInfo));
+            }
+
+            return new SharedSymbolCatalog
+            {
+                Assets = assets,
+                Symbols = symbols
+            };
+        }
 
         #region Klines client
 
@@ -119,6 +194,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
         #endregion
 
         #region Futures Symbol client
+        SharedSymbolCatalog? IFuturesSymbolRestClient.SymbolCatalog => Cache.Get<SharedSymbolCatalog?>("Binance.UsdtFutures.live.ExchangeInfo");
 
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
@@ -131,8 +207,8 @@ namespace Binance.Net.Clients.UsdFuturesApi
             if (!result.Success)
                 return HttpResult.Fail<SharedFuturesSymbol[]>(result);
 
-            BinanceExchange._usdtFuturesExchangeInfo = result.Data;
-            var exchangeInfo = await BinanceExchange.Cache.GetAsync<SharedExchangeInfo>("Binance.UsdtFutures.live.ExchangeInfo").ConfigureAwait(false);
+            _usdtFuturesExchangeInfo = result.Data;
+            var exchangeInfo = await Cache.GetOrRetrieveAsync<SharedSymbolCatalog>("Binance.UsdtFutures.live.ExchangeInfo").ConfigureAwait(false);
 
             var data = result.Data.Symbols.Where(x => x.ContractType != null);
             var resultData = data.Select(x => ParseSymbol(x, exchangeInfo));
@@ -153,7 +229,7 @@ namespace Binance.Net.Clients.UsdFuturesApi
 
         }
 
-        private SharedFuturesSymbol ParseSymbol(BinanceFuturesUsdtSymbol s, SharedExchangeInfo exchangeInfo)
+        private SharedFuturesSymbol ParseSymbol(BinanceFuturesUsdtSymbol s, SharedSymbolCatalog exchangeInfo)
         {
             exchangeInfo.Assets.TryGetValue(s.BaseAsset, out var baseAssetInfo);
             exchangeInfo.Assets.TryGetValue(s.QuoteAsset, out var quoteAssetInfo);


### PR DESCRIPTION
Updated CryptoExchange.Net to v12.2.0 
Added SpotSymbolCatalog to Shared ISpotSymbolRestClient interface
Added FuturesSymbolCatalog to Shared IFuturesSymbolRestClient interface
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to GetSymbolsRequest model
Added DisplayName to SharedSpotSymbol and SharedFuturesSymbol models
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to SharedSpotSymbol and SharedFuturesSymbol models
Added DebuggerDisplay attributes to Shared models