### PR TITLE
Add margin restricted assets endpoint

### DIFF
--- a/Binance.Net.UnitTests/BinanceRestIntegrationTests.cs
+++ b/Binance.Net.UnitTests/BinanceRestIntegrationTests.cs
@@ -139,6 +139,7 @@ namespace Binance.Net.UnitTests
             await RunAndCheckResult(warnings, client => client.SpotApi.ExchangeData.GetFutureHourlyInterestRateAsync(new[] { "ETH" }, false, null, CancellationToken.None), true);
             await RunAndCheckResult(warnings, client => client.SpotApi.ExchangeData.GetIsolatedMarginTierDataAsync("ETHUSDT", default, default, default), true);
             await RunAndCheckResult(warnings, client => client.SpotApi.ExchangeData.GetMarginDelistScheduleAsync(null, CancellationToken.None), true);
+            await RunAndCheckResult(warnings, client => client.SpotApi.ExchangeData.GetMarginRestrictedAssetsAsync(CancellationToken.None), true);
             await RunAndCheckResult(warnings, client => client.SpotApi.ExchangeData.GetConvertListAllPairsAsync(null, null, CancellationToken.None), false);
             await RunAndCheckResult(warnings, client => client.SpotApi.ExchangeData.GetDelistScheduleAsync(null, CancellationToken.None), true);
 

--- a/Binance.Net.UnitTests/Endpoints/Spot/ExchangeData/GetMarginRestrictedAssets.txt
+++ b/Binance.Net.UnitTests/Endpoints/Spot/ExchangeData/GetMarginRestrictedAssets.txt
@@ -1,0 +1,11 @@
+GET
+/sapi/v1/margin/restricted-asset
+false
+{
+  "openLongRestrictedAsset": [
+    "ADA"
+  ],
+  "maxCollateralExceededAsset": [
+    "ACH"
+  ]
+}

--- a/Binance.Net.UnitTests/RestRequestTests.cs
+++ b/Binance.Net.UnitTests/RestRequestTests.cs
@@ -133,6 +133,7 @@ namespace Binance.Net.UnitTests
             await tester.ValidateAsync(client => client.SpotApi.ExchangeData.GetFutureHourlyInterestRateAsync(new[] { "ETHUSDT" }, false), "GetFutureHourlyInterestRate");
             await tester.ValidateAsync(client => client.SpotApi.ExchangeData.GetIsolatedMarginTierDataAsync("ETHUSDT"), "GetIsolatedMarginTierData");
             await tester.ValidateAsync(client => client.SpotApi.ExchangeData.GetMarginDelistScheduleAsync(), "GetMarginDelistSchedule");
+            await tester.ValidateAsync(client => client.SpotApi.ExchangeData.GetMarginRestrictedAssetsAsync(), "GetMarginRestrictedAssets");
             await tester.ValidateAsync(client => client.SpotApi.ExchangeData.GetConvertListAllPairsAsync(), "GetConvertListAllPairs");
             await tester.ValidateAsync(client => client.SpotApi.ExchangeData.GetConvertQuantityPrecisionPerAssetAsync(), "GetConvertQuantityPrecisionPerAsset");
             await tester.ValidateAsync(client => client.SpotApi.ExchangeData.GetDelistScheduleAsync(), "GetDelistSchedule");

--- a/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiExchangeData.cs
+++ b/Binance.Net/Clients/SpotApi/BinanceRestClientSpotApiExchangeData.cs
@@ -627,6 +627,17 @@ namespace Binance.Net.Clients.SpotApi
 
         #endregion
 
+        #region Get Margin Restricted Assets
+
+        /// <inheritdoc />
+        public async Task<HttpResult<BinanceMarginRestrictedAssets>> GetMarginRestrictedAssetsAsync(CancellationToken ct = default)
+        {
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "sapi/v1/margin/restricted-asset", BinanceExchange.RateLimiter.SpotRestIp, 1);
+            return await _baseClient.SendAsync<BinanceMarginRestrictedAssets>(request, null, ct).ConfigureAwait(false);
+        }
+
+        #endregion
+
         #region Query Isolated Margin Tier Data
 
         /// <inheritdoc />

--- a/Binance.Net/Converters/BinanceSourceGenerationContext.cs
+++ b/Binance.Net/Converters/BinanceSourceGenerationContext.cs
@@ -508,6 +508,7 @@ namespace Binance.Net.Converters
     [JsonSerializable(typeof(Objects.Models.Spot.Margin.BinanceMarginAmount[]))]
     [JsonSerializable(typeof(Objects.Models.Spot.Margin.BinanceMarginAsset[]))]
     [JsonSerializable(typeof(Objects.Models.Spot.Margin.BinanceMarginDelistSchedule[]))]
