### PR TITLE
Add Hong Kong equity underlying type

### DIFF
--- a/Binance.Net/Enums/UnderlyingType.cs
+++ b/Binance.Net/Enums/UnderlyingType.cs
@@ -37,7 +37,12 @@ namespace Binance.Net.Enums
         /// ["<c>KR_EQUITY</c>"] Korean Equity
         /// </summary>
         [Map("KR_EQUITY")]
-        KrEquity
+        KrEquity,
+        /// <summary>
+        /// ["<c>HK_EQUITY</c>"] Hong Kong Equity
+        /// </summary>
+        [Map("HK_EQUITY")]
+        HkEquity,
     }
 }
 


### PR DESCRIPTION
This adds new underlying type Hong Kong equity as per recent changes 
https://developers.binance.com/en/docs/products/derivatives-trading-usds-futures/change-log#2026-07-16