+    [JsonSerializable(typeof(Objects.Models.Spot.Margin.BinanceMarginRestrictedAssets))]
     [JsonSerializable(typeof(Objects.Models.Spot.Margin.BinanceMarginDustAsset[]))]
     [JsonSerializable(typeof(Objects.Models.Spot.Margin.BinanceMarginDustTransfer[]))]
     [JsonSerializable(typeof(Objects.Models.Spot.Margin.BinanceMarginLevel[]))]

--- a/Binance.Net/Interfaces/Clients/SpotApi/IBinanceRestClientSpotApiExchangeData.cs
+++ b/Binance.Net/Interfaces/Clients/SpotApi/IBinanceRestClientSpotApiExchangeData.cs
@@ -582,6 +582,19 @@ namespace Binance.Net.Interfaces.Clients.SpotApi
         Task<HttpResult<BinanceMarginDelistSchedule[]>> GetMarginDelistScheduleAsync(int? receiveWindow = null, CancellationToken ct = default);
 
         /// <summary>
+        /// Gets the assets which are currently restricted for margin trading. Assets in the open long restricted list can only be sold, not bought. Assets in the max collateral exceeded list have reached the platform wide collateral cap and can no longer be transfered in
+        /// <para>
+        /// Docs:<br />
+        /// <a href="https://developers.binance.com/docs/margin_trading/market-data/Get-Margin-Restricted-Assets" /><br />
+        /// Endpoint:<br />
+        /// GET /sapi/v1/margin/restricted-asset
+        /// </para>
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Margin restricted assets</returns>
+        Task<HttpResult<BinanceMarginRestrictedAssets>> GetMarginRestrictedAssetsAsync(CancellationToken ct = default);
+
+        /// <summary>
         /// Gets isolated margin tier data
         /// <para>
         /// Docs:<br />

--- a/Binance.Net/Objects/Models/Spot/Margin/BinanceMarginRestrictedAssets.cs
+++ b/Binance.Net/Objects/Models/Spot/Margin/BinanceMarginRestrictedAssets.cs
@@ -1,0 +1,20 @@
+namespace Binance.Net.Objects.Models.Spot.Margin
+{
+    /// <summary>
+    /// Margin restricted assets
+    /// </summary>
+    [SerializationModel]
+    public record BinanceMarginRestrictedAssets
+    {
+        /// <summary>
+        /// ["<c>openLongRestrictedAsset</c>"] Assets which are restricted from opening long positions. These assets can only be sold, not bought
+        /// </summary>
+        [JsonPropertyName("openLongRestrictedAsset")]
+        public string[] OpenLongRestrictedAssets { get; set; } = Array.Empty<string>();
+        /// <summary>
+        /// ["<c>maxCollateralExceededAsset</c>"] Assets which have exceeded the maximum collateral limit. These assets can no longer be transfered in
+        /// </summary>
+        [JsonPropertyName("maxCollateralExceededAsset")]
+        public string[] MaxCollateralExceededAssets { get; set; } = Array.Empty<string>();
+    }
+}


### PR DESCRIPTION
Adds `GetMarginRestrictedAssetsAsync` to the Spot ExchangeData client, covering `GET /sapi/v1/margin/restricted-asset`.

[Docs: Get Margin Restricted Assets](https://developers.binance.com/docs/margin_trading/market-data/Get-Margin-Restricted-Assets)

The endpoint returns the assets Binance currently restricts for margin trading — `openLongRestrictedAsset` (can only be sold, not bought) and `maxCollateralExceededAsset` (platform-wide collateral cap reached, so the asset can no longer be transferred in).

### Notes

- Security type is MARKET_DATA, so the request definition is registered **unsigned** and takes no `recvWindow`. `BinanceAuthenticationProvider` already applies the `X-MBX-APIKEY` header to every request, which is all this endpoint needs. This follows the existing `GetHistoricalTradesAsync` registration rather than the signed margin endpoints.
- Weight 1, `SpotRestIp` rate limiter.
- New model `BinanceMarginRestrictedAssets` registered in `BinanceSourceGenerationContext`.
- Added to `RestRequestTests` with an endpoint fixture, and to `BinanceRestIntegrationTests`.

Full unit test suite passes (57/57).
